### PR TITLE
fix: api_format 后端白名单校验 + 前端徽章转义（XSS 两层防御）

### DIFF
--- a/admin-panel/index.html
+++ b/admin-panel/index.html
@@ -534,7 +534,7 @@ async function loadProviders() {
     document.getElementById('providers-list').innerHTML = list.map(p => `
       <div class="bg-panel-card border border-panel-border rounded-lg p-4 mb-3 flex items-center justify-between">
         <div>
-          <p class="font-semibold">${escHtml(p.name)} <span class="badge ${p.api_format==='anthropic'?'imp-high':'imp-mid'}" style="font-size:10px;margin-left:6px">${p.api_format || 'openai'}</span></p>
+          <p class="font-semibold">${escHtml(p.name)} <span class="badge ${p.api_format==='anthropic'?'imp-high':'imp-mid'}" style="font-size:10px;margin-left:6px">${escHtml(p.api_format || 'openai')}</span></p>
           <p class="text-xs text-gray-500 mt-1">${escHtml(p.api_base_url || '')}</p>
           <p class="text-xs text-gray-500">Key: ${p.api_key_preview || '（未设置）'}</p>
         </div>

--- a/database.py
+++ b/database.py
@@ -1901,8 +1901,28 @@ async def get_provider(provider_id: int):
         return dict(row) if row else None
 
 
+# api_format 的合法取值。供应商级只能是这两个；模型级额外允许 None（表示跟随供应商）。
+_VALID_API_FORMATS = {'openai', 'anthropic'}
+
+
+def _normalize_api_format(value, allow_none: bool = False):
+    """把 api_format 收敛到合法白名单。
+
+    入口处统一校验，根治脏数据/恶意值（避免前端拼进 innerHTML 时的 XSS，
+    也避免请求链路里拿到未知格式）。
+      - 合法（openai/anthropic）→ 原样返回
+      - allow_none 且为空 → None（模型级表示"跟随供应商"）
+      - 其他一律回落到 'openai'
+    """
+    v = (value or '').strip().lower()
+    if v in _VALID_API_FORMATS:
+        return v
+    return None if allow_none else 'openai'
+
+
 async def create_provider(name: str, api_base_url: str, api_key: str = '', enabled: bool = True, api_format: str = 'openai'):
     """创建供应商"""
+    api_format = _normalize_api_format(api_format)
     pool = await get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow("""
@@ -1918,6 +1938,8 @@ async def update_provider(provider_id: int, **kwargs):
     pool = await get_pool()
     allowed = {'name', 'api_base_url', 'api_key', 'enabled', 'api_format'}
     fields = {k: v for k, v in kwargs.items() if k in allowed and v is not None}
+    if 'api_format' in fields:
+        fields['api_format'] = _normalize_api_format(fields['api_format'])
     if not fields:
         return None
 
@@ -1985,6 +2007,7 @@ async def add_provider_model(provider_id: int, model_id: str, display_name: str 
                              model_type: str = 'chat', input_modes: str = 'text',
                              output_modes: str = 'text', capabilities: str = '', api_format: str = None):
     """添加模型到供应商"""
+    api_format = _normalize_api_format(api_format, allow_none=True)
     pool = await get_pool()
     async with pool.acquire() as conn:
         row = await conn.fetchrow("""
@@ -2004,9 +2027,9 @@ async def update_provider_model(model_pk_id: int, **kwargs):
     pool = await get_pool()
     allowed = {'display_name', 'model_type', 'input_modes', 'output_modes', 'capabilities', 'api_format'}
     fields = {k: v for k, v in kwargs.items() if k in allowed}
-    # api_format 允许设为 None/空串（表示跟随供应商）
+    # api_format 允许设为 None/空串（表示跟随供应商），非法值收敛为 None
     if 'api_format' in fields:
-        fields['api_format'] = fields['api_format'] or None
+        fields['api_format'] = _normalize_api_format(fields['api_format'], allow_none=True)
     fields = {k: v for k, v in fields.items() if v is not None or k == 'api_format'}
     if not fields:
         return None


### PR DESCRIPTION
Codex 在 PR #16 指出供应商徽章把 `p.api_format` 直接拼进 `innerHTML` 的存储型 XSS。前端转义那条 commit 没赶上 #16 的 squash（合并后才推），这里把**前端兜底 + 后端根治**两层一起补进 main。

## 后端（根治）— database.py

新增 `_normalize_api_format()`，在所有写入入口收敛白名单：

| 入口 | 校验 |
|---|---|
| `create_provider` / `update_provider` | 供应商级 → `openai` / `anthropic`，非法值回落 `openai` |
| `add_provider_model` / `update_provider_model` | 模型级 → 额外允许 `None`（"跟随供应商"），非法值收敛 `None` |

大小写不敏感、空值/None 安全。10 个用例自测全过（含 ``&lt;img src=x onerror=...&gt;`` payload → `openai`）。

## 前端（兜底）— admin-panel/index.html

- 徽章显示文本改 `escHtml(p.api_format || 'openai')`
- class 仍走 `==='anthropic'?'imp-high':'imp-mid'` 三元（只产固定字面量，本身安全）

> 注：main 上当前是 PR #16 的第一版（徽章未转义），本 PR 同时把那条 XSS 兜底补回。

## Commit
- `f918bdd` fix: validate api_format at backend entry + escape badge text (XSS defense-in-depth)

Refs: chatgpt-codex-connector review on #16

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXU7QqWCdr5qNPt3ExcFzn)_