### PR TITLE
Fix timezone handling and improve error handling across codebase

### DIFF
--- a/daily_digest.py
+++ b/daily_digest.py
@@ -74,10 +74,16 @@ async def run_daily_digest(target_date: str = None, model_override: str = None, 
         prompt_override: 覆盖默认整理提示词
     """
     from database import get_pool, save_memory, get_embedding, get_all_categories, match_category_by_name
-    
+    from datetime import date as date_cls
+
     now_cst = datetime.now(TZ_CST)
 
     if target_date:
+        # 校验格式，避免后续 fromisoformat 直接抛 ValueError 让接口 500
+        try:
+            date_cls.fromisoformat(target_date)
+        except (ValueError, TypeError):
+            return {"error": f"无效日期格式: {target_date!r}，需要 YYYY-MM-DD"}
         date_str = target_date
     else:
         yesterday = now_cst - timedelta(days=1)
@@ -120,9 +126,9 @@ async def _run_daily_digest_impl(date_str: str, now_cst, model_override: str = N
     async with pool.acquire() as conn:
         fragments = await conn.fetch("""
             SELECT id, title, content, importance, created_at
-            FROM memories 
+            FROM memories
             WHERE COALESCE(memory_type, 'fragment') = 'fragment'
-              AND created_at::date = $1
+              AND (created_at AT TIME ZONE 'Asia/Shanghai')::date = $1
             ORDER BY created_at ASC
         """, target_date_obj)
     
@@ -477,20 +483,24 @@ async def daily_digest_scheduler():
     while True:
         try:
             now = datetime.now(TZ_CST)
-            
+
             # 计算下一个 0:05
             tomorrow = now.replace(hour=0, minute=5, second=0, microsecond=0)
             if now >= tomorrow:
                 tomorrow += timedelta(days=1)
-            
+
+            # 在 sleep 前就锁定要整理的日期，避免 sleep 因 OS 挂起或时钟跳变后
+            # 用 datetime.now() 重算时落到错误的"昨天"
+            target_date_str = (tomorrow - timedelta(days=1)).strftime("%Y-%m-%d")
+
             wait_seconds = (tomorrow - now).total_seconds()
             hours = int(wait_seconds // 3600)
             mins = int((wait_seconds % 3600) // 60)
-            print(f"🕐 下次整理：{tomorrow.strftime('%Y-%m-%d %H:%M')}（{hours}小时{mins}分钟后）")
-            
+            print(f"🕐 下次整理：{tomorrow.strftime('%Y-%m-%d %H:%M')}（{hours}小时{mins}分钟后），目标日期 {target_date_str}")
+
             await asyncio.sleep(wait_seconds)
-            
-            yesterday = (datetime.now(TZ_CST) - timedelta(days=1)).strftime("%Y-%m-%d")
+
+            yesterday = target_date_str
             
             # 1. 日页面生成（从碎片生成详细日页面）
             try:
@@ -552,7 +562,7 @@ async def cleanup_expired_fragments():
               AND COALESCE(is_permanent, FALSE) = FALSE
               AND importance < 8
               AND created_at < NOW() - INTERVAL '7 days'
-              AND EXISTS (SELECT 1 FROM calendar_pages WHERE date = memories.created_at::date AND type = 'day')
+              AND EXISTS (SELECT 1 FROM calendar_pages WHERE date = (memories.created_at AT TIME ZONE 'Asia/Shanghai')::date AND type = 'day')
               AND dream_processed_at IS NOT NULL
         """)
         try:
@@ -567,7 +577,7 @@ async def cleanup_expired_fragments():
               AND COALESCE(is_permanent, FALSE) = FALSE
               AND importance >= 8
               AND created_at < NOW() - INTERVAL '30 days'
-              AND EXISTS (SELECT 1 FROM calendar_pages WHERE date = memories.created_at::date AND type = 'day')
+              AND EXISTS (SELECT 1 FROM calendar_pages WHERE date = (memories.created_at AT TIME ZONE 'Asia/Shanghai')::date AND type = 'day')
               AND dream_processed_at IS NOT NULL
         """)
         try:
@@ -673,9 +683,14 @@ async def generate_day_page(target_date: str = None, model_override: str = None)
     """
     from database import get_pool, get_chat_messages_for_date, save_calendar_page
     from config import get_config
+    from datetime import date as date_cls
 
     now_cst = datetime.now(TZ_CST)
     if target_date:
+        try:
+            date_cls.fromisoformat(target_date)
+        except (ValueError, TypeError):
+            return {"error": f"无效日期格式: {target_date!r}，需要 YYYY-MM-DD"}
         date_str = target_date
     else:
         yesterday = now_cst - timedelta(days=1)
@@ -728,7 +743,7 @@ async def generate_day_page(target_date: str = None, model_override: str = None)
     async with pool.acquire() as conn:
         fragments = await conn.fetch("""
             SELECT title, content FROM memories
-            WHERE created_at::date = $1
+            WHERE (created_at AT TIME ZONE 'Asia/Shanghai')::date = $1
               AND memory_type = 'fragment'
             ORDER BY created_at ASC
         """, target_date_obj)

--- a/database.py
+++ b/database.py
@@ -991,14 +991,19 @@ async def search_memories(query: str, limit: int = 10, track_recall: bool = True
                         )
                     WHERE id = ANY($1::int[])
                 """, ids, json.dumps([query_hash]))
-            except Exception:
+            except Exception as e:
                 # 降级：如果合并语句失败（如 access_query_hashes 列不存在），只更新 access_count
-                await conn.execute("""
-                    UPDATE memories 
-                    SET last_accessed = NOW(),
-                        access_count = COALESCE(access_count, 0) + 1
-                    WHERE id = ANY($1::int[])
-                """, ids)
+                # 打日志便于排查 schema 缺失或 jsonb 操作不兼容等情况，不再 silent 吞掉
+                print(f"   ⚠️ 召回追踪合并 UPDATE 失败，降级为只更新 access_count: {type(e).__name__}: {e}")
+                try:
+                    await conn.execute("""
+                        UPDATE memories
+                        SET last_accessed = NOW(),
+                            access_count = COALESCE(access_count, 0) + 1
+                        WHERE id = ANY($1::int[])
+                    """, ids)
+                except Exception as e2:
+                    print(f"   ❌ 召回追踪降级 UPDATE 也失败: {type(e2).__name__}: {e2}")
         
         # v5.4：自动锁定检测
         try:
@@ -2505,7 +2510,13 @@ async def get_calendar_for_injection(lookback_days: int = 365):
 
 
 async def get_chat_messages_for_date(date_str: str):
-    """读取指定日期的所有聊天消息（用于生成日页面）"""
+    """读取指定日期的所有聊天消息（用于生成日页面）
+
+    注：time 字段是 TIMESTAMPTZ，直接 ::date 会按 PostgreSQL 服务器时区
+    （多数云数据库默认 UTC）转换，导致东八区凌晨 0:00-7:59 的消息被
+    归到前一天。这里强制按 Asia/Shanghai 算 date，与代码中其他位置
+    使用的 TZ_CST = UTC+8 保持一致。
+    """
     from datetime import date as date_cls
     pool = await get_pool()
     d = date_cls.fromisoformat(date_str)
@@ -2513,7 +2524,7 @@ async def get_chat_messages_for_date(date_str: str):
         rows = await conn.fetch("""
             SELECT role, content, time, conversation_id
             FROM chat_messages
-            WHERE time::date = $1
+            WHERE (time AT TIME ZONE 'Asia/Shanghai')::date = $1
               AND role IN ('user', 'assistant')
               AND content != ''
             ORDER BY time ASC

--- a/dream.py
+++ b/dream.py
@@ -567,7 +567,11 @@ async def get_drowsy_prompt() -> str:
     if too_many_fragments:
         reasons.append(f"脑子里堆了 {fragment_count} 条记忆碎片还没整理")
     if too_long_no_dream:
-        reasons.append(f"已经连续 {days_since_dream} 天没有睡觉了")
+        if last_dream and days_since_dream > 0:
+            reasons.append(f"已经连续 {days_since_dream} 天没有睡觉了")
+        else:
+            # 从未做过梦 / 上次时间无法解析
+            reasons.append("从来都没好好睡过一觉")
     if too_many_pages:
         reasons.append(f"有 {unprocessed_pages} 天的日记还没消化")
 

--- a/main.py
+++ b/main.py
@@ -326,7 +326,8 @@ def replace_template_variables(text: str, context: dict = None) -> str:
     }
 
     for key, val in replacements.items():
-        if key in text and val and isinstance(val, str):
+        # 即便 val 是空字符串也要替换，否则 {user_name} 等占位符会原样残留进 prompt
+        if key in text and isinstance(val, str):
             text = text.replace(key, val)
 
     return text
@@ -1674,7 +1675,7 @@ async def stream_and_capture(headers: dict, body: dict, session_id: str, user_me
                     error_body += chunk
                 print(f"❌ 流式请求失败 [{response.status_code}]: {error_body[:500].decode('utf-8', errors='ignore')}")
                 err_msg = f"⚠️ 请求失败 ({response.status_code})"
-                err_payload = json.dumps({'choices': [{'delta': {'content': err_msg}, 'finish_reason': None}]})
+                err_payload = json.dumps({'choices': [{'delta': {'content': err_msg}, 'finish_reason': None}], 'model': model}, ensure_ascii=False)
                 yield f"data: {err_payload}\n\n".encode("utf-8")
                 yield b"data: [DONE]\n\n"
                 return


### PR DESCRIPTION
## Summary
This PR addresses timezone inconsistencies in date filtering queries and improves error handling and validation throughout the codebase. The main focus is ensuring that all date-based operations consistently use Asia/Shanghai timezone (UTC+8) to match the application's TZ_CST setting.

## Key Changes

### Timezone Fixes
- **daily_digest.py**: Updated SQL queries to use `(created_at AT TIME ZONE 'Asia/Shanghai')::date` instead of `created_at::date` in memory fragment queries and cleanup operations. This prevents messages created in the early morning hours (00:00-07:59 CST) from being incorrectly attributed to the previous day when the database server uses UTC.
- **database.py**: Applied the same timezone fix to `get_chat_messages_for_date()` to ensure chat messages are correctly grouped by date in Asia/Shanghai timezone. Added detailed comment explaining the issue.

### Scheduler Improvements
- **daily_digest.py**: Fixed `daily_digest_scheduler()` to lock in the target date before sleeping, preventing issues where OS suspension or clock adjustments could cause the scheduler to process the wrong day. The target date is now calculated once and reused after sleep.

### Input Validation
- **daily_digest.py**: Added date format validation in `run_daily_digest()` and `generate_day_page()` to catch invalid ISO format dates early and return a user-friendly error message instead of letting `fromisoformat()` raise an unhandled ValueError.

### Error Handling Improvements
- **database.py**: Enhanced error handling in `search_memories()` recall tracking to log failures instead of silently swallowing exceptions. Added fallback error handling for the degraded update path.
- **dream.py**: Fixed null reference issue in `get_drowsy_prompt()` by checking if `last_dream` exists before calculating days since last dream.
- **main.py**: Fixed template variable replacement to handle empty strings correctly, preventing placeholder text from remaining in prompts. Also added `ensure_ascii=False` to error response JSON for better Unicode support.

## Implementation Details
- All timezone conversions now explicitly use `AT TIME ZONE 'Asia/Shanghai'` to be database-agnostic and work correctly regardless of the server's default timezone setting.
- Error messages are now more informative with exception type and details logged for debugging.
- The scheduler fix ensures consistent daily digest generation even under adverse conditions like system sleep or clock adjustments.

https://claude.ai/code/session_018dVSMzX1azr7eiLEngGUfF