### PR TITLE
feat: 供应商 API Key 一键验证端点 (/admin/test-provider)

### DIFF
--- a/anthropic_adapter.py
+++ b/anthropic_adapter.py
@@ -70,6 +70,13 @@ def to_anthropic_request(openai_body: dict) -> dict:
             body["tool_choice"] = {"type": "none"}
         elif tc == "required":
             body["tool_choice"] = {"type": "any"}
+        elif isinstance(tc, dict) and tc.get("type") == "function":
+            # OpenAI 强制指定某个函数：{"type":"function","function":{"name":"..."}}
+            # → Anthropic 强制单工具：{"type":"tool","name":"..."}
+            # 不转的话 Anthropic 会回退到自动选择，依赖 forced function call 的客户端会拿错工具
+            func_name = (tc.get("function") or {}).get("name")
+            if func_name:
+                body["tool_choice"] = {"type": "tool", "name": func_name}
 
     # ── 思考链 / extended thinking ──
     reasoning = openai_body.get("reasoning")

--- a/main.py
+++ b/main.py
@@ -3212,6 +3212,40 @@ async def api_delete_provider(provider_id: int):
         return {"error": str(e)}
 
 
+@app.post("/admin/test-provider/{provider_id}")
+async def api_test_provider(provider_id: int):
+    """测试供应商 API Key 是否可用（调 /models 端点验证）"""
+    try:
+        provider = await get_provider(provider_id)
+        if not provider:
+            return {"ok": False, "error": "供应商不存在"}
+        base_url = (provider.get("api_base_url") or "").rstrip("/")
+        api_key = provider.get("api_key") or ""
+        if not base_url or not api_key:
+            return {"ok": False, "error": "缺少 API Base URL 或 API Key"}
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(
+                f"{base_url}/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+        if resp.status_code == 200:
+            data = resp.json()
+            count = len(data.get("data", []))
+            return {"ok": True, "message": f"连接成功，获取到 {count} 个模型"}
+        elif resp.status_code == 401:
+            return {"ok": False, "error": "API Key 无效（401）"}
+        elif resp.status_code == 403:
+            return {"ok": False, "error": "权限不足（403）"}
+        else:
+            return {"ok": False, "error": f"HTTP {resp.status_code}"}
+    except httpx.TimeoutException:
+        return {"ok": False, "error": "连接超时"}
+    except httpx.ConnectError:
+        return {"ok": False, "error": "无法连接到服务器"}
+    except Exception as e:
+        return {"ok": False, "error": str(e)}
+
+
 def _detect_provider_type(api_base_url: str) -> str:
     """根据供应商 URL 判断类型"""
     url = (api_base_url or '').lower()


### PR DESCRIPTION
## 内容

从私人后端同步过来的最后一个通用功能：`POST /admin/test-provider/{provider_id}`。

管理面板配完一个供应商后，可以一键验证它的 API Key 能不能用——后端调供应商的 `/models` 端点，按响应给出明确反馈：

| 情况 | 返回 |
|---|---|
| 200 | `{ok: true, message: "连接成功，获取到 N 个模型"}` |
| 401 | `{ok: false, error: "API Key 无效（401）"}` |
| 403 | `{ok: false, error: "权限不足（403）"}` |
| 其他状态码 | `{ok: false, error: "HTTP xxx"}` |
| 超时 / 连接失败 | 对应中文错误 |

## 实现

- 端点插在 `api_delete_provider` 之后
- 用现有的 `get_provider(provider_id)` db helper 取代私人版的裸 SQL，与公开版其他 provider 端点风格一致
- `httpx` 已在顶部 import，复用
- 零个人化内容

## Commit
- `2ae5c2a` feat: add /admin/test-provider endpoint to validate provider API key

---

这是本轮「私人后端 → 开源版」同步的收尾。剩余差异均为**有意保持的分歧**（个人化文案、公开版自己更好的实现、私人数据），不再同步。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXU7QqWCdr5qNPt3ExcFzn)_