### PR TITLE
Fix SQL injection vulnerability and improve Dream trigger handling

### DIFF
--- a/database.py
+++ b/database.py
@@ -1611,42 +1611,34 @@ async def _keyword_search(query: str, limit: int = 10, heat_params: dict = None,
 # ============================================================
 
 async def get_recent_memories(limit: int = 20, category_id: int = None, project_id: str = None):
+    """
+    最近记忆。
+    project_id 语义（保持与本函数原有调用方一致）：
+      - 传值 → 只看该项目的记忆（m.project_id = project_id）
+      - 不传 / 空 → 不过滤项目（全部）
+    """
     pool = await get_pool()
+    base_select = """SELECT m.id, m.content, m.importance, m.created_at,
+                  COALESCE(m.title, '') as title, COALESCE(m.memory_type, 'fragment') as memory_type,
+                  m.category_id, COALESCE(c.name, '') as category_name, COALESCE(c.color, '') as category_color,
+                  COALESCE(m.source, 'ai_extracted') as source,
+                  COALESCE(m.resolution, 1.0) as resolution
+           FROM memories m LEFT JOIN memory_categories c ON m.category_id = c.id
+           WHERE COALESCE(m.memory_type, 'fragment') NOT IN ('digested', 'dream_deleted')
+             AND (m.valid_until IS NULL OR m.valid_until > NOW())"""
+    params: list = []
+    where_extra = ""
+    if category_id is not None:
+        params.append(category_id)
+        where_extra += f" AND m.category_id = ${len(params)}"
+    if project_id:
+        # 必须参数化, 否则 project_id 来自客户端 body, 直接 f-string 拼会被 SQL 注入
+        params.append(project_id)
+        where_extra += f" AND m.project_id = ${len(params)}"
+    params.append(limit)
+    sql = f"{base_select}{where_extra} ORDER BY m.created_at DESC LIMIT ${len(params)}"
     async with pool.acquire() as conn:
-        # 构建 project_id 过滤条件
-        proj_clause = ""
-        if project_id:
-            proj_clause = f"AND m.project_id = '{project_id}'"
-        
-        if category_id is not None:
-            return await conn.fetch(
-                f"""SELECT m.id, m.content, m.importance, m.created_at, 
-                          COALESCE(m.title, '') as title, COALESCE(m.memory_type, 'fragment') as memory_type,
-                          m.category_id, COALESCE(c.name, '') as category_name, COALESCE(c.color, '') as category_color,
-                          COALESCE(m.source, 'ai_extracted') as source,
-                          COALESCE(m.resolution, 1.0) as resolution
-                   FROM memories m LEFT JOIN memory_categories c ON m.category_id = c.id
-                   WHERE COALESCE(m.memory_type, 'fragment') NOT IN ('digested', 'dream_deleted')
-                     AND (m.valid_until IS NULL OR m.valid_until > NOW())
-                     AND m.category_id = $1
-                     {proj_clause}
-                   ORDER BY m.created_at DESC LIMIT $2""",
-                category_id, limit,
-            )
-        else:
-            return await conn.fetch(
-                f"""SELECT m.id, m.content, m.importance, m.created_at, 
-                          COALESCE(m.title, '') as title, COALESCE(m.memory_type, 'fragment') as memory_type,
-                          m.category_id, COALESCE(c.name, '') as category_name, COALESCE(c.color, '') as category_color,
-                          COALESCE(m.source, 'ai_extracted') as source,
-                          COALESCE(m.resolution, 1.0) as resolution
-                   FROM memories m LEFT JOIN memory_categories c ON m.category_id = c.id
-                   WHERE COALESCE(m.memory_type, 'fragment') NOT IN ('digested', 'dream_deleted')
-                     AND (m.valid_until IS NULL OR m.valid_until > NOW())
-                     {proj_clause}
-                   ORDER BY m.created_at DESC LIMIT $1""",
-                limit,
-            )
+        return await conn.fetch(sql, *params)
 
 
 async def get_all_memories_count():

--- a/main.py
+++ b/main.py
@@ -245,9 +245,15 @@ app = FastAPI(title="AI Memory Gateway", version="3.1.0", lifespan=lifespan)
 # ============================================================
 
 class AdminAuthMiddleware(BaseHTTPMiddleware):
-    """当设置了 ACCESS_TOKEN 时，/admin/* 和 /debug/* 端点需要认证"""
-    
-    PROTECTED_PREFIXES = ("/admin/", "/debug/", "/sync/")
+    """当设置了 ACCESS_TOKEN 时，需要认证的路径前缀。
+
+    - /admin/、/debug/、/sync/：管理面板 / 调试 / 云同步导出导入
+    - /projects/：v5.8 项目文件上传与 chunk 管理（POST /projects/{id}/files/{fid}/process
+      与 DELETE /projects/{id}/files/{fid}/chunks），写操作必须保护
+    - /import/：导入种子记忆（如 /import/seed-memories），会写入数据库
+    """
+
+    PROTECTED_PREFIXES = ("/admin/", "/debug/", "/sync/", "/projects/", "/import/")
     
     async def dispatch(self, request: Request, call_next):
         path = request.url.path
@@ -2286,7 +2292,7 @@ async def api_extract_now(request: Request):
         # 获取对比用的已有记忆
         user_text = " ".join(r["content"] for r in recent_msgs if r["role"] == "user")
         related = await search_memories(user_text[:500], limit=50, track_recall=False, project_id=project_id)
-        recent = await get_recent_memories(limit=30)
+        recent = await get_recent_memories(limit=30, project_id=project_id)
         seen = set()
         existing_contents = []
         for content in [r["content"] for r in related] + [r["content"] for r in recent]:
@@ -2643,6 +2649,9 @@ async def api_dream_status():
             "status": "ok",
             **status,
             "unprocessed_count": len(unprocessed),
+            # 前端 admin-panel 读 unprocessed_fragments / is_dreaming, 这里加别名保证两套字段都能用
+            "unprocessed_fragments": len(unprocessed),
+            "is_dreaming": status.get("is_running", False),
             "drowsy_threshold": drowsy_threshold,
             "is_drowsy": len(unprocessed) >= drowsy_threshold,
             "last_dream_date": last_dream_date,

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -553,26 +553,43 @@ async def trigger_dream() -> str:
     通常在碎片堆积较多或长时间未整理时使用。
     """
     try:
-        # /dream/start 返回 SSE 流，不能当 JSON 解析
-        # 只需要触发启动，不等待完成（Dream 可能跑几分钟）
-        async with httpx.AsyncClient(timeout=30, headers=GATEWAY_HEADERS) as client:
-            resp = await client.post(
+        # /dream/start 返回 SSE 流（StreamingResponse），Dream 实际跑 1-5 分钟。
+        # 不能用 client.post() 等响应完整 —— httpx 默认会把整个流读完才返回，
+        # timeout 设多大都可能不够；而且客户端断开会触发 FastAPI 端 generator 的
+        # CancelledError 把 Dream 中途杀掉。
+        # 正确做法：用 client.stream() 读到第一个 data: 事件就 return，
+        # 后续 Dream 在网关后台继续跑，让客户端用 get_dream_status 查进度。
+        async with httpx.AsyncClient(timeout=60, headers=GATEWAY_HEADERS) as client:
+            async with client.stream(
+                "POST",
                 f"{GATEWAY_BASE}/dream/start",
                 json={"trigger_type": "manual"},
-            )
+            ) as resp:
+                if resp.status_code != 200:
+                    body = (await resp.aread()).decode("utf-8", errors="ignore")[:300]
+                    return f"Dream 启动失败（HTTP {resp.status_code}）：{body}"
 
-        if resp.status_code == 200:
+                first_data = ""
+                async for line in resp.aiter_lines():
+                    line = (line or "").strip()
+                    if line.startswith("data:"):
+                        first_data = line[len("data:"):].strip()
+                        break
+
+        if not first_data:
             return "🌙 Dream 已启动，可以用 get_dream_status 查看进度。"
-        else:
-            # 尝试读取错误信息
-            try:
-                data = resp.json()
-                return f"Dream 启动失败：{data.get('error', resp.text)}"
-            except Exception:
-                return f"Dream 启动失败（HTTP {resp.status_code}）：{resp.text[:200]}"
 
+        # 错误事件
+        if first_data.startswith("{") and '"error"' in first_data.lower():
+            return f"Dream 启动失败：{first_data[:200]}"
+
+        return f"🌙 Dream 已启动：{first_data[:200]}\n后续可用 get_dream_status 查看进度。"
+
+    except httpx.TimeoutException:
+        # 60s 内连首个事件都没到, 但请求已发出, Dream 多半已在后台跑了
+        return "🌙 Dream 已启动（首事件超时未到，可用 get_dream_status 确认）"
     except Exception as e:
-        return f"启动出错：{str(e)}"
+        return f"启动出错：{type(e).__name__}: {e}"
 
 
 @mcp_calendar.tool()


### PR DESCRIPTION
## Summary
This PR addresses a critical SQL injection vulnerability in the memory query function and improves the Dream trigger mechanism to handle long-running operations correctly. It also enhances API security by protecting additional endpoints and fixes project-scoped memory queries.

## Key Changes

### Security Fixes
- **SQL Injection Prevention in `get_recent_memories()`**: Refactored query building to use parameterized queries instead of f-string interpolation for `project_id` and `category_id` parameters. This prevents SQL injection attacks when `project_id` comes from untrusted client input.
- **Extended Admin Auth Protection**: Added `/projects/` and `/import/` endpoints to `AdminAuthMiddleware.PROTECTED_PREFIXES` to require authentication for file uploads, chunk management, and seed memory imports.

### Dream Trigger Improvements
- **Fixed Streaming Response Handling**: Changed from `client.post()` to `client.stream()` to properly handle the SSE stream returned by `/dream/start`. The previous implementation would block waiting for the entire response, causing timeout issues for long-running Dream operations (1-5 minutes).
- **Early Return on First Event**: Now reads only the first SSE data event and returns immediately, allowing Dream to continue running in the background while clients can check progress via `get_dream_status`.
- **Better Error Handling**: Added timeout exception handling and improved error message formatting.

### Bug Fixes
- **Project-Scoped Memory Queries**: Fixed `api_extract_now()` to pass `project_id` to `get_recent_memories()`, ensuring memory extraction respects project boundaries.
- **Dream Status Response**: Added field aliases (`unprocessed_fragments`, `is_dreaming`) to maintain compatibility with frontend admin-panel expectations while keeping the original field names.

### Code Quality
- Consolidated duplicate SQL queries in `get_recent_memories()` into a single parameterized query with dynamic WHERE clause building.
- Added comprehensive docstring explaining `project_id` parameter semantics.
- Improved code comments explaining the SSE streaming approach and timeout behavior.

https://claude.ai/code/session_018dVSMzX1azr7eiLEngGUfF