### PR TITLE
fix: 记忆提取移除过早的 API_KEY 拦截（Codex 复审）

### DIFF
--- a/memory_extractor.py
+++ b/memory_extractor.py
@@ -103,10 +103,6 @@ async def extract_memories(messages: List[Dict[str, str]], existing_memories: Li
     返回：
         记忆列表，格式 [{"content": "...", "importance": N, "emotional_weight": N, "category": "..."}, ...]
     """
-    if not API_KEY:
-        print("⚠️  API_KEY 未设置，跳过记忆提取")
-        return []
-
     if not messages:
         return []
 


### PR DESCRIPTION
Codex 复审 #1 后标的边角小修。

`memory_extractor` 在调 `resolve_model_endpoint` 之前就用 `if not API_KEY: return []` 拦截，导致"只在管理面板填供应商 key、环境变量不填 key"的部署连数据库供应商都查不到就被跳过。

删掉这个早 gate——`resolve_model_endpoint` 之后已有正确的 `if not use_api_key` 兜底（查完数据库供应商再判断），覆盖"哪里都没 key"的情况。`dream` / `daily_digest` 没有这个早 gate，无需改。

> 另一条（env 降级路径假设 OpenAI 兼容、直配 Anthropic 原生地址不生效）按 Lucie 决定不动——Anthropic 原生走供应商表 `api_format=anthropic` 是主路径。

## Commit
- `dc5e341` fix: 记忆提取移除过早的 API_KEY 拦截（Codex 复审）

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXU7QqWCdr5qNPt3ExcFzn)_