### PR TITLE
fix: 两处 PR #10 合并后的回归（项目锁定记忆 + 抽屉运行时切换）

### DIFF
--- a/database.py
+++ b/database.py
@@ -2985,12 +2985,27 @@ async def get_aging_memories(min_age_days: int = 5, limit: int = 20):
     return [dict(r) for r in rows]
 
 
-async def get_permanent_memories():
-    """获取长期设定记忆（仅全局，排除项目锁定记忆）"""
+async def get_permanent_memories(project_id: str = None):
+    """获取长期设定记忆。
+
+    project_id:
+      - None（默认，全局对话）→ 只返回全局锁定记忆（project_id IS NULL）
+      - 传入值（项目对话）→ 返回全局锁定 + 该项目锁定（IS NULL OR = project_id）
+
+    这样既不会让项目锁定记忆泄漏到全局对话（这是 PR #10 的原始意图），
+    也不会让项目对话拿不到自己项目锁定的设定（Codex 反馈的回归 bug）。
+    """
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
-            "SELECT id, title, content FROM memories WHERE is_permanent = TRUE AND (valid_until IS NULL OR valid_until > NOW()) AND project_id IS NULL ORDER BY created_at ASC"
+            """
+            SELECT id, title, content FROM memories
+            WHERE is_permanent = TRUE
+              AND (valid_until IS NULL OR valid_until > NOW())
+              AND (project_id IS NULL OR project_id = $1)
+            ORDER BY created_at ASC
+            """,
+            project_id,
         )
     return [dict(r) for r in rows]
 

--- a/main.py
+++ b/main.py
@@ -404,8 +404,9 @@ async def build_system_prompt_with_memories(user_message: str, user_msg_count: i
     
     try:
         # ---- ② 锁定记忆：全量注入（静态，很少变）----
+        # 全局对话：只拿全局锁定；项目对话：拿全局 + 当前项目锁定
         from database import get_permanent_memories
-        permanent = await get_permanent_memories()
+        permanent = await get_permanent_memories(project_id=project_id)
         if permanent:
             perm_lines = []
             for mem in permanent:

--- a/main.py
+++ b/main.py
@@ -1350,6 +1350,14 @@ async def chat_completions(request: Request):
 
     if drawer_enabled:
         # ---- 抽屉模式：向量路由按需展开内部工具 + 外部 MCP 双轨 ----
+        # Lazy init：toggle 启动时为 false、运行时打开的场景下，lifespan 没跑过
+        # init_drawer，此时 CATEGORIES 为空会让 route_tools 返回 0 工具，叠加
+        # 下面的 `not drawer_enabled` 门控会让传统工具也消失。这里幂等调用兜底。
+        try:
+            from tool_drawer import init_drawer as _drawer_init
+            await _drawer_init()
+        except Exception as e:
+            print(f"⚠️ 工具抽屉 lazy init 失败: {e}")
         try:
             from tool_drawer import route_tools as _drawer_route
             user_embedding = prompt_meta.get("user_embedding") if prompt_meta else None

--- a/tool_drawer.py
+++ b/tool_drawer.py
@@ -270,7 +270,15 @@ _category_embeddings = {}
 _initialized = False
 
 async def init_drawer():
+    """初始化工具抽屉（自动发现工具 + 预计算类别 embedding）。
+
+    幂等：已初始化时直接返回，重复调用零成本。这让 lifespan 启动时
+    没初始化（tool_drawer_enabled=false）、运行时改成 true 也能 lazy init，
+    无需重启进程。
+    """
     global _category_embeddings, _initialized
+    if _initialized:
+        return
     from database import get_embeddings_batch
 
     # Step 1: Auto-discover tools from mcp_server.py


### PR DESCRIPTION
## 背景

PR #10 已经合并进 main。Codex 在后续的 PR #11 上指出了两处 P2 级别的回归（实际指的代码就在 PR #10 合并的内容里）。两个修复都和 DeepSeek 缓存修复（PR #11）无关，单独开分支。

---

## Fix 1：项目对话拿不到自己锁定的设定（`1607142`）

### 原 bug

PR #10 给 `get_permanent_memories` 加 `AND project_id IS NULL` 是为了防止"项目锁定记忆泄漏到全局对话"。但副作用是项目对话本身也调用同一个函数——结果**项目对话再也拿不到自己锁定的设定**。

举例：「写小说」项目里锁定"主角叫 X"，这条记忆 `project_id='novel'`，在该项目对话里完全不会被注入（被 IS NULL 过滤掉）。

### 修法

- `database.py` `get_permanent_memories(project_id=None)` 参数化
- WHERE 改成 `(project_id IS NULL OR project_id = $1)`：
  - 参数 `None`（默认） → 三值逻辑下 `project_id = NULL` 为 NULL，OR 短路为 `IS NULL`，**等价于原"仅全局"行为**
  - 参数有值 → 全局锁定 + 当前项目锁定
- `main.py` `build_system_prompt_with_memories` 调用透传 `project_id`
- `dream.py` 不动（Dream 全局视角，默认 None 即可）

## Fix 2：`tool_drawer_enabled` 运行时打开会让工具全部消失（`b33b0ff`）

### 原 bug

之前的设计：
- lifespan 启动时：if `tool_drawer_enabled=true` → `init_drawer()`
- chat_completions 进 drawer 分支：只调 `route_tools`

漏洞链路：
1. 默认 `toggle=false`，lifespan 不调 `init_drawer`，`CATEGORIES` 为空
2. 用户在管理面板把 toggle 改为 `true`（kiwi-mem 卖点：**80+ 配置无需重启**）
3. 下一轮 chat 进 drawer 分支，`route_tools` 跑——但返回 0 工具（CATEGORIES 空）
4. 同时下方 4 个 `not drawer_enabled and ...` 门控让传统工具也消失
5. **工具全部不可用，直到重启**

### 修法

- `tool_drawer.init_drawer` 顶部加 `if _initialized: return` 幂等保护
- `main.py` chat_completions 进 drawer 分支顶部先 `await init_drawer()` lazy init
  - 启动时 `toggle=true` → lifespan 已 init 过，runtime 调直接 return
  - 启动时 `toggle=false`、运行时改 `true` → 首次 chat 触发 lazy init，无需重启

---

## 验证

- 4 个文件 `python3 -c "import ast; ast.parse(...)"` 全过
- `get_permanent_memories()`（无参）字节级等价于原 PR #10 的实现
- `init_drawer` 幂等保护后，已初始化的二次调用零成本

## Commits
1. `1607142` fix: include current project's permanent memories in project conversations
2. `b33b0ff` fix: tool_drawer supports runtime toggle (lazy init + idempotent)

Refs: chatgpt-codex-connector review on #11 (P2 × 2)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXU7QqWCdr5qNPt3ExcFzn)_