### PR TITLE
fix: Anthropic 格式转换保留强制函数 tool_choice

### DIFF
--- a/anthropic_adapter.py
+++ b/anthropic_adapter.py
@@ -70,6 +70,13 @@ def to_anthropic_request(openai_body: dict) -> dict:
             body["tool_choice"] = {"type": "none"}
         elif tc == "required":
             body["tool_choice"] = {"type": "any"}
+        elif isinstance(tc, dict) and tc.get("type") == "function":
+            # OpenAI 强制指定某个函数：{"type":"function","function":{"name":"..."}}
+            # → Anthropic 强制单工具：{"type":"tool","name":"..."}
+            # 不转的话 Anthropic 会回退到自动选择，依赖 forced function call 的客户端会拿错工具
+            func_name = (tc.get("function") or {}).get("name")
+            if func_name:
+                body["tool_choice"] = {"type": "tool", "name": func_name}
 
     # ── 思考链 / extended thinking ──
     reasoning = openai_body.get("reasoning")


### PR DESCRIPTION
## 背景

Codex 在 PR #9 上提过两条反馈：
1. 「drawer 没接线」→ 已在 PR #10 / #12 修复（工具抽屉集成 + lazy init）✅
2. **「强制函数 tool_choice 没转换」→ 当时漏修，本 PR 补上**

## 问题

`anthropic_adapter.to_anthropic_request` 原本只处理 `tool_choice` 的字符串形式：

| OpenAI | Anthropic |
|---|---|
| `"auto"` | `{"type":"auto"}` ✅ |
| `"none"` | `{"type":"none"}` ✅ |
| `"required"` | `{"type":"any"}` ✅ |
| `{"type":"function","function":{"name":"X"}}` | **被丢弃** ❌ |

OpenAI 客户端强制指定某个函数时（dict 形式），转换后 Anthropic 端拿不到约束、回退到自动选择。依赖 forced function call 的客户端经 Anthropic 格式供应商转发时会拿到普通文本回复或调错工具。

## 修复

```python
elif isinstance(tc, dict) and tc.get("type") == "function":
    func_name = (tc.get("function") or {}).get("name")
    if func_name:
        body["tool_choice"] = {"type": "tool", "name": func_name}
```

映射到 Anthropic 的 `{"type":"tool","name":"X"}`。`func_name` 取不到时不写 `tool_choice`，让其走默认 auto，避免造出非法请求体。

## Commit
- `23f4dbb` fix: preserve forced function tool_choice when converting to Anthropic format

Refs: chatgpt-codex-connector review on #9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXU7QqWCdr5qNPt3ExcFzn)_