### PR TITLE
feat: 后台任务支持 Anthropic 原生格式（Codex 深审 #1）

### DIFF
--- a/anthropic_adapter.py
+++ b/anthropic_adapter.py
@@ -213,6 +213,36 @@ def from_anthropic_response(anthropic_data: dict, model: str = "") -> dict:
 
 
 # ============================================================
+# 后台任务便捷封装（非流式）
+# 记忆提取 / Dream / 每日整理 / 切窗摘要等都用这两个，
+# 配合 database.resolve_model_endpoint 返回的 (url, key, api_format)。
+# ============================================================
+
+def prepare_background_request(api_key: str, api_format: str, openai_body: dict,
+                               referer: str = None, title: str = None) -> tuple:
+    """根据 api_format 构造后台请求，返回 (headers, send_body)。
+
+    - anthropic：x-api-key + anthropic-version，body 转 Anthropic Messages 格式
+    - openai：Bearer，body 原样（可带 OpenRouter 的 Referer/Title 归因头）
+
+    URL 已由 resolve_model_endpoint 按 api_format 给出，调用方直接用。
+    """
+    if api_format == "anthropic":
+        return to_anthropic_headers(api_key), to_anthropic_request(openai_body)
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    if referer:
+        headers["HTTP-Referer"] = referer
+    if title:
+        headers["X-Title"] = title
+    return headers, openai_body
+
+
+def parse_background_response(data: dict, api_format: str) -> dict:
+    """把后台任务的响应统一成 OpenAI chat.completion 结构。"""
+    return from_anthropic_response(data) if api_format == "anthropic" else data
+
+
+# ============================================================
 # 流式转换：Anthropic SSE → OpenAI SSE
 # ============================================================
 

--- a/daily_digest.py
+++ b/daily_digest.py
@@ -170,37 +170,36 @@ async def _run_daily_digest_impl(date_str: str, now_cst, model_override: str = N
     # v5.4：动态解析供应商端点
     try:
         from database import resolve_model_endpoint
-        use_api_url, use_api_key = await resolve_model_endpoint(use_model)
+        use_api_url, use_api_key, use_api_format = await resolve_model_endpoint(use_model)
     except Exception:
         use_api_url = MEMORY_API_BASE_URL
         use_api_key = MEMORY_API_KEY
-    
+        use_api_format = "openai"
+
     # ---- 3. 调用 Haiku ----
     try:
+        from anthropic_adapter import prepare_background_request, parse_background_response
+        _body = {
+            "model": use_model,
+            "max_tokens": 2000,
+            "messages": [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": f"请整理 {date_str} 的碎片记忆。"},
+            ],
+        }
+        _headers, _send_body = prepare_background_request(
+            use_api_key, use_api_format, _body,
+            referer="https://midsummer-gateway.local",
+            title="AI Memory Gateway - Daily Digest",
+        )
         async with httpx.AsyncClient(timeout=90) as client:
-            response = await client.post(
-                use_api_url,
-                headers={
-                    "Authorization": f"Bearer {use_api_key}",
-                    "Content-Type": "application/json",
-                    "HTTP-Referer": "https://midsummer-gateway.local",
-                    "X-Title": "AI Memory Gateway - Daily Digest",
-                },
-                json={
-                    "model": use_model,
-                    "max_tokens": 2000,
-                    "messages": [
-                        {"role": "system", "content": prompt},
-                        {"role": "user", "content": f"请整理 {date_str} 的碎片记忆。"},
-                    ],
-                },
-            )
-            
+            response = await client.post(use_api_url, headers=_headers, json=_send_body)
+
             if response.status_code != 200:
                 print(f"   ⚠️ Haiku 请求失败: {response.status_code}")
                 return {"date": date_str, "fragments": len(fragments), "digests": 0, "error": f"HTTP {response.status_code}"}
-            
-            data = response.json()
+
+            data = parse_background_response(response.json(), use_api_format)
             text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
             
             # 日志
@@ -413,36 +412,34 @@ async def update_user_profile(digest_text: str = None, model_override: str = Non
     # 5. 调用模型（v5.4：走供应商路由）
     try:
         from database import resolve_model_endpoint
-        use_api_url, use_api_key = await resolve_model_endpoint(use_model)
+        use_api_url, use_api_key, use_api_format = await resolve_model_endpoint(use_model)
     except Exception:
         use_api_url = MEMORY_API_BASE_URL
         use_api_key = MEMORY_API_KEY
+        use_api_format = "openai"
 
     try:
+        from anthropic_adapter import prepare_background_request, parse_background_response
+        _body = {
+            "model": use_model,
+            "max_tokens": 2000,
+            "messages": [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": "请根据今天的日志更新用户画像。"},
+            ],
+        }
+        _headers, _send_body = prepare_background_request(
+            use_api_key, use_api_format, _body,
+            referer="https://midsummer-gateway.local", title="User Profile Update",
+        )
         async with httpx.AsyncClient(timeout=90) as client:
-            response = await client.post(
-                use_api_url,
-                headers={
-                    "Authorization": f"Bearer {use_api_key}",
-                    "Content-Type": "application/json",
-                    "HTTP-Referer": "https://midsummer-gateway.local",
-                    "X-Title": "User Profile Update",
-                },
-                json={
-                    "model": use_model,
-                    "max_tokens": 2000,
-                    "messages": [
-                        {"role": "system", "content": prompt},
-                        {"role": "user", "content": "请根据今天的日志更新用户画像。"},
-                    ],
-                },
-            )
-            
+            response = await client.post(use_api_url, headers=_headers, json=_send_body)
+
             if response.status_code != 200:
                 print(f"   ⚠️ 画像更新请求失败: {response.status_code}")
                 return {"status": "error", "error": f"HTTP {response.status_code}"}
-            
-            data = response.json()
+
+            data = parse_background_response(response.json(), use_api_format)
             new_profile = data.get("choices", [{}])[0].get("message", {}).get("content", "").strip()
             
             if not new_profile:
@@ -774,36 +771,34 @@ async def generate_day_page(target_date: str = None, model_override: str = None)
     # 6. 调用模型（v5.4：走供应商路由）
     try:
         from database import resolve_model_endpoint
-        use_api_url, use_api_key = await resolve_model_endpoint(use_model)
+        use_api_url, use_api_key, use_api_format = await resolve_model_endpoint(use_model)
     except Exception:
         use_api_url = MEMORY_API_BASE_URL
         use_api_key = MEMORY_API_KEY
+        use_api_format = "openai"
 
     try:
+        from anthropic_adapter import prepare_background_request, parse_background_response
+        _body = {
+            "model": use_model,
+            "max_tokens": 6000,
+            "messages": [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": f"请生成 {date_str} 的日页面。"},
+            ],
+        }
+        _headers, _send_body = prepare_background_request(
+            use_api_key, use_api_format, _body,
+            referer="https://midsummer-gateway.local", title="Day Page Generation",
+        )
         async with httpx.AsyncClient(timeout=120) as client:
-            response = await client.post(
-                use_api_url,
-                headers={
-                    "Authorization": f"Bearer {use_api_key}",
-                    "Content-Type": "application/json",
-                    "HTTP-Referer": "https://midsummer-gateway.local",
-                    "X-Title": "Day Page Generation",
-                },
-                json={
-                    "model": use_model,
-                    "max_tokens": 6000,
-                    "messages": [
-                        {"role": "system", "content": prompt},
-                        {"role": "user", "content": f"请生成 {date_str} 的日页面。"},
-                    ],
-                },
-            )
+            response = await client.post(use_api_url, headers=_headers, json=_send_body)
 
             if response.status_code != 200:
                 print(f"   ⚠️ 日页面生成请求失败: {response.status_code}")
                 return {"date": date_str, "status": "error", "error": f"HTTP {response.status_code}"}
 
-            data = response.json()
+            data = parse_background_response(response.json(), use_api_format)
             text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
 
             # 清理 markdown 包裹
@@ -1320,35 +1315,33 @@ async def _call_model_for_json(prompt: str, user_msg: str, model: str, max_token
     # 动态解析供应商端点
     try:
         from database import resolve_model_endpoint
-        use_api_url, use_api_key = await resolve_model_endpoint(model)
+        use_api_url, use_api_key, use_api_format = await resolve_model_endpoint(model)
     except Exception:
         use_api_url = MEMORY_API_BASE_URL
         use_api_key = MEMORY_API_KEY
+        use_api_format = "openai"
 
     try:
+        from anthropic_adapter import prepare_background_request, parse_background_response
+        _body = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "messages": [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": user_msg},
+            ],
+        }
+        _headers, _send_body = prepare_background_request(
+            use_api_key, use_api_format, _body,
+            referer="https://midsummer-gateway.local", title="Memory Summary",
+        )
         async with httpx.AsyncClient(timeout=120) as client:
-            response = await client.post(
-                use_api_url,
-                headers={
-                    "Authorization": f"Bearer {use_api_key}",
-                    "Content-Type": "application/json",
-                    "HTTP-Referer": "https://midsummer-gateway.local",
-                    "X-Title": "Memory Summary",
-                },
-                json={
-                    "model": model,
-                    "max_tokens": max_tokens,
-                    "messages": [
-                        {"role": "system", "content": prompt},
-                        {"role": "user", "content": user_msg},
-                    ],
-                },
-            )
+            response = await client.post(use_api_url, headers=_headers, json=_send_body)
             if response.status_code != 200:
                 print(f"   ⚠️ 模型请求失败: {response.status_code}")
                 return None
 
-            data = response.json()
+            data = parse_background_response(response.json(), use_api_format)
             text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
             text = text.strip()
             if text.startswith("```json"):

--- a/database.py
+++ b/database.py
@@ -3325,31 +3325,40 @@ def detect_contradictions(new_title: str, new_content: str, similar_results: lis
 
 async def resolve_model_endpoint(model_id: str) -> tuple:
     """
-    为后台任务（记忆提取 / Dream / 每日整理）解析模型的 API 端点。
-    
+    为后台任务（记忆提取 / Dream / 每日整理 / 切窗摘要）解析模型的 API 端点。
+
     解析顺序：
     1. 供应商数据库（模型在某个 provider 下注册了）
     2. 环境变量降级（MEMORY_API_BASE_URL / API_BASE_URL + 对应 key）
-    
-    返回：(api_url, api_key) — api_url 以 /chat/completions 结尾
+
+    返回：(api_url, api_key, api_format)
+      - api_format == 'anthropic' 时 api_url 是 Anthropic messages 端点
+      - 否则 api_url 以 /chat/completions 结尾
+    调用方配合 anthropic_adapter.prepare_background_request /
+    parse_background_response 处理请求体和响应。
     """
     if model_id:
         try:
             provider_info = await resolve_provider_for_model(model_id)
             if provider_info:
                 base = provider_info["api_base_url"].rstrip("/")
-                api_url = base if base.endswith("/chat/completions") else f"{base}/chat/completions"
                 api_key = provider_info["api_key"]
-                print(f"🔀 后台任务路由到 [{provider_info['provider_name']}]: {model_id}")
-                return api_url, api_key
+                api_format = provider_info.get("api_format", "openai") or "openai"
+                if api_format == "anthropic":
+                    from anthropic_adapter import get_anthropic_url
+                    api_url = get_anthropic_url(base)
+                else:
+                    api_url = base if base.endswith("/chat/completions") else f"{base}/chat/completions"
+                print(f"🔀 后台任务路由到 [{provider_info['provider_name']}] (format={api_format}): {model_id}")
+                return api_url, api_key, api_format
         except Exception as e:
             print(f"⚠️ 供应商路由查询失败，降级到环境变量: {e}")
 
-    # 降级：环境变量
+    # 降级：环境变量（按 OpenAI 兼容端点处理）
     _raw = os.getenv("MEMORY_API_BASE_URL", "") or os.getenv("API_BASE_URL", "https://openrouter.ai/api/v1/chat/completions")
     api_url = _raw if _raw.rstrip("/").endswith("/chat/completions") else f"{_raw.rstrip('/')}/chat/completions"
     api_key = os.getenv("MEMORY_API_KEY", "") or os.getenv("API_KEY", "")
-    return api_url, api_key
+    return api_url, api_key, "openai"
 
 
 # ============================================================

--- a/dream.py
+++ b/dream.py
@@ -286,30 +286,28 @@ async def run_dream(trigger_type: str = "manual", model_override: str = None):
         # v5.4：动态解析供应商端点
         try:
             from database import resolve_model_endpoint
-            use_api_url, use_api_key = await resolve_model_endpoint(use_model)
+            use_api_url, use_api_key, use_api_format = await resolve_model_endpoint(use_model)
         except Exception:
             use_api_url = MEMORY_API_BASE_URL
             use_api_key = MEMORY_API_KEY
+            use_api_format = "openai"
 
         try:
+            from anthropic_adapter import prepare_background_request, parse_background_response
+            _body = {
+                "model": use_model,
+                "max_tokens": 6000,
+                "messages": [
+                    {"role": "system", "content": prompt},
+                    {"role": "user", "content": "开始做梦。"},
+                ],
+            }
+            _headers, _send_body = prepare_background_request(
+                use_api_key, use_api_format, _body,
+                referer="https://midsummer-gateway.local", title="Dream",
+            )
             async with httpx.AsyncClient(timeout=120) as client:
-                response = await client.post(
-                    use_api_url,
-                    headers={
-                        "Authorization": f"Bearer {use_api_key}",
-                        "Content-Type": "application/json",
-                        "HTTP-Referer": "https://midsummer-gateway.local",
-                        "X-Title": "Dream",
-                    },
-                    json={
-                        "model": use_model,
-                        "max_tokens": 6000,
-                        "messages": [
-                            {"role": "system", "content": prompt},
-                            {"role": "user", "content": "开始做梦。"},
-                        ],
-                    },
-                )
+                response = await client.post(use_api_url, headers=_headers, json=_send_body)
 
                 if response.status_code != 200:
                     error_msg = f"模型请求失败: HTTP {response.status_code}"
@@ -318,7 +316,7 @@ async def run_dream(trigger_type: str = "manual", model_override: str = None):
                     yield {"type": "error", "data": error_msg}
                     return
 
-                data = response.json()
+                data = parse_background_response(response.json(), use_api_format)
                 text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
 
         except Exception as e:

--- a/main.py
+++ b/main.py
@@ -3048,31 +3048,28 @@ async def _generate_handoff_summary(conv_id: str, handoff_msgs: list, prev_title
         # 解析供应商端点
         try:
             from database import resolve_model_endpoint
-            use_api_url, use_api_key = await resolve_model_endpoint(use_model)
+            use_api_url, use_api_key, use_api_format = await resolve_model_endpoint(use_model)
         except Exception:
             use_api_url = os.getenv("MEMORY_API_BASE_URL", "") or os.getenv("API_BASE_URL", "https://openrouter.ai/api/v1/chat/completions")
             if not use_api_url.rstrip("/").endswith("/chat/completions"):
                 use_api_url = f"{use_api_url.rstrip('/')}/chat/completions"
             use_api_key = os.getenv("MEMORY_API_KEY", "") or os.getenv("API_KEY", "")
-        
+            use_api_format = "openai"
+
+        from anthropic_adapter import prepare_background_request, parse_background_response
+        _body = {
+            "model": use_model,
+            "max_tokens": 500,
+            "messages": [
+                {"role": "user", "content": prompt},
+            ],
+        }
+        _headers, _send_body = prepare_background_request(use_api_key, use_api_format, _body)
         async with httpx.AsyncClient(timeout=30) as client:
-            response = await client.post(
-                use_api_url,
-                headers={
-                    "Authorization": f"Bearer {use_api_key}",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "model": use_model,
-                    "max_tokens": 500,
-                    "messages": [
-                        {"role": "user", "content": prompt},
-                    ],
-                },
-            )
-            
+            response = await client.post(use_api_url, headers=_headers, json=_send_body)
+
             if response.status_code == 200:
-                data = response.json()
+                data = parse_background_response(response.json(), use_api_format)
                 summary = data.get("choices", [{}])[0].get("message", {}).get("content", "").strip()
                 if summary:
                     _handoff_summary_cache = {"conv_id": conv_id, "summary": summary}

--- a/memory_extractor.py
+++ b/memory_extractor.py
@@ -153,10 +153,11 @@ async def extract_memories(messages: List[Dict[str, str]], existing_memories: Li
     # v5.4：动态解析供应商端点（优先走数据库 provider，降级到环境变量）
     try:
         from database import resolve_model_endpoint
-        use_api_url, use_api_key = await resolve_model_endpoint(use_model)
+        use_api_url, use_api_key, use_api_format = await resolve_model_endpoint(use_model)
     except Exception:
         use_api_url = API_BASE_URL
         use_api_key = API_KEY
+        use_api_format = "openai"
 
     if not use_api_key:
         print("⚠️  无可用 API Key（供应商和环境变量均未配置），跳过记忆提取")
@@ -164,30 +165,28 @@ async def extract_memories(messages: List[Dict[str, str]], existing_memories: Li
 
     # 调用 LLM 提取记忆
     try:
+        from anthropic_adapter import prepare_background_request, parse_background_response
+        _body = {
+            "model": use_model,
+            "max_tokens": 1000,
+            "messages": [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": f"请从以下对话中提取新的记忆：\n\n{conversation_text}"},
+            ],
+        }
+        _headers, _send_body = prepare_background_request(
+            use_api_key, use_api_format, _body,
+            referer="https://midsummer-gateway.local",
+            title="AI Memory Gateway - Memory Extraction",
+        )
         async with httpx.AsyncClient(timeout=60) as client:
-            response = await client.post(
-                use_api_url,
-                headers={
-                    "Authorization": f"Bearer {use_api_key}",
-                    "Content-Type": "application/json",
-                    "HTTP-Referer": "https://midsummer-gateway.local",
-                    "X-Title": "AI Memory Gateway - Memory Extraction",
-                },
-                json={
-                    "model": use_model,
-                    "max_tokens": 1000,
-                    "messages": [
-                        {"role": "system", "content": prompt},
-                        {"role": "user", "content": f"请从以下对话中提取新的记忆：\n\n{conversation_text}"},
-                    ],
-                },
-            )
+            response = await client.post(use_api_url, headers=_headers, json=_send_body)
 
             if response.status_code != 200:
                 print(f"⚠️  记忆提取请求失败: {response.status_code}")
                 return []
 
-            data = response.json()
+            data = parse_background_response(response.json(), use_api_format)
             text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
             
             # 日志：打印模型原始返回（方便排查）


### PR DESCRIPTION
Codex 深审 #1。之前 Anthropic 原生只接通了 `/v1/chat/completions` 主聊天链路，后台任务（记忆提取 / Dream / 每日整理 / 切窗摘要）仍只发 `Bearer` + OpenAI body——把 `default_memory_model` / `dream_model` / `default_digest_model` 等设成 **Anthropic 原生**供应商时，聊天正常但这些后台整理会失败。

## 改法（收口成共享 helper，避免每个调用点重复手写四套分流）

- **`database.resolve_model_endpoint`** 返回值加 `api_format`：
  - `anthropic` → `api_url` 走 `get_anthropic_url`（messages 端点）
  - 否则 → `/chat/completions`；环境变量降级按 `openai`
  - URL 分流集中在这里（单一真相源）
- **`anthropic_adapter`** 新增两个便捷封装：
  - `prepare_background_request(api_key, api_format, body, referer, title)` → `(headers, send_body)`：anthropic 用 x-api-key + anthropic-version + `to_anthropic_request`；openai 用 Bearer（保留 OpenRouter Referer/Title）
  - `parse_background_response(data, api_format)` → 统一成 OpenAI chat.completion 结构（anthropic 走 `from_anthropic_response`）
- **7 个调用方**改为三元解包 + 走 helper：
  - `memory_extractor`（记忆提取）
  - `dream`（Dream）
  - `main`（切窗摘要）
  - `daily_digest` ×4（日整理 / 画像 / 日页面 / 记忆摘要）

OpenAI 路径行为不变（含 OpenRouter 归因头）。

## 验证
- 6 个文件 AST 通过
- helper 纯函数自测全过：anthropic（x-api-key + 剥模型前缀 + system 提取 + max_tokens）、openai（Bearer + Referer/Title）、响应解析（content blocks → choices）
- 受运行环境限制（缺 asyncpg/httpx），未做真实 DB/API 联调

## Commit
- `2f40167` feat: 后台任务支持 Anthropic 原生格式（Codex 深审 #1）

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXU7QqWCdr5qNPt3ExcFzn)_