### PR TITLE
fix: test-provider 去聊天后缀 + Anthropic 格式鉴权（补 #14 漏的 Codex 修复）

### DIFF
--- a/main.py
+++ b/main.py
@@ -3219,15 +3219,29 @@ async def api_test_provider(provider_id: int):
         provider = await get_provider(provider_id)
         if not provider:
             return {"ok": False, "error": "供应商不存在"}
-        base_url = (provider.get("api_base_url") or "").rstrip("/")
+        base = (provider.get("api_base_url") or "").rstrip("/")
         api_key = provider.get("api_key") or ""
-        if not base_url or not api_key:
+        if not base or not api_key:
             return {"ok": False, "error": "缺少 API Base URL 或 API Key"}
+
+        # 去掉聊天端点后缀，还原到基础地址再拼 /models
+        # （供应商可能保存成完整的 .../v1/chat/completions 或 Anthropic 的 .../v1/messages）
+        for suffix in ("/chat/completions", "/messages"):
+            if base.endswith(suffix):
+                base = base.rsplit(suffix, 1)[0]
+                break
+
+        api_format = (provider.get("api_format") or "openai") or "openai"
+        if api_format == "anthropic":
+            # Anthropic 用 x-api-key + anthropic-version，模型列表在 /v1/models
+            headers = to_anthropic_headers(api_key)
+            models_url = f"{base}/models" if base.endswith("/v1") else f"{base}/v1/models"
+        else:
+            headers = {"Authorization": f"Bearer {api_key}"}
+            models_url = f"{base}/models"
+
         async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.get(
-                f"{base_url}/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-            )
+            resp = await client.get(models_url, headers=headers)
         if resp.status_code == 200:
             data = resp.json()
             count = len(data.get("data", []))


### PR DESCRIPTION
## 背景

PR #14（test-provider 端点）已合并进 main，但 Codex 在它上面提的两条修复是在 #14 squash 之后才推的，没赶上那次合并，孤立在已删除的分支上。这里基于最新 main 重做，补进去。

## 修复

针对 main 上现有的 `api_test_provider`：

1. **去后缀**：供应商可能保存成完整的 `.../v1/chat/completions`（或 Anthropic 的 `.../v1/messages`），原来直接拼 `/models` 会得到 `.../chat/completions/models` → 404。先剥掉聊天端点后缀再拼，和相邻的 `/admin/providers/{id}/models` 端点保持一致。

2. **Anthropic 鉴权**：`api_format == "anthropic"` 的供应商用 `x-api-key` + `anthropic-version`（`to_anthropic_headers`），模型列表走 `/v1/models`，而不是 OpenAI 的 Bearer——否则合法的 Anthropic 供应商会被误判为 401 未授权。

## Commit
- `173a39b` fix: test-provider strips chat suffix + uses Anthropic headers for anthropic format

Refs: chatgpt-codex-connector review on #14

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXU7QqWCdr5qNPt3ExcFzn)_