### PR TITLE
项目隔离读取端补漏 + 工具抽屉集成（带配置开关）

### DIFF
--- a/config.py
+++ b/config.py
@@ -85,6 +85,9 @@ CONFIG_SCHEMA = {
     "quick_phrases":         ("",                        "",     "快捷短语",          "text"),
     "mcp_switches":          ("",                        "",     "MCP开关状态",       "text"),
     "theme_preference":      ("",                        "",     "主题偏好",          "text"),
+    # v6.3：工具抽屉（向量路由按需展开工具）。默认关闭——开启后内部工具走向量路由，
+    #       外部 mcp_servers 仍走原路径并合并，对模型表现为一组完整工具
+    "tool_drawer_enabled":   ("",                        "false","工具抽屉开关",      "bool"),
 }
 
 

--- a/database.py
+++ b/database.py
@@ -2820,18 +2820,21 @@ async def get_calendar_for_injection(lookback_days: int = 365):
 
 
 async def get_chat_messages_for_date(date_str: str):
-    """读取指定日期的所有聊天消息（用于生成日页面）"""
+    """读取指定日期的所有聊天消息（用于生成日页面，排除项目对话）"""
     from datetime import date as date_cls
     pool = await get_pool()
     d = date_cls.fromisoformat(date_str)
     async with pool.acquire() as conn:
+        # LEFT JOIN 是为了让没有 conversation_id 的旧消息也能命中（c.id 为 NULL）
         rows = await conn.fetch("""
-            SELECT role, content, time, conversation_id
-            FROM chat_messages
-            WHERE (time AT TIME ZONE 'Asia/Shanghai')::date = $1
-              AND role IN ('user', 'assistant')
-              AND content != ''
-            ORDER BY time ASC
+            SELECT m.role, m.content, m.time, m.conversation_id
+            FROM chat_messages m
+            LEFT JOIN chat_conversations c ON m.conversation_id = c.id
+            WHERE (m.time AT TIME ZONE 'Asia/Shanghai')::date = $1
+              AND m.role IN ('user', 'assistant')
+              AND m.content != ''
+              AND (c.project_id IS NULL OR c.id IS NULL)
+            ORDER BY m.time ASC
         """, d)
     return [dict(r) for r in rows]
 
@@ -2930,7 +2933,7 @@ async def get_active_scenes():
 
 
 async def get_unprocessed_memories():
-    """获取未被Dream处理过的碎片记忆"""
+    """获取未被Dream处理过的碎片记忆（仅全局，排除项目碎片）"""
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch("""
@@ -2940,6 +2943,7 @@ async def get_unprocessed_memories():
             WHERE dream_processed_at IS NULL
               AND memory_type IN ('fragment', 'daily_digest')
               AND (valid_until IS NULL OR valid_until > NOW())
+              AND project_id IS NULL
             ORDER BY created_at ASC
         """)
     return [dict(r) for r in rows]
@@ -2981,11 +2985,11 @@ async def get_aging_memories(min_age_days: int = 5, limit: int = 20):
 
 
 async def get_permanent_memories():
-    """获取长期设定记忆"""
+    """获取长期设定记忆（仅全局，排除项目锁定记忆）"""
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
-            "SELECT id, title, content FROM memories WHERE is_permanent = TRUE AND (valid_until IS NULL OR valid_until > NOW()) ORDER BY created_at ASC"
+            "SELECT id, title, content FROM memories WHERE is_permanent = TRUE AND (valid_until IS NULL OR valid_until > NOW()) AND project_id IS NULL ORDER BY created_at ASC"
         )
     return [dict(r) for r in rows]
 

--- a/database.py
+++ b/database.py
@@ -2977,6 +2977,7 @@ async def get_aging_memories(min_age_days: int = 5, limit: int = 20):
               AND (valid_until IS NULL OR valid_until > NOW())
               AND COALESCE(resolution, 1.0) >= 1.0
               AND importance < 8
+              AND project_id IS NULL
               AND created_at < NOW() - $1 * INTERVAL '1 day'
             ORDER BY created_at ASC
             LIMIT $2

--- a/main.py
+++ b/main.py
@@ -231,6 +231,21 @@ async def lifespan(app: FastAPI):
     async with mcp_memory.session_manager.run():
         async with mcp_calendar.session_manager.run():
             print("✅ MCP server 已启动（/memory/mcp + /calendar/mcp）")
+
+            # v6.3：仅当 tool_drawer_enabled=true 时初始化工具抽屉
+            # （默认 false，开源用户行为不变；抽屉打开后通过向量路由按需展开工具）
+            try:
+                drawer_enabled = await get_config_bool("tool_drawer_enabled", fallback=False)
+            except Exception:
+                drawer_enabled = False
+            if drawer_enabled:
+                try:
+                    from tool_drawer import init_drawer
+                    await init_drawer()
+                    print("✅ 工具抽屉已初始化")
+                except Exception as e:
+                    print(f"⚠️ 工具抽屉初始化失败: {e}（降级为传统模式）")
+
             yield
     
     if digest_task:
@@ -436,13 +451,28 @@ async def build_system_prompt_with_memories(user_message: str, user_msg_count: i
             except Exception as e:
                 print(f"⚠️  项目指令注入失败: {e}")
         
+        # ---- v6.3：工具抽屉目录（静态，仅在抽屉开启时注入）----
+        drawer_enabled_inject = await get_config_bool("tool_drawer_enabled", fallback=False)
+        if drawer_enabled_inject:
+            try:
+                from tool_drawer import get_directory_text
+                active_prompt += get_directory_text()
+            except Exception as e:
+                print(f"⚠️  工具目录注入失败: {e}")
+
         # ---- 静态/动态分隔标记（用于 Prompt Caching）----
-        # 上面的人设+画像+锁定记忆+日历是静态的（一天内不变），下面的搜索碎片/犯困/切窗是动态的
+        # 上面的人设+画像+锁定记忆+日历(+工具目录)是静态的（一天内不变），下面的搜索碎片/犯困/切窗是动态的
         active_prompt += "\n\n<!-- CACHE_BOUNDARY -->"
-        
+
         # ---- ⑤ 语义搜索碎片（动态，每轮变化）----
         inject_limit = await get_max_inject()
-        memories = await search_memories(user_message, limit=inject_limit, project_id=project_id)
+        # v6.3：抽屉开启时复用 query embedding 给抽屉路由（省一次 embedding API 调用）
+        if drawer_enabled_inject:
+            memories, _query_emb = await search_memories(user_message, limit=inject_limit, project_id=project_id, return_embedding=True)
+            if _query_emb:
+                prompt_meta["user_embedding"] = _query_emb
+        else:
+            memories = await search_memories(user_message, limit=inject_limit, project_id=project_id)
         
         # 加载热度参数（v5.4：可配置阈值）
         from database import get_heat_params
@@ -1311,12 +1341,41 @@ async def chat_completions(request: Request):
     if body.get("reasoning") or body.get("reasoning_effort") or body.get("include_reasoning"):
         print(f"🔍 [思考链参数] reasoning={body.get('reasoning')}, reasoning_effort={body.get('reasoning_effort')}, include_reasoning={body.get('include_reasoning')}")
     
-    # ========== 收集工具（MCP + 联网搜索 auto） ==========
+    # ========== 收集工具（v6.3：抽屉模式 / 传统模式 二选一） ==========
     openai_tools = []
     tool_map = {}
 
+    drawer_enabled = await get_config_bool("tool_drawer_enabled", fallback=False)
+
+    if drawer_enabled:
+        # ---- 抽屉模式：向量路由按需展开内部工具 + 外部 MCP 双轨 ----
+        try:
+            from tool_drawer import route_tools as _drawer_route
+            user_embedding = prompt_meta.get("user_embedding") if prompt_meta else None
+            drawer_tools, drawer_map = await _drawer_route(
+                user_message=user_message,
+                session_id=session_id,
+                user_embedding=user_embedding,
+                mem_enabled=mem_enabled,
+                search_enabled=bool(do_search_auto),
+                project_id=project_id,
+            )
+            openai_tools.extend(drawer_tools)
+            tool_map.update(drawer_map)
+        except Exception as e:
+            print(f"❌ 工具抽屉路由失败: {e}")
+        # 外部 MCP 仍可用：抽屉管内部工具，mcp_servers 走原路径并合并
+        if mcp_servers:
+            try:
+                mcp_tools, mcp_map = await get_tools_for_servers(mcp_servers)
+                openai_tools.extend(mcp_tools)
+                tool_map.update(mcp_map)
+            except Exception as e:
+                print(f"❌ 外部 MCP 工具获取失败: {e}")
+
+    # ---- 传统模式：原有逐项注册（drawer_enabled=False 时执行）----
     # MCP 工具
-    if mcp_servers:
+    if not drawer_enabled and mcp_servers:
         try:
             mcp_tools, mcp_map = await get_tools_for_servers(mcp_servers)
             openai_tools.extend(mcp_tools)
@@ -1325,7 +1384,7 @@ async def chat_completions(request: Request):
             print(f"❌ MCP 工具获取失败: {e}")
 
     # 联网搜索 auto 模式：注册为 function tool，让模型自行决定是否调用
-    if do_search_auto:
+    if not drawer_enabled and do_search_auto:
         search_engine = await get_config("search_engine") or ""
         if search_engine:
             openai_tools.append({
@@ -1352,7 +1411,7 @@ async def chat_completions(request: Request):
             print(f"⚠️ 联网搜索 auto 模式已请求但未配置搜索引擎")
 
     # v5.8：对话搜索工具（始终可用，让模型能主动搜索过去的对话）
-    if mem_enabled:
+    if not drawer_enabled and mem_enabled:
         openai_tools.append({
             "type": "function",
             "function": {
@@ -1389,7 +1448,7 @@ async def chat_completions(request: Request):
     ]
     _need_reminder_tools = any(kw in user_message for kw in _REMINDER_TRIGGER_KEYWORDS)
 
-    if _need_reminder_tools:
+    if not drawer_enabled and _need_reminder_tools:
         _reminder_tools = [
         {
             "type": "function",
@@ -1833,8 +1892,12 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
         for p in parsed:
             p["name"] = _resolve_tool_name(p["name"])
         
+        # v6.3：四类工具分发 — gateway / drawer / meta / mcp
+        # 抽屉模式下 tool_map 会出现 drawer 和 meta 类型，传统模式只有 gateway_builtin/MCP
         gw_parsed = [p for p in parsed if tool_map.get(p["name"], {}).get("type") == "gateway_builtin"]
-        mcp_parsed = [p for p in parsed if tool_map.get(p["name"], {}).get("type") != "gateway_builtin"]
+        drawer_parsed = [p for p in parsed if tool_map.get(p["name"], {}).get("type") == "drawer"]
+        meta_parsed = [p for p in parsed if tool_map.get(p["name"], {}).get("type") == "meta"]
+        mcp_parsed = [p for p in parsed if tool_map.get(p["name"], {}).get("type") not in ("gateway_builtin", "drawer", "meta")]
 
         tool_results = {}   # { call_id: result_text }
         tool_extras = {}    # { call_id: extra_metadata } — 并发安全，每个 call 独立
@@ -1846,10 +1909,35 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
             tool_results[p["id"]] = result_text
             tool_extras[p["id"]] = extra_meta
 
+        # 抽屉工具：调 mcp_server 函数直跑（绕开 MCP 协议），跑完通知抽屉
+        async def _run_drawer(p):
+            try:
+                from tool_drawer import execute_drawer_tool, record_tool_use
+                result_text, extra_meta = await execute_drawer_tool(p["name"], p["args"])
+                tool_results[p["id"]] = result_text
+                tool_extras[p["id"]] = extra_meta or {}
+                record_tool_use(session_id, p["name"])
+            except Exception as e:
+                tool_results[p["id"]] = f"[drawer_error] {p['name']}: {e}"
+                tool_extras[p["id"]] = {}
+
+        # Meta 工具（_drawer_request_tools / _drawer_return_tools）：单独走 handle_meta_tool
+        async def _run_meta(p):
+            try:
+                from tool_drawer import handle_meta_tool
+                result_text = await handle_meta_tool(p["name"], p["args"], session_id)
+                tool_results[p["id"]] = result_text
+                tool_extras[p["id"]] = {}
+            except Exception as e:
+                tool_results[p["id"]] = f"[meta_error] {p['name']}: {e}"
+                tool_extras[p["id"]] = {}
+
         # 构建并发任务列表
         tasks = [_run_gw(p) for p in gw_parsed]
+        tasks.extend(_run_drawer(p) for p in drawer_parsed)
+        tasks.extend(_run_meta(p) for p in meta_parsed)
 
-        # MCP 工具：同服务器复用连接，不同服务器并发
+        # 外部 MCP 工具：同服务器复用连接，不同服务器并发
         if mcp_parsed:
             async def _run_mcp():
                 r = await call_tools_batch(mcp_parsed, tool_map)


### PR DESCRIPTION
承接上一轮 PR #9（Stage A/C/D/E/G）的两块收尾。

## 任务一：项目隔离读取端补漏

上一轮 Stage G 只做了写入端（项目对话跳过记忆提取），读取端有几处会让项目记忆泄漏到全局通路。

- **`4bebe8d`** — 3 个核心读取函数加 `project_id` 过滤：
  - `get_chat_messages_for_date` — LEFT JOIN chat_conversations 排除项目对话（也兜底处理了没 conversation_id 的旧消息），不再混进日页面摘要
  - `get_unprocessed_memories` — Dream 不再整合项目碎片
  - `get_permanent_memories` — 项目锁定记忆不会注入到所有对话的 system prompt
- **`9192882`** — 顺手补的同类 bug：
  - `get_aging_memories` — Dream 软化遍历也排除项目记忆（暴露面很窄，但兜底）

## 任务二：工具抽屉集成（配置开关方案）

`tool_drawer.py` 文件上一轮已放进仓库，这次接上 `main.py`。

- **`7ff3ca3`** — 新增 `tool_drawer_enabled` 配置项（**默认 false**，开源用户行为零变化）：
  - `config.py` — CONFIG_SCHEMA 加 `tool_drawer_enabled` bool 项
  - `main.py` lifespan — 仅 toggle 开时 `init_drawer()`
  - `main.py` chat_completions 工具组装 — toggle 开时走 `route_tools` 向量路由 + 外部 `mcp_servers` 双轨合并；toggle 关时原有 4 个 if 块（MCP / web_search auto / search_conversations / reminder）加 `not drawer_enabled and` 门控，行为不变
  - `main.py` build_system_prompt_with_memories — toggle 开时在 `<!-- CACHE_BOUNDARY -->` 前注入工具目录文本（静态区，命中 prompt cache）；`search_memories` 改用 `return_embedding=True` 把 query embedding 存进 `prompt_meta["user_embedding"]`，供下游抽屉路由复用，省一次 embedding API 调用
  - `main.py` `_stream_with_tools` 工具分发 — `tool_map` 现在可能出现 `drawer` / `meta` 两类新 type，加 `_run_drawer` / `_run_meta` 两路分支：
    - `drawer` → `execute_drawer_tool` 直跑 `mcp_server` 函数 + `record_tool_use` 通知抽屉自动 collapse 计数
    - `meta` → `handle_meta_tool`（`_drawer_request_tools` / `_drawer_return_tools`）
    - `gateway_builtin` / 外部 MCP 走原路径不变

### 偏离 spec 的一处（必须做）

Spec 没提到 dispatch，但 `route_tools` 返回的 `tool_map` 用 `{"type": "drawer"}` / `{"type": "meta"}`，而原 `_stream_with_tools` 把所有非 `gateway_builtin` 都当 MCP 发给 `call_tools_batch` 跑——drawer 模式下任何模型 tool call 都会失败。所以加了上面的 4 类分发。

## 验证

- `python3 -c "import ast; ast.parse(...)"` 4 个文件全过
- `tool_drawer_enabled` 默认 false 时，所有 4 个原有 if 块的执行路径完全等价于上一轮 push 的代码
- toggle 开启后，4 类 tool_map type 都有对应 dispatch

## Commits
1. `4bebe8d` fix: project isolation read-side — exclude project memories from digest/dream/locked injection
2. `7ff3ca3` feat: tool drawer integration with config toggle (default off)
3. `9192882` fix: get_aging_memories 也排除项目记忆（Dream 软化遍历）

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXU7QqWCdr5qNPt3ExcFzn)_