### PR TITLE
Add tool drawer auto-discovery and Anthropic API adapter support

### DIFF
--- a/anthropic_adapter.py
+++ b/anthropic_adapter.py
@@ -1,0 +1,430 @@
+"""
+Anthropic API 格式适配器
+将 OpenAI 格式的请求/响应与 Anthropic Messages API 格式互相转换
+
+OpenAI format:    POST /v1/chat/completions
+Anthropic format: POST /v1/messages
+
+用法：
+  from anthropic_adapter import (
+      to_anthropic_request, to_anthropic_headers, get_anthropic_url,
+      from_anthropic_response, anthropic_stream_to_openai,
+  )
+"""
+
+import json
+import uuid
+from typing import AsyncGenerator
+
+
+# ============================================================
+# 请求转换：OpenAI → Anthropic
+# ============================================================
+
+def to_anthropic_request(openai_body: dict) -> dict:
+    """将 OpenAI chat/completions 请求体转换为 Anthropic Messages API 格式"""
+    messages = list(openai_body.get("messages", []))
+
+    # ── 提取 system message（可能多条，合并） ──
+    system_blocks = []
+    non_system_messages = []
+    for msg in messages:
+        if msg.get("role") == "system":
+            content = msg.get("content")
+            if isinstance(content, list):
+                # 已经是 content blocks 格式（带 cache_control）
+                system_blocks.extend(content)
+            elif isinstance(content, str) and content.strip():
+                system_blocks.append({"type": "text", "text": content})
+        else:
+            non_system_messages.append(msg)
+
+    # ── 转换消息列表 ──
+    anthropic_messages = _convert_messages(non_system_messages)
+
+    # ── 构建请求体 ──
+    body = {
+        "model": _strip_model_prefix(openai_body.get("model", "")),
+        "messages": anthropic_messages,
+        "max_tokens": openai_body.get("max_tokens") or 8192,
+    }
+
+    if system_blocks:
+        body["system"] = system_blocks
+
+    # 可选参数
+    if "temperature" in openai_body:
+        body["temperature"] = openai_body["temperature"]
+    if "top_p" in openai_body:
+        body["top_p"] = openai_body["top_p"]
+    if openai_body.get("stream"):
+        body["stream"] = True
+
+    # ── tools ──
+    if "tools" in openai_body and openai_body["tools"]:
+        body["tools"] = _convert_tools_openai_to_anthropic(openai_body["tools"])
+        tc = openai_body.get("tool_choice", "auto")
+        if tc == "auto":
+            body["tool_choice"] = {"type": "auto"}
+        elif tc == "none":
+            body["tool_choice"] = {"type": "none"}
+        elif tc == "required":
+            body["tool_choice"] = {"type": "any"}
+
+    # ── 思考链 / extended thinking ──
+    reasoning = openai_body.get("reasoning")
+    if reasoning and isinstance(reasoning, dict) and reasoning.get("enabled"):
+        budget = 10000
+        effort = reasoning.get("effort")
+        if effort == "low":
+            budget = 5000
+        elif effort == "high":
+            budget = 20000
+        body["thinking"] = {"type": "enabled", "budget_tokens": budget}
+        # Anthropic extended thinking 要求 temperature == 1
+        body["temperature"] = 1
+
+    return body
+
+
+def to_anthropic_headers(api_key: str) -> dict:
+    """生成 Anthropic API 请求头"""
+    return {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+    }
+
+
+def get_anthropic_url(base_url: str) -> str:
+    """将 base URL 转换为 Anthropic messages 端点
+    
+    输入示例：
+      https://api.anthropic.com/v1           → .../v1/messages
+      https://api.anthropic.com/v1/messages  → 不变
+      https://xxx.com/v1/chat/completions    → .../v1/messages
+      https://xxx.com                        → .../v1/messages
+    """
+    base = base_url.rstrip("/")
+    if base.endswith("/messages"):
+        return base
+    if base.endswith("/chat/completions"):
+        base = base[: -len("/chat/completions")]
+    if base.endswith("/v1"):
+        return base + "/messages"
+    return base + "/v1/messages"
+
+
+# ============================================================
+# 响应转换：Anthropic → OpenAI（非流式）
+# ============================================================
+
+def from_anthropic_response(anthropic_data: dict, model: str = "") -> dict:
+    """将 Anthropic Messages API 响应转换为 OpenAI chat/completions 格式"""
+
+    # ── 错误处理 ──
+    if anthropic_data.get("type") == "error" or "error" in anthropic_data:
+        err = anthropic_data.get("error", {})
+        return {
+            "error": {
+                "message": err.get("message", str(anthropic_data)),
+                "type": err.get("type", "api_error"),
+            }
+        }
+
+    content_blocks = anthropic_data.get("content", [])
+
+    # 拆解 content blocks
+    text_parts = []
+    tool_calls = []
+    reasoning_parts = []
+
+    for block in content_blocks:
+        btype = block.get("type")
+        if btype == "text":
+            text_parts.append(block.get("text", ""))
+        elif btype == "thinking":
+            reasoning_parts.append(block.get("thinking", ""))
+        elif btype == "tool_use":
+            tool_calls.append({
+                "id": block.get("id", f"call_{uuid.uuid4().hex[:24]}"),
+                "type": "function",
+                "function": {
+                    "name": block.get("name", ""),
+                    "arguments": json.dumps(block.get("input", {}), ensure_ascii=False),
+                },
+            })
+
+    full_text = "\n".join(text_parts) if text_parts else ""
+
+    # ── message ──
+    message = {"role": "assistant", "content": full_text}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    if reasoning_parts:
+        message["reasoning_content"] = "\n".join(reasoning_parts)
+
+    # ── usage ──
+    au = anthropic_data.get("usage", {})
+    input_tokens = au.get("input_tokens", 0)
+    output_tokens = au.get("output_tokens", 0)
+    usage = {
+        "prompt_tokens": input_tokens,
+        "completion_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+    }
+    cache_creation = au.get("cache_creation_input_tokens", 0)
+    cache_read = au.get("cache_read_input_tokens", 0)
+    if cache_creation or cache_read:
+        usage["prompt_tokens_details"] = {
+            "cached_tokens": cache_read,
+            "cache_write_tokens": cache_creation,
+        }
+
+    # ── stop reason ──
+    stop_reason = anthropic_data.get("stop_reason", "end_turn")
+    finish_map = {
+        "end_turn": "stop",
+        "max_tokens": "length",
+        "tool_use": "tool_calls",
+        "stop_sequence": "stop",
+    }
+
+    return {
+        "id": f"chatcmpl-{anthropic_data.get('id', uuid.uuid4().hex[:12])}",
+        "object": "chat.completion",
+        "model": model or anthropic_data.get("model", ""),
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": finish_map.get(stop_reason, "stop"),
+            }
+        ],
+        "usage": usage,
+    }
+
+
+# ============================================================
+# 流式转换：Anthropic SSE → OpenAI SSE
+# ============================================================
+
+async def anthropic_stream_to_openai(response, model: str = "") -> AsyncGenerator[bytes, None]:
+    """将 Anthropic SSE 流转换为 OpenAI SSE 格式的 bytes 流
+
+    Anthropic 事件类型：
+      message_start → content_block_start → content_block_delta → content_block_stop
+      → message_delta → message_stop
+
+    转换为 OpenAI 格式：
+      data: {"choices": [{"delta": {...}}]}
+      data: [DONE]
+    """
+    msg_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+    buffer = ""
+    input_tokens = 0
+    output_tokens = 0
+    cache_creation = 0
+    cache_read = 0
+
+    async for chunk in response.aiter_bytes(chunk_size=256):
+        buffer += chunk.decode("utf-8", errors="ignore")
+
+        while "\n" in buffer:
+            line, buffer = buffer.split("\n", 1)
+            line = line.strip()
+
+            if not line or line.startswith(":") or line.startswith("event:"):
+                continue
+            if not line.startswith("data: "):
+                continue
+
+            raw = line[6:].strip()
+            if not raw:
+                continue
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = data.get("type", "")
+
+            # ── message_start ──
+            if event_type == "message_start":
+                msg = data.get("message", {})
+                model = model or msg.get("model", "")
+                u = msg.get("usage", {})
+                input_tokens = u.get("input_tokens", 0)
+                cache_creation = u.get("cache_creation_input_tokens", 0)
+                cache_read = u.get("cache_read_input_tokens", 0)
+                yield _sse(msg_id, model, {"role": "assistant"})
+
+            # ── content_block_start ──
+            elif event_type == "content_block_start":
+                block = data.get("content_block", {})
+                if block.get("type") == "tool_use":
+                    yield _sse(msg_id, model, {
+                        "tool_calls": [{
+                            "index": data.get("index", 0),
+                            "id": block.get("id", ""),
+                            "type": "function",
+                            "function": {"name": block.get("name", ""), "arguments": ""},
+                        }]
+                    })
+
+            # ── content_block_delta ──
+            elif event_type == "content_block_delta":
+                delta = data.get("delta", {})
+                dtype = delta.get("type", "")
+
+                if dtype == "text_delta":
+                    text = delta.get("text", "")
+                    if text:
+                        yield _sse(msg_id, model, {"content": text})
+
+                elif dtype == "thinking_delta":
+                    thinking = delta.get("thinking", "")
+                    if thinking:
+                        yield _sse(msg_id, model, {"reasoning_content": thinking})
+
+                elif dtype == "input_json_delta":
+                    partial = delta.get("partial_json", "")
+                    if partial:
+                        yield _sse(msg_id, model, {
+                            "tool_calls": [{
+                                "index": data.get("index", 0),
+                                "function": {"arguments": partial},
+                            }]
+                        })
+
+            # ── message_delta (含 stop_reason 和 output usage) ──
+            elif event_type == "message_delta":
+                d = data.get("delta", {})
+                stop = d.get("stop_reason", "end_turn")
+                u = data.get("usage", {})
+                output_tokens = u.get("output_tokens", 0)
+
+                finish_map = {"end_turn": "stop", "max_tokens": "length",
+                              "tool_use": "tool_calls", "stop_sequence": "stop"}
+
+                usage = {
+                    "prompt_tokens": input_tokens,
+                    "completion_tokens": output_tokens,
+                    "total_tokens": input_tokens + output_tokens,
+                }
+                if cache_creation or cache_read:
+                    usage["prompt_tokens_details"] = {
+                        "cached_tokens": cache_read,
+                        "cache_write_tokens": cache_creation,
+                    }
+
+                payload = {
+                    "id": msg_id, "object": "chat.completion.chunk", "model": model,
+                    "choices": [{"index": 0, "delta": {},
+                                 "finish_reason": finish_map.get(stop, "stop")}],
+                    "usage": usage,
+                }
+                yield f"data: {json.dumps(payload, ensure_ascii=False)}\n\n".encode()
+
+            # ── message_stop ──
+            elif event_type == "message_stop":
+                yield b"data: [DONE]\n\n"
+
+            # ── error ──
+            elif event_type == "error":
+                err_msg = data.get("error", {}).get("message", "Unknown error")
+                yield _sse(msg_id, model, {"content": f"⚠️ {err_msg}"})
+                yield b"data: [DONE]\n\n"
+
+
+# ============================================================
+# 内部工具函数
+# ============================================================
+
+def _strip_model_prefix(model: str) -> str:
+    """去掉 OpenRouter 风格前缀：anthropic/claude-sonnet-4 → claude-sonnet-4"""
+    return model.split("/", 1)[1] if "/" in model else model
+
+
+def _convert_tools_openai_to_anthropic(openai_tools: list) -> list:
+    """OpenAI tools → Anthropic tools"""
+    result = []
+    for tool in openai_tools:
+        if tool.get("type") == "function":
+            func = tool["function"]
+            result.append({
+                "name": func["name"],
+                "description": func.get("description", ""),
+                "input_schema": func.get("parameters", {"type": "object", "properties": {}}),
+            })
+        else:
+            result.append(tool)  # 可能已经是 Anthropic 格式
+    return result
+
+
+def _convert_messages(openai_msgs: list) -> list:
+    """将 OpenAI 格式的消息列表转换为 Anthropic 格式
+    
+    主要差异：
+    - OpenAI tool result: {"role": "tool", "tool_call_id": "...", "content": "..."}
+    - Anthropic tool result: {"role": "user", "content": [{"type": "tool_result", ...}]}
+    - OpenAI assistant with tool_calls: message.tool_calls 数组
+    - Anthropic assistant with tool_use: content 里包含 tool_use blocks
+    """
+    result = []
+
+    for msg in openai_msgs:
+        role = msg.get("role")
+        content = msg.get("content", "")
+
+        if role == "tool":
+            # ── tool result → 合并到 user message ──
+            block = {
+                "type": "tool_result",
+                "tool_use_id": msg.get("tool_call_id", ""),
+                "content": content if isinstance(content, str) else json.dumps(content, ensure_ascii=False),
+            }
+            if result and result[-1]["role"] == "user" and isinstance(result[-1]["content"], list):
+                result[-1]["content"].append(block)
+            else:
+                result.append({"role": "user", "content": [block]})
+
+        elif role == "assistant":
+            blocks = []
+
+            # 文本内容
+            if isinstance(content, str) and content:
+                blocks.append({"type": "text", "text": content})
+            elif isinstance(content, list):
+                blocks.extend(content)
+
+            # tool_calls → tool_use blocks
+            for tc in msg.get("tool_calls", []):
+                func = tc.get("function", {})
+                args = func.get("arguments", "{}")
+                blocks.append({
+                    "type": "tool_use",
+                    "id": tc.get("id", f"toolu_{uuid.uuid4().hex[:24]}"),
+                    "name": func.get("name", ""),
+                    "input": json.loads(args) if isinstance(args, str) else args,
+                })
+
+            if blocks:
+                result.append({"role": "assistant", "content": blocks})
+            elif content:
+                result.append({"role": "assistant", "content": content})
+
+        else:
+            # user 等其他角色
+            result.append({"role": role, "content": content})
+
+    return result
+
+
+def _sse(msg_id: str, model: str, delta: dict) -> bytes:
+    """构建 OpenAI SSE 格式的一行"""
+    payload = {
+        "id": msg_id, "object": "chat.completion.chunk", "model": model,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+    }
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n".encode()

--- a/database.py
+++ b/database.py
@@ -260,12 +260,15 @@ async def init_tables():
                 error           BOOLEAN DEFAULT FALSE,
                 token_info      JSONB,
                 thinking        TEXT,
+                status_events   JSONB,
                 tool_events     JSONB,
                 memory_result   JSONB,
                 memory_event    JSONB,
+                handoff_info    JSONB,
                 web_search_results JSONB,
                 versions        JSONB,
                 version_index   INTEGER DEFAULT 0,
+                images          JSONB,
                 attachments     JSONB,
                 usage           JSONB,
                 summary         TEXT,
@@ -449,6 +452,22 @@ async def init_tables():
         if not has_memory_event:
             await conn.execute("ALTER TABLE chat_messages ADD COLUMN memory_event JSONB")
             print("✅ chat_messages 表已添加 memory_event 列")
+
+        # v6.1：chat_messages 表扩展 — 完整前端消息状态同步
+        for col_name, col_def in [
+            ("status_events", "JSONB"),
+            ("handoff_info", "JSONB"),
+            ("images", "JSONB"),
+        ]:
+            has_col = await conn.fetchval("""
+                SELECT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'chat_messages' AND column_name = $1
+                )
+            """, col_name)
+            if not has_col:
+                await conn.execute(f"ALTER TABLE chat_messages ADD COLUMN {col_name} {col_def}")
+                print(f"✅ chat_messages 表已添加 {col_name} 列（完整消息同步）")
 
         # v5.3：时间有效期窗口（MemPalace 启发）
         for col_name, col_def in [
@@ -815,23 +834,27 @@ async def get_recent_conversation(limit: int = 20):
         return list(reversed(rows))
 
 
-async def get_handoff_messages(limit: int = 6):
+async def get_handoff_messages(limit: int = 6, exclude_conversation_id: str = None):
     """
     获取最近一个有足够消息的对话的最后 N 条消息，用于无缝切窗。
     只取 user 和 assistant 角色的消息，按时间正序返回。
+
+    exclude_conversation_id: 当前正在进行的对话 ID。如果传入，会跳过它，
+    避免在同一个对话里继续聊时把自己的最后几条又当成"上一个对话"注入。
     """
     pool = await get_pool()
     async with pool.acquire() as conn:
-        # 找最近一个至少有 4 条消息（2 轮来回）的对话
+        # 找最近一个至少有 4 条消息（2 轮来回）的对话，排除当前对话本身
         conv = await conn.fetchrow("""
             SELECT c.id, c.title FROM chat_conversations c
-            WHERE (
-                SELECT COUNT(*) FROM chat_messages m 
+            WHERE ($1::text IS NULL OR c.id <> $1)
+              AND (
+                SELECT COUNT(*) FROM chat_messages m
                 WHERE m.conversation_id = c.id AND m.role IN ('user', 'assistant')
             ) >= 4
             ORDER BY c.updated_at DESC
             LIMIT 1
-        """)
+        """, exclude_conversation_id)
         if not conv:
             return [], ""
         
@@ -972,21 +995,23 @@ async def update_memory(memory_id: int, content: str = None, importance: int = N
 # 记忆搜索（v3.0 向量语义搜索）
 # ============================================================
 
-async def search_memories(query: str, limit: int = 10, track_recall: bool = True, project_id: str = None):
+async def search_memories(query: str, limit: int = 10, track_recall: bool = True, project_id: str = None, return_embedding: bool = False):
     """
     搜索相关记忆 —— RRF 混合检索（v5.7）
-    
+
     流程：
     1. 生成查询向量
     2. 并行执行向量搜索 + 关键词搜索
     3. RRF（Reciprocal Rank Fusion）合并两路结果
     4. 更新召回追踪数据（可关闭）
     5. 返回 top-K
-    
+
     参数：
         track_recall: 是否记录召回追踪数据。聊天注入时=True，去重对比时=False
         project_id: 项目ID。提供时搜索全局记忆+该项目记忆；不提供时只搜全局记忆
-    
+        return_embedding: True 时返回 (results, query_embedding) 元组，
+                          调用方可复用 embedding 避免重复计算（如工具抽屉路由）
+
     降级：如果 embedding 生成失败，只用关键词搜索
     """
     # 候选池扩大到 3 倍，给 RRF 合并留充足的候选
@@ -1075,7 +1100,11 @@ async def search_memories(query: str, limit: int = 10, track_recall: bool = True
             await _check_auto_lock(ids, heat_params)
         except Exception as e:
             print(f"   ⚠️ 自动锁定检测出错（不影响搜索）: {e}")
-    
+
+    # v6.0：可选返回 query_embedding（供工具抽屉路由复用）
+    if return_embedding:
+        return results, query_embedding
+
     return results
 
 
@@ -2186,14 +2215,14 @@ async def sync_upsert_messages(conv_id: str, messages: list):
                 await conn.execute("""
                     INSERT INTO chat_messages (
                         id, conversation_id, role, content, time, model,
-                        streaming, error, token_info, thinking, tool_events,
-                        memory_result, memory_event, web_search_results, versions, version_index,
-                        attachments, usage, summary, sort_order
+                        streaming, error, token_info, thinking, status_events, tool_events,
+                        memory_result, memory_event, handoff_info, web_search_results, versions, version_index,
+                        images, attachments, usage, summary, sort_order
                     ) VALUES (
                         $1, $2, $3, $4, $5, $6,
-                        $7, $8, $9, $10, $11,
-                        $12, $13, $14, $15, $16,
-                        $17, $18, $19, $20
+                        $7, $8, $9, $10, $11, $12,
+                        $13, $14, $15, $16, $17, $18,
+                        $19, $20, $21, $22, $23
                     )
                 """,
                     str(msg.get("id") or f"m-{conv_id}-{idx}"),
@@ -2206,12 +2235,15 @@ async def sync_upsert_messages(conv_id: str, messages: list):
                     bool(msg.get("error", False)),
                     _to_json(msg.get("tokenInfo") or msg.get("token_info")),
                     msg.get("thinking") if isinstance(msg.get("thinking"), str) else None,
+                    _to_json(msg.get("statusEvents") or msg.get("status_events")),
                     _to_json(msg.get("toolEvents") or msg.get("tool_events")),
                     _to_json(msg.get("memoryResult") or msg.get("memory_result")),
                     _to_json(msg.get("memoryEvent") or msg.get("memory_event")),
+                    _to_json(msg.get("handoffInfo") or msg.get("handoff_info")),
                     _to_json(msg.get("webSearchResults") or msg.get("web_search_results")),
                     _to_json(msg.get("versions")),
                     int(msg.get("versionIndex", msg.get("version_index", 0)) or 0),
+                    _to_json(msg.get("images")),
                     _to_json(msg.get("attachments")),
                     _to_json(msg.get("usage")),
                     msg.get("summary") if isinstance(msg.get("summary"), str) else None,

--- a/database.py
+++ b/database.py
@@ -174,6 +174,7 @@ async def init_tables():
                 api_base_url    TEXT NOT NULL,
                 api_key         TEXT DEFAULT '',
                 enabled         BOOLEAN DEFAULT TRUE,
+                api_format      TEXT DEFAULT 'openai',
                 created_at      TIMESTAMPTZ DEFAULT NOW(),
                 updated_at      TIMESTAMPTZ DEFAULT NOW()
             );
@@ -190,6 +191,7 @@ async def init_tables():
                 input_modes     TEXT DEFAULT 'text',
                 output_modes    TEXT DEFAULT 'text',
                 capabilities    TEXT DEFAULT '',
+                api_format      TEXT DEFAULT NULL,
                 created_at      TIMESTAMPTZ DEFAULT NOW(),
                 UNIQUE(provider_id, model_id)
             );
@@ -571,7 +573,29 @@ async def init_tables():
             await conn.execute("ALTER TABLE memories ADD COLUMN resolution FLOAT DEFAULT 1.0")
             print("✅ memories 表已添加 resolution 列（记忆软化系统）")
 
-    print("✅ 数据库表结构已就绪（v5.9 记忆软化）")
+        # v6.2：providers 表添加 api_format 列（openai / anthropic）
+        has_api_format = await conn.fetchval("""
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'providers' AND column_name = 'api_format'
+            )
+        """)
+        if not has_api_format:
+            await conn.execute("ALTER TABLE providers ADD COLUMN api_format TEXT DEFAULT 'openai'")
+            print("✅ providers 表已添加 api_format 列（Anthropic 格式支持）")
+
+        # v6.2b：provider_models 表添加 api_format 列（模型级别覆盖供应商默认值）
+        has_model_api_format = await conn.fetchval("""
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'provider_models' AND column_name = 'api_format'
+            )
+        """)
+        if not has_model_api_format:
+            await conn.execute("ALTER TABLE provider_models ADD COLUMN api_format TEXT DEFAULT NULL")
+            print("✅ provider_models 表已添加 api_format 列（模型级覆盖）")
+
+    print("✅ 数据库表结构已就绪（v6.2b 模型级 API 格式支持）")
 
 
 # ============================================================
@@ -1849,7 +1873,7 @@ async def get_all_providers():
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch("""
-            SELECT id, name, api_base_url, api_key, enabled, created_at, updated_at
+            SELECT id, name, api_base_url, api_key, api_format, enabled, created_at, updated_at
             FROM providers ORDER BY created_at ASC
         """)
         return [dict(r) for r in rows]
@@ -1860,28 +1884,28 @@ async def get_provider(provider_id: int):
     pool = await get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow("""
-            SELECT id, name, api_base_url, api_key, enabled, created_at, updated_at
+            SELECT id, name, api_base_url, api_key, api_format, enabled, created_at, updated_at
             FROM providers WHERE id = $1
         """, provider_id)
         return dict(row) if row else None
 
 
-async def create_provider(name: str, api_base_url: str, api_key: str = '', enabled: bool = True):
+async def create_provider(name: str, api_base_url: str, api_key: str = '', enabled: bool = True, api_format: str = 'openai'):
     """创建供应商"""
     pool = await get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow("""
-            INSERT INTO providers (name, api_base_url, api_key, enabled)
-            VALUES ($1, $2, $3, $4)
-            RETURNING id, name, api_base_url, api_key, enabled, created_at, updated_at
-        """, name, api_base_url, api_key, enabled)
+            INSERT INTO providers (name, api_base_url, api_key, enabled, api_format)
+            VALUES ($1, $2, $3, $4, $5)
+            RETURNING id, name, api_base_url, api_key, api_format, enabled, created_at, updated_at
+        """, name, api_base_url, api_key, enabled, api_format)
         return dict(row)
 
 
 async def update_provider(provider_id: int, **kwargs):
     """更新供应商"""
     pool = await get_pool()
-    allowed = {'name', 'api_base_url', 'api_key', 'enabled'}
+    allowed = {'name', 'api_base_url', 'api_key', 'enabled', 'api_format'}
     fields = {k: v for k, v in kwargs.items() if k in allowed and v is not None}
     if not fields:
         return None
@@ -1897,7 +1921,7 @@ async def update_provider(provider_id: int, **kwargs):
     query = f"""
         UPDATE providers SET {', '.join(sets)}
         WHERE id = ${len(vals)}
-        RETURNING id, name, api_base_url, api_key, enabled, created_at, updated_at
+        RETURNING id, name, api_base_url, api_key, api_format, enabled, created_at, updated_at
     """
     async with pool.acquire() as conn:
         row = await conn.fetchrow(query, *vals)
@@ -1924,7 +1948,7 @@ async def get_provider_models(provider_id: int):
     async with pool.acquire() as conn:
         rows = await conn.fetch("""
             SELECT id, provider_id, model_id, display_name, model_type,
-                   input_modes, output_modes, capabilities, created_at
+                   input_modes, output_modes, capabilities, api_format, created_at
             FROM provider_models WHERE provider_id = $1
             ORDER BY created_at ASC
         """, provider_id)
@@ -1937,7 +1961,7 @@ async def get_all_saved_models():
     async with pool.acquire() as conn:
         rows = await conn.fetch("""
             SELECT pm.id, pm.provider_id, pm.model_id, pm.display_name, pm.model_type,
-                   pm.input_modes, pm.output_modes, pm.capabilities, pm.created_at,
+                   pm.input_modes, pm.output_modes, pm.capabilities, pm.api_format, pm.created_at,
                    p.name as provider_name
             FROM provider_models pm
             JOIN providers p ON pm.provider_id = p.id
@@ -1948,27 +1972,31 @@ async def get_all_saved_models():
 
 async def add_provider_model(provider_id: int, model_id: str, display_name: str = '',
                              model_type: str = 'chat', input_modes: str = 'text',
-                             output_modes: str = 'text', capabilities: str = ''):
+                             output_modes: str = 'text', capabilities: str = '', api_format: str = None):
     """添加模型到供应商"""
     pool = await get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow("""
             INSERT INTO provider_models (provider_id, model_id, display_name, model_type,
-                                         input_modes, output_modes, capabilities)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
+                                         input_modes, output_modes, capabilities, api_format)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             ON CONFLICT (provider_id, model_id) DO NOTHING
             RETURNING id, provider_id, model_id, display_name, model_type,
-                      input_modes, output_modes, capabilities, created_at
+                      input_modes, output_modes, capabilities, api_format, created_at
         """, provider_id, model_id, display_name or model_id, model_type,
-             input_modes, output_modes, capabilities)
+             input_modes, output_modes, capabilities, api_format or None)
         return dict(row) if row else None
 
 
 async def update_provider_model(model_pk_id: int, **kwargs):
     """更新模型配置"""
     pool = await get_pool()
-    allowed = {'display_name', 'model_type', 'input_modes', 'output_modes', 'capabilities'}
-    fields = {k: v for k, v in kwargs.items() if k in allowed and v is not None}
+    allowed = {'display_name', 'model_type', 'input_modes', 'output_modes', 'capabilities', 'api_format'}
+    fields = {k: v for k, v in kwargs.items() if k in allowed}
+    # api_format 允许设为 None/空串（表示跟随供应商）
+    if 'api_format' in fields:
+        fields['api_format'] = fields['api_format'] or None
+    fields = {k: v for k, v in fields.items() if v is not None or k == 'api_format'}
     if not fields:
         return None
 
@@ -1983,7 +2011,7 @@ async def update_provider_model(model_pk_id: int, **kwargs):
         UPDATE provider_models SET {', '.join(sets)}
         WHERE id = ${len(vals)}
         RETURNING id, provider_id, model_id, display_name, model_type,
-                  input_modes, output_modes, capabilities, created_at
+                  input_modes, output_modes, capabilities, api_format, created_at
     """
     async with pool.acquire() as conn:
         row = await conn.fetchrow(query, *vals)
@@ -2001,11 +2029,16 @@ async def delete_provider_model(model_pk_id: int):
 
 
 async def resolve_provider_for_model(model_id: str):
-    """根据 model_id 查找对应的已启用供应商，返回 {api_base_url, api_key, provider_name} 或 None"""
+    """根据 model_id 查找对应的已启用供应商，返回 {api_base_url, api_key, api_format, provider_name} 或 None
+
+    api_format 优先级：模型级 > 供应商级 > 默认 'openai'
+    """
     pool = await get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow("""
-            SELECT p.api_base_url, p.api_key, p.name as provider_name
+            SELECT p.api_base_url, p.api_key,
+                   COALESCE(pm.api_format, p.api_format, 'openai') as api_format,
+                   p.name as provider_name
             FROM provider_models pm
             JOIN providers p ON pm.provider_id = p.id
             WHERE pm.model_id = $1 AND p.enabled = TRUE

--- a/database.py
+++ b/database.py
@@ -1227,6 +1227,7 @@ async def _vector_search(query_embedding: list, limit: int, heat_params: dict, p
             "is_permanent": row.get("is_permanent", False),
             "emotional_weight": row.get("emotional_weight", 0),
             "resolution": row.get("resolution", 1.0),
+            "project_id": row.get("project_id"),
             "heat": round(heat, 4),
             "similarity": round(sim, 4),
             "score": round(score, 4),
@@ -1617,6 +1618,7 @@ async def _keyword_search(query: str, limit: int = 10, heat_params: dict = None,
                 COALESCE(m.access_query_hashes, '[]'::jsonb) as access_query_hashes,
                 COALESCE(m.is_permanent, false) as is_permanent,
                 COALESCE(m.resolution, 1.0) as resolution,
+                m.project_id,
                 ({hit_count_expr}) AS hit_count,
                 (
                     0.5 * ({hit_count_expr})::float / {max_hits} +
@@ -1651,6 +1653,7 @@ async def _keyword_search(query: str, limit: int = 10, heat_params: dict = None,
                 "is_permanent": r.get("is_permanent", False),
                 "emotional_weight": r.get("emotional_weight", 0),
                 "resolution": r.get("resolution", 1.0),
+                "project_id": r.get("project_id"),
                 "heat": round(heat, 4),
                 "similarity": 0.0,
                 "score": round(float(r["score"]), 4),
@@ -1707,38 +1710,46 @@ async def get_all_memories_count():
 # 记忆去重检测
 # ============================================================
 
-async def check_memory_duplicate(new_content: str, threshold: float = None, new_title: str = ""):
+async def check_memory_duplicate(new_content: str, threshold: float = None, new_title: str = "", project_id: str = None):
     """
     检查新记忆是否与已有记忆重复（v5.4：标题不同时不判重复）
-    
+
     三层检测：
     1. 精确匹配
     2. 包含关系
     3. 字符重叠度 + 标题保护（标题明显不同 → 不同主题 → 放行）
-    
+
+    project_id: 传入时只在该项目内去重；不传时只在全局（project_id IS NULL）去重
+
     返回：(is_duplicate: bool, similar_results: list)
-    
+
     注意：去重仍用字符级检测（而非向量），因为去重需要精确判断，
     而向量搜索更适合"模糊相关"的场景。
     """
     if threshold is None:
         threshold = DEDUP_THRESHOLD
-    
+
     pool = await get_pool()
-    
-    # 第1层：精确匹配
+
+    # 第1层：精确匹配（按作用域过滤）
     async with pool.acquire() as conn:
-        exact_count = await conn.fetchval(
-            "SELECT COUNT(*) FROM memories WHERE content = $1",
-            new_content,
-        )
+        if project_id:
+            exact_count = await conn.fetchval(
+                "SELECT COUNT(*) FROM memories WHERE content = $1 AND project_id = $2",
+                new_content, project_id,
+            )
+        else:
+            exact_count = await conn.fetchval(
+                "SELECT COUNT(*) FROM memories WHERE content = $1 AND project_id IS NULL",
+                new_content,
+            )
         if exact_count > 0:
             print(f"🔄 精确重复，跳过: {new_content[:60]}...")
             return True, []
-    
+
     # 第2层 + 第3层：先用向量搜索找候选，再做精确对比
     try:
-        similar = await search_memories(new_content, limit=15, track_recall=False)
+        similar = await search_memories(new_content, limit=15, track_recall=False, project_id=project_id)
     except Exception:
         return False, []
     

--- a/main.py
+++ b/main.py
@@ -693,6 +693,12 @@ async def process_memories_background(session_id: str, user_msg: str, assistant_
                     print(f"   🌙 Dream 异常: {e}")
             _spawn_background_task(_silent_dream())
 
+        # 项目对话默认不提取碎片（对话已保存，但不走记忆提取流程）
+        # 未来做"碎片进全局"开关后，这里加条件判断
+        if project_id:
+            print(f"📂 项目对话，跳过记忆提取（project_id={project_id}）")
+            return {"action": "skip_project", "project_id": project_id}
+
         # 检测用户是否主动要求记忆
         force_extract = any(kw in user_msg for kw in MEMORY_TRIGGER_WORDS)
 
@@ -792,26 +798,33 @@ async def process_memories_background(session_id: str, user_msg: str, assistant_
         saved_count = 0
         skipped_count = 0
         contradiction_count = 0
-        
+        saved_items = []  # 收集保存的记忆内容（供事件 payload 使用）
+
         for mem in filtered_memories:
-            # 去重检测（v5.4：传标题，标题不同时不误杀）
-            is_dup, similar_results = await check_memory_duplicate(mem["content"], new_title=mem.get("title", ""))
-            
+            # 去重检测（v5.4：传标题，标题不同时不误杀；v5.8：按 project_id 作用域去重）
+            is_dup, similar_results = await check_memory_duplicate(mem["content"], new_title=mem.get("title", ""), project_id=project_id)
+
             if is_dup:
                 skipped_count += 1
                 continue
-            
+
+            # 按作用域过滤矛盾候选：项目碎片只能替代同项目的旧碎片，全局只看全局
+            if project_id:
+                scoped_results = [m for m in similar_results if m.get("project_id") == project_id]
+            else:
+                scoped_results = [m for m in similar_results if m.get("project_id") is None]
+
             # 矛盾检测（v5.3：复用去重搜索结果，不额外调 embedding API）
             contradicted_ids = detect_contradictions(
-                mem.get("title", ""), mem["content"], similar_results
+                mem.get("title", ""), mem["content"], scoped_results
             )
-            
+
             # 自动匹配分类
             cat_id = None
             cat_hint = mem.get("category", "")
             if cat_hint:
                 cat_id = await match_category_by_name(cat_hint)
-            
+
             # 保存新记忆（v5.3：返回 ID，用于创建 supersedes edge）
             new_id = await save_memory(
                 content=mem["content"],
@@ -824,7 +837,8 @@ async def process_memories_background(session_id: str, user_msg: str, assistant_
                 project_id=project_id,
             )
             saved_count += 1
-            
+            saved_items.append({"title": mem.get("title", ""), "content": mem["content"][:120]})
+
             # 处理矛盾：标旧记忆失效 + 创建 supersedes edge
             if contradicted_ids and new_id:
                 for old_id in contradicted_ids:
@@ -834,15 +848,15 @@ async def process_memories_background(session_id: str, user_msg: str, assistant_
                         reason="提取时自动检测到信息更新", created_by="extractor"
                     )
                     contradiction_count += 1
-        
+
         if saved_count > 0 or skipped_count > 0:
             total = await get_all_memories_count()
             contra_msg = f"，{contradiction_count} 条旧记忆被替代" if contradiction_count > 0 else ""
             print(f"💾 提取结果：{saved_count} 条新记忆已保存，{skipped_count} 条重复已跳过{contra_msg}，总计 {total} 条")
-            return {"action": "extract", "saved": saved_count, "skipped": skipped_count, "contradictions": contradiction_count, "total": total}
+            return {"action": "extract", "saved": saved_count, "skipped": skipped_count, "contradictions": contradiction_count, "total": total, "items": saved_items}
         else:
             print(f"💭 本轮对话未产生新记忆")
-            return {"action": "extract", "saved": 0, "skipped": 0, "contradictions": 0, "total": await get_all_memories_count()}
+            return {"action": "extract", "saved": 0, "skipped": 0, "contradictions": 0, "total": await get_all_memories_count(), "items": []}
             
     except Exception as e:
         print(f"⚠️  后台记忆处理失败: {e}")
@@ -2455,7 +2469,7 @@ async def api_extract_now(request: Request):
         for mem in new_memories:
             if any(kw in mem["content"] for kw in META_BLACKLIST):
                 continue
-            is_dup, _ = await check_memory_duplicate(mem["content"], new_title=mem.get("title", ""))
+            is_dup, _ = await check_memory_duplicate(mem["content"], new_title=mem.get("title", ""), project_id=project_id)
             if is_dup:
                 skipped_count += 1
                 continue

--- a/main.py
+++ b/main.py
@@ -351,7 +351,7 @@ def replace_template_variables(text: str, context: dict = None) -> str:
 # 记忆注入
 # ============================================================
 
-async def build_system_prompt_with_memories(user_message: str, user_msg_count: int = 1, project_id: str = None) -> tuple:
+async def build_system_prompt_with_memories(user_message: str, user_msg_count: int = 1, project_id: str = None, conversation_id: str = None) -> tuple:
     """
     构建带记忆的 system prompt（v5.5 日历层级注入 + v5.8 项目注入 + 缓存优化）
     
@@ -529,7 +529,7 @@ async def build_system_prompt_with_memories(user_message: str, user_msg_count: i
             if handoff_on and user_msg_count <= handoff_stop:
                 from database import get_handoff_messages
                 handoff_count = await get_config_int("handoff_msg_count", fallback=6)
-                handoff_msgs, prev_title = await get_handoff_messages(limit=handoff_count)
+                handoff_msgs, prev_title = await get_handoff_messages(limit=handoff_count, exclude_conversation_id=conversation_id)
                 if handoff_msgs:
                     title_hint = f"（上一个对话：{prev_title}）" if prev_title else ""
                     prompt_meta["handoff"] = {"title": prev_title or "", "count": len(handoff_msgs)}
@@ -1100,6 +1100,8 @@ async def chat_completions(request: Request):
     
     # v5.8：项目 ID（前端传来，用于项目指令/记忆/文件注入）
     project_id = body.pop('project_id', None) or None
+    # v6.0：前端对话 ID，用于无缝换窗时避免衔接到当前对话自身
+    conversation_id = body.pop('conversation_id', None) or None
 
     # 先确定最终模型，后面的 prompt cache 判断要用它。
     # 如果客户端没传 model，这里会补上默认值，避免误判为“非 Claude”而跳过缓存。
@@ -1114,7 +1116,7 @@ async def chat_completions(request: Request):
         # v5.6：计算用户消息数（用于无缝切窗判断是第几轮）
         user_msg_count = sum(1 for m in messages if m.get('role') == 'user')
         if mem_enabled and user_message:
-            enhanced_prompt, prompt_meta = await build_system_prompt_with_memories(user_message, user_msg_count=user_msg_count, project_id=project_id)
+            enhanced_prompt, prompt_meta = await build_system_prompt_with_memories(user_message, user_msg_count=user_msg_count, project_id=project_id, conversation_id=conversation_id)
         else:
             # v5.4：即使记忆关闭，也从数据库优先读取 system prompt（降级到文件版本）
             enhanced_prompt = await get_active_system_prompt() or SYSTEM_PROMPT

--- a/main.py
+++ b/main.py
@@ -48,6 +48,10 @@ from memory_extractor import extract_memories
 from mcp_server import get_mcp_app, get_calendar_mcp_app, mcp_memory, mcp_calendar
 from web_search import web_search, format_results_for_prompt, get_engine_list
 from mcp_client import get_tools_for_servers, run_tool_call_loop, call_tool, call_tools_batch, clear_tool_cache
+from anthropic_adapter import (
+    to_anthropic_request, to_anthropic_headers, get_anthropic_url,
+    from_anthropic_response, anthropic_stream_to_openai,
+)
 
 # ============================================================
 # 配置项 —— 全部从环境变量读取，部署时在云平台面板里设置
@@ -1226,12 +1230,18 @@ async def chat_completions(request: Request):
         provider_info = await resolve_provider_for_model(model)
     except Exception:
         provider_info = None
+
+    api_format = "openai"  # 默认 OpenAI 格式
     if provider_info:
         chat_api_key = provider_info["api_key"]
-        # 确保 URL 以 /chat/completions 结尾
+        api_format = provider_info.get("api_format", "openai") or "openai"
         base = provider_info["api_base_url"].rstrip("/")
-        chat_api_url = base if base.endswith("/chat/completions") else f"{base}/chat/completions"
-        print(f"🔀 路由到供应商 [{provider_info['provider_name']}]: {base}")
+        if api_format == "anthropic":
+            chat_api_url = get_anthropic_url(base)
+            print(f"🔀 路由到供应商 [{provider_info['provider_name']}] (Anthropic 格式): {chat_api_url}")
+        else:
+            chat_api_url = base if base.endswith("/chat/completions") else f"{base}/chat/completions"
+            print(f"🔀 路由到供应商 [{provider_info['provider_name']}]: {base}")
     else:
         chat_api_key = API_KEY
         chat_api_url = API_BASE_URL
@@ -1270,13 +1280,16 @@ async def chat_completions(request: Request):
             print(f"🔀 Provider 偏好：优先 Anthropic 直连")
 
     # ---------- 转发请求 ----------
-    headers = {
-        "Authorization": f"Bearer {chat_api_key}",
-        "Content-Type": "application/json",
-    }
-    if "openrouter" in chat_api_url:
-        headers["HTTP-Referer"] = EXTRA_REFERER
-        headers["X-Title"] = EXTRA_TITLE
+    if api_format == "anthropic":
+        headers = to_anthropic_headers(chat_api_key)
+    else:
+        headers = {
+            "Authorization": f"Bearer {chat_api_key}",
+            "Content-Type": "application/json",
+        }
+        if "openrouter" in chat_api_url:
+            headers["HTTP-Referer"] = EXTRA_REFERER
+            headers["X-Title"] = EXTRA_TITLE
     
     is_stream = body.get("stream", False)
     
@@ -1443,6 +1456,7 @@ async def chat_completions(request: Request):
                 api_key=chat_api_key,
                 project_id=project_id,
                 prompt_meta=prompt_meta,
+                api_format=api_format,
             ),
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
@@ -1451,16 +1465,21 @@ async def chat_completions(request: Request):
     # ========== 正常转发模式 ==========
     if is_stream:
         return StreamingResponse(
-            stream_and_capture(headers, body, session_id, user_message, model, tool_events, api_url=chat_api_url, project_id=project_id, prompt_meta=prompt_meta),
+            stream_and_capture(headers, body, session_id, user_message, model, tool_events, api_url=chat_api_url, project_id=project_id, prompt_meta=prompt_meta, api_format=api_format, api_key=chat_api_key),
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
         )
     else:
+        # 非流式：Anthropic 格式需要转换请求和响应
+        send_body = to_anthropic_request(body) if api_format == "anthropic" else body
         async with httpx.AsyncClient(timeout=300) as client:
-            response = await client.post(chat_api_url, headers=headers, json=body)
-            
+            response = await client.post(chat_api_url, headers=headers, json=send_body)
+
             if response.status_code == 200:
                 resp_data = response.json()
+                # Anthropic 响应转回 OpenAI 格式
+                if api_format == "anthropic":
+                    resp_data = from_anthropic_response(resp_data, model)
                 assistant_msg = ""
                 try:
                     assistant_msg = resp_data["choices"][0]["message"]["content"]
@@ -1659,7 +1678,7 @@ async def _execute_gateway_tool(tool_name: str, arguments: dict, tool_info: dict
     return f"未知的内置工具: {tool_name}", extra
 
 
-async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool_events, session_id, user_message, mem_enabled, api_url=None, api_key=None, project_id=None, prompt_meta=None):
+async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool_events, session_id, user_message, mem_enabled, api_url=None, api_key=None, project_id=None, prompt_meta=None, api_format="openai"):
     """
     工具 + 流式模式：tool call 轮次用非流式（需要完整看 tool_calls），
     最终回复直接输出已获得的内容（模拟流式），不再重复请求 LLM。
@@ -1678,13 +1697,16 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
     for evt in (tool_events or []):
         yield f"data: {json.dumps({'ev_tool': evt}, ensure_ascii=False)}\n\n"
 
-    headers = {
-        "Authorization": f"Bearer {_api_key}",
-        "Content-Type": "application/json",
-    }
-    if "openrouter" in _api_url:
-        headers["HTTP-Referer"] = EXTRA_REFERER
-        headers["X-Title"] = EXTRA_TITLE
+    if api_format == "anthropic":
+        headers = to_anthropic_headers(_api_key)
+    else:
+        headers = {
+            "Authorization": f"Bearer {_api_key}",
+            "Content-Type": "application/json",
+        }
+        if "openrouter" in _api_url:
+            headers["HTTP-Referer"] = EXTRA_REFERER
+            headers["X-Title"] = EXTRA_TITLE
 
     current_messages = list(messages)
     max_rounds = 10
@@ -1700,19 +1722,26 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
             "stream": False,
         }
         # OpenRouter：非流式也启用思考链，这样最终回复直接输出时不丢思考内容
-        if "openrouter" in _api_url:
+        # （Anthropic 直连不需要这个 OpenRouter 私有字段）
+        if api_format == "openai" and "openrouter" in _api_url:
             body["reasoning"] = {"enabled": True}
 
-        print(f"🔄 Tool loop round {round_num + 1}: {len(tools)} tools, {len(current_messages)} msgs")
+        # Anthropic 格式转换
+        send_body = to_anthropic_request(body) if api_format == "anthropic" else body
+
+        print(f"🔄 Tool loop round {round_num + 1}: {len(tools)} tools, {len(current_messages)} msgs (format={api_format})")
 
         async with _httpx.AsyncClient(timeout=120) as client:
-            resp = await client.post(_api_url, headers=headers, json=body)
+            resp = await client.post(_api_url, headers=headers, json=send_body)
             if resp.status_code != 200:
                 print(f"❌ LLM 请求失败: {resp.status_code}")
                 yield f"data: {json.dumps({'choices': [{'delta': {'content': f'⚠️ 模型请求失败 ({resp.status_code})'}, 'finish_reason': None}], 'model': model}, ensure_ascii=False)}\n\n"
                 yield "data: [DONE]\n\n"
                 return
             data = resp.json()
+            # Anthropic 响应转回 OpenAI 格式
+            if api_format == "anthropic":
+                data = from_anthropic_response(data, model)
 
         choice = data.get("choices", [{}])[0]
         message = choice.get("message", {})
@@ -1877,72 +1906,112 @@ def _estimate_tokens(text: str) -> int:
     return max(1, round(cjk / 1.5 + other / 4))
 
 
-async def stream_and_capture(headers: dict, body: dict, session_id: str, user_message: str, model: str, tool_events: list = None, api_url: str = None, project_id: str = None, prompt_meta: dict = None):
+async def stream_and_capture(headers: dict, body: dict, session_id: str, user_message: str, model: str, tool_events: list = None, api_url: str = None, project_id: str = None, prompt_meta: dict = None, api_format: str = "openai", api_key: str = None):
     """流式响应 + 捕获完整回复 + 工具事件"""
     _api_url = api_url or API_BASE_URL
-    
+
     # 先发送衔接提示（如果有无缝切窗）
     if prompt_meta and prompt_meta.get("handoff"):
         yield f"data: {json.dumps({'ev_handoff': prompt_meta['handoff']}, ensure_ascii=False)}\n\n".encode("utf-8")
-    
+
     # 先发送工具事件
     for evt in (tool_events or []):
         yield f"data: {json.dumps({'ev_tool': evt}, ensure_ascii=False)}\n\n".encode("utf-8")
-    
+
     full_response = []
-    buffer = ""
     _logged_first_delta = False
     _reasoning_chunks = 0
-    
-    async with httpx.AsyncClient(timeout=300) as client:
-        async with client.stream("POST", _api_url, headers=headers, json=body) as response:
-            if response.status_code != 200:
-                error_body = b""
-                async for chunk in response.aiter_bytes():
-                    error_body += chunk
-                print(f"❌ 流式请求失败 [{response.status_code}]: {error_body[:500].decode('utf-8', errors='ignore')}")
-                err_msg = f"⚠️ 请求失败 ({response.status_code})"
-                err_payload = json.dumps({'choices': [{'delta': {'content': err_msg}, 'finish_reason': None}], 'model': model}, ensure_ascii=False)
-                yield f"data: {err_payload}\n\n".encode("utf-8")
-                yield b"data: [DONE]\n\n"
-                return
-            
-            async for chunk in response.aiter_bytes():
-                yield chunk
-                try:
-                    buffer += chunk.decode("utf-8", errors="ignore")
-                    while "\n" in buffer:
-                        line, buffer = buffer.split("\n", 1)
-                        line = line.strip()
-                        if line.startswith("data: ") and line != "data: [DONE]":
-                            try:
+
+    # Anthropic 格式：转换请求体，使用流式适配器
+    if api_format == "anthropic":
+        send_body = to_anthropic_request(body)
+        send_body["stream"] = True
+        _headers = to_anthropic_headers(api_key or API_KEY)
+        _headers["Accept-Encoding"] = "identity"
+
+        async with httpx.AsyncClient(timeout=300) as client:
+            async with client.stream("POST", _api_url, headers=_headers, json=send_body) as response:
+                if response.status_code != 200:
+                    error_body = b""
+                    async for chunk in response.aiter_bytes():
+                        error_body += chunk
+                    print(f"❌ Anthropic 流式请求失败 [{response.status_code}]: {error_body[:500].decode('utf-8', errors='ignore')}")
+                    err_msg = f"⚠️ 请求失败 ({response.status_code})"
+                    err_payload = json.dumps({'choices': [{'delta': {'content': err_msg}, 'finish_reason': None}], 'model': model}, ensure_ascii=False)
+                    yield f"data: {err_payload}\n\n".encode("utf-8")
+                    yield b"data: [DONE]\n\n"
+                    return
+
+                # 使用适配器将 Anthropic SSE 转换为 OpenAI SSE
+                async for openai_chunk in anthropic_stream_to_openai(response, model):
+                    yield openai_chunk
+                    # 捕获正文内容（用于后续记忆提取）
+                    try:
+                        decoded = openai_chunk.decode("utf-8", errors="ignore")
+                        for line in decoded.strip().split("\n"):
+                            line = line.strip()
+                            if line.startswith("data: ") and line != "data: [DONE]":
                                 data = json.loads(line[6:])
                                 delta = data.get("choices", [{}])[0].get("delta", {})
-                                
-                                # 🔍 调试日志：记录第一个有效delta的所有字段
-                                if not _logged_first_delta and delta:
-                                    keys = list(delta.keys())
-                                    if keys and keys != ['role']:
-                                        print(f"🔍 [流式调试] 首个delta字段: {keys}, 模型: {model}")
-                                        # 如果有思考链相关字段，打印示例
-                                        for k in ('reasoning_content', 'reasoning', 'reasoning_details'):
-                                            if k in delta:
-                                                sample = str(delta[k])[:100]
-                                                print(f"🔍 [流式调试] {k} 示例: {sample}")
-                                        _logged_first_delta = True
-                                
-                                # 统计思考链 chunk 数
-                                if delta.get('reasoning_content') or delta.get('reasoning') or delta.get('reasoning_details'):
-                                    _reasoning_chunks += 1
-                                
                                 content = delta.get("content", "")
                                 if content:
                                     full_response.append(content)
-                            except (json.JSONDecodeError, KeyError, IndexError):
-                                pass
-                except Exception:
-                    pass
-    
+                                if delta.get("reasoning_content"):
+                                    _reasoning_chunks += 1
+                    except Exception:
+                        pass
+    else:
+        # OpenAI 格式：直接转发
+        buffer = ""
+        async with httpx.AsyncClient(timeout=300) as client:
+            async with client.stream("POST", _api_url, headers=headers, json=body) as response:
+                if response.status_code != 200:
+                    error_body = b""
+                    async for chunk in response.aiter_bytes():
+                        error_body += chunk
+                    print(f"❌ 流式请求失败 [{response.status_code}]: {error_body[:500].decode('utf-8', errors='ignore')}")
+                    err_msg = f"⚠️ 请求失败 ({response.status_code})"
+                    err_payload = json.dumps({'choices': [{'delta': {'content': err_msg}, 'finish_reason': None}], 'model': model}, ensure_ascii=False)
+                    yield f"data: {err_payload}\n\n".encode("utf-8")
+                    yield b"data: [DONE]\n\n"
+                    return
+
+                async for chunk in response.aiter_bytes():
+                    yield chunk
+                    try:
+                        buffer += chunk.decode("utf-8", errors="ignore")
+                        while "\n" in buffer:
+                            line, buffer = buffer.split("\n", 1)
+                            line = line.strip()
+                            if line.startswith("data: ") and line != "data: [DONE]":
+                                try:
+                                    data = json.loads(line[6:])
+                                    delta = data.get("choices", [{}])[0].get("delta", {})
+
+                                    # 🔍 调试日志：记录第一个有效delta的所有字段
+                                    if not _logged_first_delta and delta:
+                                        keys = list(delta.keys())
+                                        if keys and keys != ['role']:
+                                            print(f"🔍 [流式调试] 首个delta字段: {keys}, 模型: {model}")
+                                            # 如果有思考链相关字段，打印示例
+                                            for k in ('reasoning_content', 'reasoning', 'reasoning_details'):
+                                                if k in delta:
+                                                    sample = str(delta[k])[:100]
+                                                    print(f"🔍 [流式调试] {k} 示例: {sample}")
+                                            _logged_first_delta = True
+
+                                    # 统计思考链 chunk 数
+                                    if delta.get('reasoning_content') or delta.get('reasoning') or delta.get('reasoning_details'):
+                                        _reasoning_chunks += 1
+
+                                    content = delta.get("content", "")
+                                    if content:
+                                        full_response.append(content)
+                                except (json.JSONDecodeError, KeyError, IndexError):
+                                    pass
+                    except Exception:
+                        pass
+
     assistant_msg = "".join(full_response)
     
     # 🔍 流式完成汇总
@@ -2995,7 +3064,7 @@ async def api_create_provider(request: Request):
         if not api_base_url:
             return {"error": "API Base URL 不能为空"}
 
-        provider = await create_provider(name, api_base_url, api_key, enabled)
+        provider = await create_provider(name, api_base_url, api_key, enabled, api_format=data.get("api_format", "openai"))
         return {"status": "created", "provider": provider}
     except Exception as e:
         return {"error": str(e)}

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -44,6 +44,8 @@ mcp_memory = FastMCP("Memory Garden", stateless_http=True)
 @mcp_memory.tool()
 async def search_memory(query: str, limit: int = 10) -> str:
     """
+    [category: memory]
+
     搜索记忆 — 用自然语言描述你想找的内容，向量语义搜索会返回最相关的记忆。
 
     参数：
@@ -94,6 +96,8 @@ async def search_memory(query: str, limit: int = 10) -> str:
 @mcp_memory.tool()
 async def save_memory(content: str, title: str = "", importance: int = 5) -> str:
     """
+    [category: memory]
+
     保存一条新记忆到记忆库。
 
     参数：
@@ -137,6 +141,8 @@ async def save_memory(content: str, title: str = "", importance: int = 5) -> str
 @mcp_memory.tool()
 async def get_recent(limit: int = 20) -> str:
     """
+    [category: memory]
+
     获取最近的记忆，按时间倒序排列。
 
     参数：
@@ -181,6 +187,8 @@ async def get_recent(limit: int = 20) -> str:
 @mcp_memory.tool()
 async def trigger_digest(date: str = "") -> str:
     """
+    [category: system_internal]
+
     手动触发每日记忆整理 — 把当天的碎片记忆合并成独立事件条目。
 
     参数：
@@ -213,6 +221,8 @@ async def trigger_digest(date: str = "") -> str:
 @mcp_memory.tool()
 async def lock_memory(memory_id: int) -> str:
     """
+    [category: memory]
+
     锁定一条记忆 — 锁定后热度永远为 1.0，不会衰减遗忘，每次聊天都会注入。
 
     参数：
@@ -240,6 +250,8 @@ async def lock_memory(memory_id: int) -> str:
 @mcp_memory.tool()
 async def unlock_memory(memory_id: int) -> str:
     """
+    [category: memory]
+
     解锁一条记忆 — 解锁后恢复正常热度衰减。
 
     参数：
@@ -276,6 +288,8 @@ mcp_calendar = FastMCP("Calendar & Dream", stateless_http=True)
 @mcp_calendar.tool()
 async def get_day_page(date: str, type: str = "day") -> str:
     """
+    [category: calendar]
+
     查看某一天的日历页面（日记/周总结/月总结等）。
 
     参数：
@@ -339,6 +353,8 @@ async def get_day_page(date: str, type: str = "day") -> str:
 @mcp_calendar.tool()
 async def get_calendar_range(start: str, end: str, type: str = "") -> str:
     """
+    [category: calendar]
+
     查看一段时间内的日历页面列表。
 
     参数：
@@ -394,6 +410,8 @@ async def get_calendar_range(start: str, end: str, type: str = "") -> str:
 @mcp_calendar.tool()
 async def save_calendar_page(date: str, content: str, title: str = "", type: str = "day") -> str:
     """
+    [category: calendar]
+
     写入或更新日历页面（日记）。
 
     参数：
@@ -436,6 +454,8 @@ async def save_calendar_page(date: str, content: str, title: str = "", type: str
 @mcp_calendar.tool()
 async def get_comments(target_type: str, target_id: int) -> str:
     """
+    [category: calendar]
+
     读取某个页面的评论列表。
 
     参数：
@@ -478,6 +498,8 @@ async def get_comments(target_type: str, target_id: int) -> str:
 @mcp_calendar.tool()
 async def add_comment(target_type: str, target_id: int, content: str, parent_id: int = 0) -> str:
     """
+    [category: calendar]
+
     在日历页面或场景下添加评论。
 
     参数：
@@ -524,6 +546,8 @@ async def add_comment(target_type: str, target_id: int, content: str, parent_id:
 @mcp_calendar.tool()
 async def get_user_profile() -> str:
     """
+    [category: profile]
+
     查看当前的用户画像 — AI 对用户的认知。
 
     画像包含四个板块：基本档案、洞察、近期重点、长期偏好。
@@ -549,6 +573,8 @@ async def get_user_profile() -> str:
 @mcp_calendar.tool()
 async def trigger_dream() -> str:
     """
+    [category: dream]
+
     让 AI 去睡觉（触发 Dream 记忆整合）。
 
     Dream 会整理碎片记忆、形成记忆场景（MemScene）、产生前瞻信号（Foresight）。
@@ -597,6 +623,8 @@ async def trigger_dream() -> str:
 @mcp_calendar.tool()
 async def stop_dream() -> str:
     """
+    [category: dream]
+
     中断正在进行的 Dream。
 
     用于在 Dream 过程中需要紧急打断时使用。
@@ -618,6 +646,8 @@ async def stop_dream() -> str:
 @mcp_calendar.tool()
 async def get_dream_status() -> str:
     """
+    [category: dream]
+
     查看 Dream 状态 — 是否正在做梦、上次做梦的结果、待处理碎片数量。
     """
     try:
@@ -660,6 +690,8 @@ async def get_dream_status() -> str:
 @mcp_calendar.tool()
 async def get_dream_history(limit: int = 10) -> str:
     """
+    [category: dream]
+
     查看 Dream 执行历史记录。
 
     参数：
@@ -712,6 +744,8 @@ async def get_dream_history(limit: int = 10) -> str:
 @mcp_calendar.tool()
 async def get_dream_scenes() -> str:
     """
+    [category: dream]
+
     查看所有活跃的记忆场景（MemScene）。
 
     记忆场景是 Dream 过程中将相关碎片记忆凝聚成的主题叙事。

--- a/tool_drawer.py
+++ b/tool_drawer.py
@@ -1,0 +1,509 @@
+"""
+tool_drawer.py - Vector Tool Drawer (Auto-Discovery)
+=====================================================
+启动时自动从 mcp_server.py 发现工具、提取 schema、归类。
+新增工具只需在 mcp_server.py 写函数并加 [category: xxx] 标签。
+"""
+
+import ast
+import os
+import re
+import time
+from typing import Dict, List, Optional, Set, Tuple
+
+# ============================================================
+# 1. Category Metadata (静态配置，很少变动)
+#    加新类别时在这里加一条即可
+# ============================================================
+
+CATEGORY_META = {
+    "memory": {
+        "label": "记忆",
+        "description": "记忆搜索、保存记忆、查看最近记忆、锁定解锁记忆、提取摘要。用户想回忆过去说过的话、保存重要信息、管理记忆碎片时需要。",
+        "keywords": ["记忆", "记得", "记住", "碎片", "忘了", "忘记", "回忆",
+                     "记一下", "存一下", "想起", "记下", "保存记忆"],
+    },
+    "calendar": {
+        "label": "日历",
+        "description": "日历日志、日页面读写、周月年总结、评论系统。用户想写日记、查看某天的记录、回顾一段时间的日志时需要。",
+        "keywords": ["日记", "日志", "日历", "写日记", "那天", "那一天",
+                     "昨天的", "上周记", "今天写"],
+    },
+    "dream": {
+        "label": "Dream",
+        "description": "做梦、整理记忆、触发Dream流程、查看梦境状态和历史、查看记忆场景。用户说去做梦、整理一下、让 AI 睡觉时需要。",
+        "keywords": ["做梦", "梦境", "整理记忆", "睡觉", "睡吧", "去睡",
+                     "睡一觉", "做个梦", "Dream", "dream"],
+    },
+    "profile": {
+        "label": "画像",
+        "description": "用户画像、人格印象、对用户的认知。查看 AI 对用户的理解和印象标签。",
+        "keywords": ["你怎么看我", "你眼里的我", "你眼中我", "在你心里",
+                     "我是什么样", "你觉得我", "你对我的印象", "画像"],
+    },
+    "search": {
+        "label": "搜索",
+        "description": "联网搜索、查询实时信息、新闻、天气、价格。用户需要最新资讯或事实核查时需要。",
+        "keywords": ["搜索", "搜一下", "查一下", "新闻", "天气", "最新",
+                     "帮我查", "搜搜", "查查"],
+    },
+    "conversation": {
+        "label": "对话",
+        "description": "搜索过去的对话记录、查找之前聊过的话题和细节。用户提到之前讨论过、上次说的时需要。",
+        "keywords": ["还记得", "之前聊", "之前说", "上次说", "上次",
+                     "那次", "聊过", "讨论过", "你说过", "我说过",
+                     "我跟你说过", "我和你说过", "印象中", "印象里",
+                     "以前聊", "之前提"],
+    },
+    "reminder": {
+        "label": "提醒",
+        "description": "提醒、闹钟、定时任务。创建提醒、查看列表、完成、删除。用户说提醒我、几点叫我、别忘了时需要。",
+        "keywords": ["提醒", "闹钟", "定时", "叫我", "别忘了", "记得叫",
+                     "点钟", "每天", "每周", "到点"],
+    },
+}
+
+# ============================================================
+# 2. Gateway-builtin Tool Schemas (不在 mcp_server.py 里的工具)
+#    这些工具由 main.py 的 _execute_gateway_tool 处理
+# ============================================================
+
+GATEWAY_TOOL_SCHEMAS = {
+    "_gateway_web_search": {"type":"function","function":{"name":"_gateway_web_search","description":"联网搜索实时信息。仅在需要最新新闻/天气/实时数据时调用。","parameters":{"type":"object","properties":{"query":{"type":"string","description":"搜索关键词"}},"required":["query"]}}},
+    "_gateway_search_conversations": {"type":"function","function":{"name":"_gateway_search_conversations","description":"搜索过去的对话记录。当用户提到之前聊过、上次说的时调用。","parameters":{"type":"object","properties":{"query":{"type":"string","description":"搜索关键词"},"limit":{"type":"integer","description":"最多返回条数（默认10）"}},"required":["query"]}}},
+    "_gateway_create_reminder": {"type":"function","function":{"name":"_gateway_create_reminder","description":"为用户创建一条提醒。当用户说提醒我、几点叫我、别忘了时调用。title用简洁中文描述，notes记录上下文。","parameters":{"type":"object","properties":{"title":{"type":"string","description":"提醒标题"},"notes":{"type":"string","description":"备注信息"},"trigger_time":{"type":"string","description":"触发时间ISO8601格式"},"repeat_type":{"type":"string","enum":["once","daily","weekly","hourly"],"description":"重复类型"},"repeat_config":{"type":"object","description":"循环配置"}},"required":["title","trigger_time"]}}},
+    "_gateway_list_reminders": {"type":"function","function":{"name":"_gateway_list_reminders","description":"查看用户当前的所有活跃提醒。","parameters":{"type":"object","properties":{}}}},
+    "_gateway_complete_reminder": {"type":"function","function":{"name":"_gateway_complete_reminder","description":"标记一条提醒为已完成。用户说做完了、回来了时调用。","parameters":{"type":"object","properties":{"reminder_id":{"type":"string","description":"提醒ID"}},"required":["reminder_id"]}}},
+    "_gateway_delete_reminder": {"type":"function","function":{"name":"_gateway_delete_reminder","description":"删除一条提醒。用户说取消提醒、不用提醒了时调用。","parameters":{"type":"object","properties":{"reminder_id":{"type":"string","description":"提醒ID"}},"required":["reminder_id"]}}},
+}
+
+# Gateway 工具 → 类别映射
+GATEWAY_CATEGORY_MAP = {
+    "_gateway_web_search": "search",
+    "_gateway_search_conversations": "conversation",
+    "_gateway_create_reminder": "reminder",
+    "_gateway_list_reminders": "reminder",
+    "_gateway_complete_reminder": "reminder",
+    "_gateway_delete_reminder": "reminder",
+}
+
+# ============================================================
+# 3. Dynamic registries (populated at startup by init_drawer)
+# ============================================================
+
+TOOL_SCHEMAS = {}      # tool_name -> OpenAI schema (all tools)
+CATEGORIES = {}        # cat_id -> {label, description, tool_names}
+_tool_to_category = {} # tool_name -> cat_id
+
+# ============================================================
+# 4. Meta-tools (always available)
+# ============================================================
+
+def _build_meta_tools():
+    cats = list(CATEGORIES.keys()) if CATEGORIES else list(CATEGORY_META.keys())
+    return [
+        {"type":"function","function":{"name":"_drawer_request_tools","description":"手动请求展开工具类别。可用：" + "/".join(cats),"parameters":{"type":"object","properties":{"category":{"type":"string","enum":cats,"description":"工具类别ID"}},"required":["category"]}}},
+        {"type":"function","function":{"name":"_drawer_return_tools","description":"归还当前展开的工具，释放token空间。","parameters":{"type":"object","properties":{}}}},
+    ]
+
+META_TOOLS = []  # populated after CATEGORIES is built
+
+# ============================================================
+# 5. Auto-discovery from mcp_server.py
+# ============================================================
+
+_TYPE_MAP = {"str": "string", "int": "integer", "float": "number", "bool": "boolean"}
+
+def _auto_discover_mcp_tools():
+    """Parse mcp_server.py with AST, extract tools, build schemas."""
+    global TOOL_SCHEMAS, CATEGORIES, _tool_to_category, META_TOOLS
+
+    mcp_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "mcp_server.py")
+    if not os.path.exists(mcp_path):
+        print("\u26a0\ufe0f  auto-discover: mcp_server.py not found")
+        return
+
+    with open(mcp_path, "r", encoding="utf-8") as f:
+        source = f.read()
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as e:
+        print(f"\u26a0\ufe0f  auto-discover: parse error: {e}")
+        return
+
+    discovered = 0
+    cat_tools = {}  # cat_id -> [tool_names]
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        # Check for @mcp_xxx.tool() decorator
+        is_tool = False
+        for dec in node.decorator_list:
+            if hasattr(dec, 'func') and hasattr(dec.func, 'attr') and dec.func.attr == 'tool':
+                is_tool = True
+                break
+        if not is_tool:
+            continue
+
+        func_name = node.name
+        doc = ast.get_docstring(node) or ""
+
+        # Extract [category: xxx]
+        cat_match = re.search(r'\[category:\s*(\w+)\]', doc)
+        category = cat_match.group(1) if cat_match else "uncategorized"
+
+        # system_internal 类工具不暴露给 LLM（如 trigger_digest）
+        if category == "system_internal":
+            continue
+
+        # Clean description: remove tag, remove params section
+        desc = re.sub(r'\[category:\s*\w+\]\s*', '', doc).strip()
+        desc_parts = re.split(r'\n\s*参数[：:]', desc)
+        description = re.sub(r'\s+', ' ', desc_parts[0].strip())
+
+        # Parse parameter descriptions from docstring
+        param_descs = {}
+        if len(desc_parts) > 1:
+            for pm in re.finditer(r'-\s*(\w+)\s*[:：]\s*(.+?)(?=\n\s*-|\n\n|$)', desc_parts[1], re.DOTALL):
+                param_descs[pm.group(1)] = re.sub(r'\s+', ' ', pm.group(2).strip())
+
+        # Build parameters from function signature
+        properties = {}
+        required = []
+        args = node.args
+        num_defaults = len(args.defaults)
+        num_args = len(args.args)
+
+        for idx, arg in enumerate(args.args):
+            arg_name = arg.arg
+            # Get type annotation
+            type_str = "string"
+            if arg.annotation and isinstance(arg.annotation, ast.Name):
+                type_str = _TYPE_MAP.get(arg.annotation.id, "string")
+
+            prop = {"type": type_str}
+            if arg_name in param_descs:
+                prop["description"] = param_descs[arg_name]
+
+            properties[arg_name] = prop
+
+            # Required if no default value
+            default_idx = idx - (num_args - num_defaults)
+            if default_idx < 0:
+                required.append(arg_name)
+
+        # Build OpenAI schema
+        schema = {
+            "type": "function",
+            "function": {
+                "name": func_name,
+                "description": description,
+                "parameters": {
+                    "type": "object",
+                    "properties": properties,
+                },
+            },
+        }
+        if required:
+            schema["function"]["parameters"]["required"] = required
+
+        TOOL_SCHEMAS[func_name] = schema
+        _tool_to_category[func_name] = category
+
+        if category not in cat_tools:
+            cat_tools[category] = []
+        cat_tools[category].append(func_name)
+        discovered += 1
+
+    # Register gateway-builtin tools
+    for tool_name, schema in GATEWAY_TOOL_SCHEMAS.items():
+        TOOL_SCHEMAS[tool_name] = schema
+        cat = GATEWAY_CATEGORY_MAP.get(tool_name, "uncategorized")
+        _tool_to_category[tool_name] = cat
+        if cat not in cat_tools:
+            cat_tools[cat] = []
+        cat_tools[cat].append(tool_name)
+
+    # Build CATEGORIES from CATEGORY_META + discovered tools
+    for cat_id, tools in cat_tools.items():
+        meta = CATEGORY_META.get(cat_id, {
+            "label": cat_id,
+            "description": f"{cat_id} category tools",
+            "keywords": [],
+        })
+        CATEGORIES[cat_id] = {
+            "label": meta["label"],
+            "description": meta["description"],
+            "tool_names": tools,
+        }
+
+    # Build META_TOOLS now that CATEGORIES is populated
+    META_TOOLS.clear()
+    META_TOOLS.extend(_build_meta_tools())
+
+    total = discovered + len(GATEWAY_TOOL_SCHEMAS)
+    print(f"\U0001f5c3\ufe0f  自动发现：{discovered} 个 MCP 工具 + {len(GATEWAY_TOOL_SCHEMAS)} 个 gateway 工具 = {total} 个，{len(CATEGORIES)} 个类别")
+
+# ============================================================
+# 6. Directory Text (for system prompt)
+# ============================================================
+
+def get_directory_text():
+    if not CATEGORIES:
+        # Fallback before init
+        return ""
+    lines = ["", "【工具抽屉】", "系统会根据对话内容自动为你展开需要的工具。可用类别："]
+    for cat_id, cat in CATEGORIES.items():
+        short = cat["description"].split("。")[0]
+        lines.append(f"  - {cat['label']}（{cat_id}）：{short}")
+    lines.append("如果自动路由没有展开你需要的工具，调用 _drawer_request_tools(category) 手动请求。")
+    lines.append("用完工具后调用 _drawer_return_tools() 归还。")
+    return "\n".join(lines)
+
+# ============================================================
+# 7. Embedding Pre-computation + Init
+# ============================================================
+
+_category_embeddings = {}
+_initialized = False
+
+async def init_drawer():
+    global _category_embeddings, _initialized
+    from database import get_embeddings_batch
+
+    # Step 1: Auto-discover tools from mcp_server.py
+    _auto_discover_mcp_tools()
+
+    if not CATEGORIES:
+        print("\u26a0\ufe0f  工具抽屉：没有发现任何工具类别")
+        _initialized = True
+        return
+
+    # Step 2: Compute category embeddings
+    cat_ids = list(CATEGORIES.keys())
+    descriptions = [CATEGORIES[c]["description"] for c in cat_ids]
+    print(f"\U0001f5c3\ufe0f  工具抽屉：正在预计算 {len(cat_ids)} 个类别的 embedding...")
+    embeddings = await get_embeddings_batch(descriptions)
+    success = 0
+    for cat_id, emb in zip(cat_ids, embeddings):
+        if emb:
+            _category_embeddings[cat_id] = emb
+            success += 1
+    _initialized = True
+    if success == len(cat_ids):
+        print(f"\U0001f5c3\ufe0f  工具抽屉：{success} 个类别 embedding 就绪")
+    elif success > 0:
+        print(f"\U0001f5c3\ufe0f  工具抽屉：{success}/{len(cat_ids)} 就绪（部分降级）")
+    else:
+        print(f"\U0001f5c3\ufe0f  工具抽屉：embedding 全部失败，使用关键词降级")
+
+# ============================================================
+# 8. Keyword Fallback
+# ============================================================
+
+def _keyword_match(user_message):
+    matched = set()
+    for cat_id, meta in CATEGORY_META.items():
+        keywords = meta.get("keywords", [])
+        if any(kw in user_message for kw in keywords):
+            matched.add(cat_id)
+    return matched
+
+# ============================================================
+# 9. Session State
+# ============================================================
+
+_sessions = {}
+_SESSION_TTL = 7200
+_AUTO_COLLAPSE_ROUNDS = 3
+
+def _get_session(session_id):
+    now = time.time()
+    if session_id not in _sessions:
+        _sessions[session_id] = {"expanded": set(), "rounds_no_use": 0, "last_active": now}
+    s = _sessions[session_id]
+    s["last_active"] = now
+    return s
+
+def _cleanup_sessions():
+    now = time.time()
+    # Phase 1: 删真过期的
+    expired = [sid for sid, s in _sessions.items() if now - s["last_active"] > _SESSION_TTL]
+    for sid in expired:
+        del _sessions[sid]
+    # Phase 2: 还超 200 就按 LRU 删一半
+    if len(_sessions) > 200:
+        oldest = sorted(_sessions.items(), key=lambda kv: kv[1]["last_active"])
+        for sid, _ in oldest[:len(_sessions) // 2]:
+            del _sessions[sid]
+
+# ============================================================
+# 10. Core Routing
+# ============================================================
+
+SIMILARITY_THRESHOLD = 0.45
+
+async def route_tools(user_message, session_id, user_embedding=None, mem_enabled=True, search_enabled=False, project_id=None):
+    from database import cosine_similarity
+    if len(_sessions) > 200:
+        _cleanup_sessions()
+
+    session = _get_session(session_id)
+    matched_categories = set()
+
+    if user_embedding and _category_embeddings:
+        scores = {}
+        for cat_id, cat_emb in _category_embeddings.items():
+            score = cosine_similarity(user_embedding, cat_emb)
+            scores[cat_id] = score
+            if score >= SIMILARITY_THRESHOLD:
+                matched_categories.add(cat_id)
+        top3 = sorted(scores.items(), key=lambda x: -x[1])[:3]
+        top3_str = ", ".join(f"{c}={s:.3f}" for c, s in top3)
+        if matched_categories:
+            print(f"\U0001f5c3\ufe0f  抽屉路由：命中 {matched_categories}（top3: {top3_str}）")
+        else:
+            print(f"\U0001f5c3\ufe0f  抽屉路由：未命中（top3: {top3_str}）")
+    else:
+        matched_categories = _keyword_match(user_message)
+        if matched_categories:
+            print(f"\U0001f5c3\ufe0f  抽屉路由（关键词降级）：命中 {matched_categories}")
+
+    # Filter by feature flags (also filter expanded)
+    if not search_enabled:
+        matched_categories.discard("search")
+        session["expanded"].discard("search")
+    if not mem_enabled:
+        matched_categories.discard("memory")
+        matched_categories.discard("conversation")
+        session["expanded"].discard("memory")
+        session["expanded"].discard("conversation")
+
+    active_categories = matched_categories | session["expanded"]
+
+    # Auto-collapse
+    if session["expanded"] and not matched_categories:
+        session["rounds_no_use"] += 1
+        if session["rounds_no_use"] >= _AUTO_COLLAPSE_ROUNDS:
+            print(f"\U0001f5c3\ufe0f  抽屉自动收回：{session['expanded']}")
+            session["expanded"] = set()
+            session["rounds_no_use"] = 0
+            active_categories = matched_categories
+    else:
+        session["rounds_no_use"] = 0
+
+    session["expanded"] = active_categories.copy()
+
+    # Assemble tool list
+    openai_tools = []
+    tool_map = {}
+    for cat_id in active_categories:
+        cat = CATEGORIES.get(cat_id)
+        if not cat:
+            continue
+        for tool_name in cat["tool_names"]:
+            schema = TOOL_SCHEMAS.get(tool_name)
+            if not schema:
+                continue
+            openai_tools.append(schema)
+            if tool_name.startswith("_gateway_"):
+                route_info = {"type": "gateway_builtin", "handler": _infer_handler(tool_name)}
+                if tool_name == "_gateway_search_conversations":
+                    route_info["project_id"] = project_id
+                tool_map[tool_name] = route_info
+            else:
+                tool_map[tool_name] = {"type": "drawer", "handler": tool_name}
+
+    # Always include meta-tools
+    for mt in META_TOOLS:
+        openai_tools.append(mt)
+        tool_map[mt["function"]["name"]] = {"type": "meta", "handler": "drawer_meta"}
+
+    expanded_count = len(openai_tools) - len(META_TOOLS)
+    if expanded_count > 0:
+        print(f"\U0001f5c3\ufe0f  展开 {expanded_count} 个工具 + 2 meta = {len(openai_tools)} total")
+    else:
+        print(f"\U0001f5c3\ufe0f  无工具展开，仅 {len(META_TOOLS)} 个 meta-tool")
+
+    return openai_tools, tool_map
+
+def _infer_handler(tool_name):
+    if "web_search" in tool_name: return "web_search"
+    if "search_conversations" in tool_name: return "search_conversations"
+    if "reminder" in tool_name: return "reminder"
+    return tool_name
+
+# ============================================================
+# 11. Meta-tool Execution
+# ============================================================
+
+async def handle_meta_tool(tool_name, args, session_id):
+    session = _get_session(session_id)
+    if tool_name == "_drawer_request_tools":
+        category = args.get("category", "")
+        if category not in CATEGORIES:
+            return f"未知类别：{category}。可用：{', '.join(CATEGORIES.keys())}"
+        session["expanded"].add(category)
+        session["rounds_no_use"] = 0
+        cat = CATEGORIES[category]
+        names = ", ".join(cat["tool_names"])
+        print(f"\U0001f5c3\ufe0f  手动展开：{category}（{names}）")
+        return f"已展开「{cat['label']}」类工具：{names}。下一轮对话即可使用。"
+
+    if tool_name == "_drawer_return_tools":
+        if session["expanded"]:
+            returned = ", ".join(CATEGORIES[c]["label"] for c in session["expanded"] if c in CATEGORIES)
+            print(f"\U0001f5c3\ufe0f  主动归还：{session['expanded']}")
+            session["expanded"] = set()
+            session["rounds_no_use"] = 0
+            return f"已归还工具：{returned}。"
+        return "当前没有展开的工具。"
+
+    return f"未知meta-tool：{tool_name}"
+
+# ============================================================
+# 12. Drawer Tool Execution
+# ============================================================
+
+async def execute_drawer_tool(tool_name, arguments):
+    extra = {}
+    try:
+        import mcp_server
+        func = getattr(mcp_server, tool_name, None)
+        if not func:
+            return f"[tool_error] tool_not_found: {tool_name}", extra
+        result = await func(**arguments)
+        return result, extra
+    except TypeError as e:
+        msg = str(e)
+        import re as _re
+        m = _re.search(r"missing \d+ required.*?: '(\w+)'", msg)
+        if m:
+            return f"[tool_error] {tool_name}: missing required arg '{m.group(1)}'", extra
+        m = _re.search(r"unexpected keyword argument '(\w+)'", msg)
+        if m:
+            return f"[tool_error] {tool_name}: unknown arg '{m.group(1)}'", extra
+        return f"[tool_error] {tool_name}: argument mismatch", extra
+    except Exception as e:
+        print(f"\u274c drawer\u5de5\u5177 {tool_name} \u6267\u884c\u5931\u8d25: {e}")
+        return f"[tool_error] {tool_name}: execution failed", extra
+
+# ============================================================
+# 13. Helpers
+# ============================================================
+
+def record_tool_use(session_id, tool_name):
+    if session_id in _sessions:
+        _sessions[session_id]["rounds_no_use"] = 0
+
+def get_drawer_stats():
+    return {
+        "initialized": _initialized,
+        "categories": len(CATEGORIES),
+        "tools": len(TOOL_SCHEMAS),
+        "embeddings_ready": len(_category_embeddings),
+        "active_sessions": len(_sessions),
+        "threshold": SIMILARITY_THRESHOLD,
+    }


### PR DESCRIPTION
## Summary
This PR introduces two major features: (1) an automatic tool discovery and categorization system ("tool drawer") that dynamically loads MCP tools from `mcp_server.py` and organizes them by category, and (2) support for Anthropic API format alongside OpenAI format, with a complete request/response adapter.

## Key Changes

### Tool Drawer System (`tool_drawer.py` - new file)
- **Auto-discovery**: Parses `mcp_server.py` using AST to extract async functions decorated with `@mcp_xxx.tool()`, automatically extracting docstrings and parameter schemas
- **Category metadata**: Defines static category configurations (memory, calendar, dream, profile, search, conversation, reminder) with descriptions and keywords
- **Dynamic routing**: Routes user messages to appropriate tool categories using:
  - Embedding-based semantic similarity (with configurable threshold of 0.45)
  - Keyword fallback when embeddings unavailable
  - Feature flag filtering (e.g., disable search/memory tools)
- **Session state management**: Tracks expanded tool categories per session with auto-collapse after 3 rounds of non-use, TTL-based cleanup, and LRU eviction at 200+ sessions
- **Meta-tools**: Provides `_drawer_request_tools()` and `_drawer_return_tools()` for manual tool category control
- **Gateway-builtin tools**: Registers non-MCP tools (web search, conversation search, reminders) with category mapping

### Anthropic API Adapter (`anthropic_adapter.py` - new file)
- **Request conversion**: Transforms OpenAI chat/completions format to Anthropic Messages API format
  - Handles system message extraction and merging
  - Converts tool definitions and tool_choice parameters
  - Supports extended thinking/reasoning with budget token configuration
- **Response conversion**: Transforms Anthropic responses back to OpenAI format
  - Extracts text, tool_use blocks, and thinking content
  - Maps stop reasons (end_turn → stop, max_tokens → length, etc.)
  - Handles cache creation/read token tracking
- **Streaming support**: Converts Anthropic SSE events to OpenAI SSE format with proper delta handling for text, thinking, and tool arguments
- **URL normalization**: Intelligently converts base URLs to appropriate Anthropic endpoints

### Database Schema Extensions (`database.py`)
- Added `api_format` column to `providers` table (default: 'openai')
- Added `api_format` column to `provider_models` table for model-level format override
- Added `status_events`, `handoff_info`, and `images` columns to `chat_messages` for complete message state synchronization

### Main Integration (`main.py`)
- Imports and integrates tool drawer and Anthropic adapter
- Routes requests to appropriate API format based on provider configuration
- Passes `conversation_id` to memory building to avoid self-referential handoff injection
- Handles project-scoped memory extraction with proper deduplication and contradiction detection
- Collects saved memory items for event payload tracking
- Supports both OpenAI and Anthropic API formats in streaming and non-streaming modes

### MCP Server Updates (`mcp_server.py`)
- Adds `[category: xxx]` tags to tool docstrings for auto-discovery categorization
- Marks internal tools (e.g., `trigger_digest`) with `[category: system_internal]` to exclude from LLM exposure
- Maintains backward compatibility with existing tool signatures

## Notable Implementation Details
- **Embedding pre-computation**: Category embeddings are computed at startup and cached to avoid repeated API calls during routing
- **RRF hybrid search**: Memory search combines vector and keyword results using Reciprocal Rank Fusion
- **Scoped deduplication**: Memory deduplication respects project boundaries (project memories only deduplicate against same project)
- **Graceful degradation**: Tool drawer falls back to keyword matching if embedding service unavailable
- **Session cleanup**: Two-phase cleanup strategy (TTL expiration + LRU eviction) prevents unbounded session growth

https://claude.ai/code/session_01NXU7QqWCdr5qNPt3ExcFzn