### PR TITLE
v1.3.1 同步：SSE [DONE] 顺序修复 + strip_emotion_tag + 热度衰减改进

### DIFF
--- a/database.py
+++ b/database.py
@@ -800,14 +800,26 @@ def calculate_heat(row, params: dict = None) -> float:
     half_life = base_half_life * (1.0 + access_count * p["recall_extend"])
     
     # --- 时间衰减 ---
-    if created_at:
+    # v5.10：基准时间取"创建时间"和"上次被想起"中更近的那个
+    # 这样冷记忆一旦被用户对话重新命中，时钟就从这一刻重新开始，热度瞬间回升
+    # （就像很久没想起的事，突然有人提起，一下子就鲜活了）
+    last_accessed = row.get("last_accessed")
+    anchor = created_at  # 默认用创建时间
+    if last_accessed is not None and access_count > 0:
         try:
-            # v5.4：安全时区处理（已有时区信息则转换，无则假设 UTC）
-            if created_at.tzinfo is not None:
-                created_utc = created_at.astimezone(timezone.utc)
+            la = last_accessed.astimezone(timezone.utc) if last_accessed.tzinfo else last_accessed.replace(tzinfo=timezone.utc)
+            ca = created_at.astimezone(timezone.utc) if created_at.tzinfo else created_at.replace(tzinfo=timezone.utc)
+            anchor = max(ca, la)
+        except Exception:
+            pass
+
+    if anchor:
+        try:
+            if anchor.tzinfo is not None:
+                anchor_utc = anchor.astimezone(timezone.utc)
             else:
-                created_utc = created_at.replace(tzinfo=timezone.utc)
-            age_seconds = (datetime.now(timezone.utc) - created_utc).total_seconds()
+                anchor_utc = anchor.replace(tzinfo=timezone.utc)
+            age_seconds = (datetime.now(timezone.utc) - anchor_utc).total_seconds()
             age_days = age_seconds / 86400.0
             # 指数衰减：heat = 2^(-age/half_life)
             decay = math.pow(2, -age_days / half_life)
@@ -2929,15 +2941,14 @@ async def get_chat_messages_for_date(date_str: str):
     pool = await get_pool()
     d = date_cls.fromisoformat(date_str)
     async with pool.acquire() as conn:
-        # LEFT JOIN 是为了让没有 conversation_id 的旧消息也能命中（c.id 为 NULL）
         rows = await conn.fetch("""
             SELECT m.role, m.content, m.time, m.conversation_id
             FROM chat_messages m
-            LEFT JOIN chat_conversations c ON m.conversation_id = c.id
+            JOIN chat_conversations c ON m.conversation_id = c.id
             WHERE (m.time AT TIME ZONE 'Asia/Shanghai')::date = $1
               AND m.role IN ('user', 'assistant')
               AND m.content != ''
-              AND (c.project_id IS NULL OR c.id IS NULL)
+              AND c.project_id IS NULL
             ORDER BY m.time ASC
         """, d)
     return [dict(r) for r in rows]

--- a/database.py
+++ b/database.py
@@ -1239,7 +1239,7 @@ async def _vector_search(query_embedding: list, limit: int, heat_params: dict, p
                           COALESCE(m.access_query_hashes, '[]'::jsonb) as access_query_hashes,
                           COALESCE(m.is_permanent, false) as is_permanent,
                           COALESCE(m.resolution, 1.0) as resolution,
-                          m.valid_until, m.project_id
+                          m.valid_until, m.project_id, m.last_accessed
                    FROM memories m LEFT JOIN memory_categories c ON m.category_id = c.id
                    WHERE COALESCE(m.memory_type, 'fragment') NOT IN ('digested', 'dream_deleted')
                      AND (m.valid_until IS NULL OR m.valid_until > NOW())
@@ -1248,7 +1248,7 @@ async def _vector_search(query_embedding: list, limit: int, heat_params: dict, p
             )
         else:
             rows = await conn.fetch(
-                """SELECT m.id, m.content, m.importance, m.created_at, m.embedding, 
+                """SELECT m.id, m.content, m.importance, m.created_at, m.embedding,
                           COALESCE(m.title, '') as title, COALESCE(m.memory_type, 'fragment') as memory_type,
                           m.category_id, COALESCE(c.name, '') as category_name, COALESCE(c.color, '') as category_color,
                           COALESCE(m.source, 'ai_extracted') as source,
@@ -1257,7 +1257,7 @@ async def _vector_search(query_embedding: list, limit: int, heat_params: dict, p
                           COALESCE(m.access_query_hashes, '[]'::jsonb) as access_query_hashes,
                           COALESCE(m.is_permanent, false) as is_permanent,
                           COALESCE(m.resolution, 1.0) as resolution,
-                          m.valid_until, m.project_id
+                          m.valid_until, m.project_id, m.last_accessed
                    FROM memories m LEFT JOIN memory_categories c ON m.category_id = c.id
                    WHERE COALESCE(m.memory_type, 'fragment') NOT IN ('digested', 'dream_deleted')
                      AND (m.valid_until IS NULL OR m.valid_until > NOW())
@@ -1698,7 +1698,7 @@ async def _keyword_search(query: str, limit: int = 10, heat_params: dict = None,
                 COALESCE(m.access_query_hashes, '[]'::jsonb) as access_query_hashes,
                 COALESCE(m.is_permanent, false) as is_permanent,
                 COALESCE(m.resolution, 1.0) as resolution,
-                m.project_id,
+                m.project_id, m.last_accessed,
                 ({hit_count_expr}) AS hit_count,
                 (
                     0.5 * ({hit_count_expr})::float / {max_hits} +

--- a/main.py
+++ b/main.py
@@ -766,6 +766,15 @@ def detect_emotion_from_response(text: str) -> str:
     return "normal"
 
 
+def strip_emotion_tag(text: str) -> str:
+    """滤掉回复里的情绪隐藏标记（任何值），用于存储和提取前的清洗。
+    情绪解析须在调用本函数之前完成（解析依赖原始带标记文本）。"""
+    if not text:
+        return text
+    import re
+    return re.sub(r'<!--\s*emotion\s*[:：][^>]*-->', '', text).rstrip()
+
+
 def detect_dream_trigger(text: str) -> bool:
     """检测模型回复中是否有 <!--dream:trigger--> 标记"""
     if not text:
@@ -821,13 +830,17 @@ async def process_memories_background(session_id: str, user_msg: str, assistant_
     """
     global _conversation_counter
 
+    # 情绪解析已在调用方用原始文本完成（emotion_level 已传入），
+    # 这里把标记滤掉，保证存储和提取用的都是干净文本。
+    assistant_msg = strip_emotion_tag(assistant_msg)
+    assistant_msg = strip_dream_tag(assistant_msg)
+
     try:
         # 对话始终保存
         if is_regenerate:
             await delete_latest_assistant_message(session_id)
         else:
             await save_message(session_id, "user", user_msg, model)
-        assistant_msg = strip_dream_tag(assistant_msg)
         await save_message(session_id, "assistant", assistant_msg, model)
 
         # 项目对话默认不提取碎片（对话已保存，但不走记忆提取流程）
@@ -1987,18 +2000,22 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
             if usage_data:
                 finish_payload['usage'] = usage_data
             yield f"data: {json.dumps(finish_payload, ensure_ascii=False)}\n\n"
-            yield "data: [DONE]\n\n"
 
             assistant_msg = final_text
             dream_triggered = detect_dream_trigger(assistant_msg)
+            # 记忆提取在流内同步等待，好让记忆行实时出现在聊天里
+            # （仅每隔 N 轮真正提取并调 LLM，平时是快速 skip，不显示也不卡）
             if mem_enabled and user_message and assistant_msg:
                 _emo = merge_emotion_levels(detect_emotion_from_user_msg(user_message), detect_emotion_from_response(assistant_msg))
                 mem_result = await process_memories_background(session_id, user_message, assistant_msg, model, emotion_level=_emo, project_id=project_id, is_regenerate=is_regenerate)
                 if mem_result and mem_result.get("action") != "skip":
                     yield f"data: {json.dumps({'ev_memory': mem_result}, ensure_ascii=False)}\n\n"
+            # Dream 事件必须在 [DONE] 之前
             if dream_triggered:
                 print(f"🌙 检测到 Dream 标记，通知前端启动 Dream...")
                 yield f"data: {json.dumps({'ev_dream': {'triggered': True}}, ensure_ascii=False)}\n\n"
+            # [DONE] 作为流的最后一个事件
+            yield "data: [DONE]\n\n"
             return
 
         # ── 有 tool_calls → 并行执行工具 ──
@@ -2223,24 +2240,32 @@ async def stream_and_capture(headers: dict, body: dict, session_id: str, user_me
                     yield b"data: [DONE]\n\n"
                     return
 
-                # 使用适配器将 Anthropic SSE 转换为 OpenAI SSE
+                # 按 SSE 事件（\n\n）缓冲转发，并抑制上游 [DONE]——由本函数末尾统一发，保证它是流的最后一个事件
+                _ev_buf = ""
                 async for openai_chunk in anthropic_stream_to_openai(response, model):
-                    yield openai_chunk
-                    # 捕获正文内容（用于后续记忆提取）
-                    try:
-                        decoded = openai_chunk.decode("utf-8", errors="ignore")
-                        for line in decoded.strip().split("\n"):
-                            line = line.strip()
-                            if line.startswith("data: ") and line != "data: [DONE]":
-                                data = json.loads(line[6:])
-                                delta = data.get("choices", [{}])[0].get("delta", {})
-                                content = delta.get("content", "")
-                                if content:
-                                    full_response.append(content)
-                                if delta.get("reasoning_content"):
-                                    _reasoning_chunks += 1
-                    except Exception:
-                        pass
+                    _ev_buf += openai_chunk.decode("utf-8", errors="ignore").replace("\r\n", "\n")
+                    while "\n\n" in _ev_buf:
+                        event, _ev_buf = _ev_buf.split("\n\n", 1)
+                        event = event.strip()
+                        if not event or event == "data: [DONE]":
+                            continue
+                        yield (event + "\n\n").encode("utf-8")
+                        try:
+                            for line in event.split("\n"):
+                                line = line.strip()
+                                if line.startswith("data: "):
+                                    data = json.loads(line[6:])
+                                    delta = data.get("choices", [{}])[0].get("delta", {})
+                                    content = delta.get("content", "")
+                                    if content:
+                                        full_response.append(content)
+                                    if delta.get("reasoning_content"):
+                                        _reasoning_chunks += 1
+                        except Exception:
+                            pass
+                _tail = _ev_buf.strip()
+                if _tail and _tail != "data: [DONE]":
+                    yield (_tail + "\n\n").encode("utf-8")
     else:
         # OpenAI 格式：直接转发
         buffer = ""
@@ -2257,41 +2282,46 @@ async def stream_and_capture(headers: dict, body: dict, session_id: str, user_me
                     yield b"data: [DONE]\n\n"
                     return
 
-                async for chunk in response.aiter_bytes():
-                    yield chunk
-                    try:
-                        buffer += chunk.decode("utf-8", errors="ignore")
-                        while "\n" in buffer:
-                            line, buffer = buffer.split("\n", 1)
+                # 按 SSE 事件（\n\n）缓冲转发，并抑制上游 [DONE]——由本函数末尾统一发，保证它是流的最后一个事件。
+                # 以「整事件」为单位转发（而非裸字节），既能干净拦掉 [DONE]，又不破坏事件分帧。
+                async for chunk in response.aiter_bytes(chunk_size=256):
+                    buffer += chunk.decode("utf-8", errors="ignore").replace("\r\n", "\n")
+                    while "\n\n" in buffer:
+                        event, buffer = buffer.split("\n\n", 1)
+                        event = event.strip()
+                        if not event or event == "data: [DONE]":
+                            continue
+                        yield (event + "\n\n").encode("utf-8")
+                        for line in event.split("\n"):
                             line = line.strip()
-                            if line.startswith("data: ") and line != "data: [DONE]":
-                                try:
-                                    data = json.loads(line[6:])
-                                    delta = data.get("choices", [{}])[0].get("delta", {})
+                            if not line.startswith("data: "):
+                                continue
+                            try:
+                                data = json.loads(line[6:])
+                                delta = data.get("choices", [{}])[0].get("delta", {})
 
-                                    # 🔍 调试日志：记录第一个有效delta的所有字段
-                                    if not _logged_first_delta and delta:
-                                        keys = list(delta.keys())
-                                        if keys and keys != ['role']:
-                                            print(f"🔍 [流式调试] 首个delta字段: {keys}, 模型: {model}")
-                                            # 如果有思考链相关字段，打印示例
-                                            for k in ('reasoning_content', 'reasoning', 'reasoning_details'):
-                                                if k in delta:
-                                                    sample = str(delta[k])[:100]
-                                                    print(f"🔍 [流式调试] {k} 示例: {sample}")
-                                            _logged_first_delta = True
+                                # 🔍 调试日志：记录第一个有效delta的所有字段
+                                if not _logged_first_delta and delta:
+                                    keys = list(delta.keys())
+                                    if keys and keys != ['role']:
+                                        print(f"🔍 [流式调试] 首个delta字段: {keys}, 模型: {model}")
+                                        for k in ('reasoning_content', 'reasoning', 'reasoning_details'):
+                                            if k in delta:
+                                                sample = str(delta[k])[:100]
+                                                print(f"🔍 [流式调试] {k} 示例: {sample}")
+                                        _logged_first_delta = True
 
-                                    # 统计思考链 chunk 数
-                                    if delta.get('reasoning_content') or delta.get('reasoning') or delta.get('reasoning_details'):
-                                        _reasoning_chunks += 1
+                                if delta.get('reasoning_content') or delta.get('reasoning') or delta.get('reasoning_details'):
+                                    _reasoning_chunks += 1
 
-                                    content = delta.get("content", "")
-                                    if content:
-                                        full_response.append(content)
-                                except (json.JSONDecodeError, KeyError, IndexError):
-                                    pass
-                    except Exception:
-                        pass
+                                content = delta.get("content", "")
+                                if content:
+                                    full_response.append(content)
+                            except (json.JSONDecodeError, KeyError, IndexError):
+                                pass
+                _tail = buffer.strip()
+                if _tail and _tail != "data: [DONE]":
+                    yield (_tail + "\n\n").encode("utf-8")
 
     assistant_msg = "".join(full_response)
     
@@ -2315,10 +2345,13 @@ async def stream_and_capture(headers: dict, body: dict, session_id: str, user_me
         if mem_result and mem_result.get("action") != "skip":
             yield f"data: {json.dumps({'ev_memory': mem_result}, ensure_ascii=False)}\n\n".encode("utf-8")
 
-    # Dream 触发：推送 SSE 事件通知前端，由前端连接 Dream SSE 获取进度
+    # Dream 触发：在 [DONE] 之前推送，由前端连接 Dream SSE 获取进度
     if dream_triggered:
         print(f"🌙 检测到 Dream 标记，通知前端启动 Dream...")
         yield f"data: {json.dumps({'ev_dream': {'triggered': True}}, ensure_ascii=False)}\n\n".encode("utf-8")
+
+    # [DONE] 作为流的最后一个事件（上游/适配器的 [DONE] 已在上面被抑制）
+    yield b"data: [DONE]\n\n"
 
 # ============================================================
 # 记忆管理接口


### PR DESCRIPTION
## Summary

从 ai-memory-gateway（私人版）同步 5 项改动到 kiwi-mem（开源版），涵盖 4 个 P0 修复 + 1 个 P1 改进。

### 改动清单

- **P0-1**：新增 `strip_emotion_tag()` 函数，在存储和记忆提取前清理 `<!--emotion:高-->` 等隐藏标记，防止脏文本入库
- **P0-2**：`_stream_with_tools` 的 `[DONE]` 从 `ev_memory`/`ev_dream` 之前移到之后，修复前端收不到这两个事件的 bug
- **P0-3**：`stream_and_capture` 的 Anthropic 和 OpenAI 两条路径改为事件级缓冲（按 `\n\n` 切分），拦截上游 `[DONE]`，末尾统一发送，保证事件顺序：content → ev_memory → ev_dream → [DONE]
- **P0-4**：`get_chat_messages_for_date` 从 `LEFT JOIN` 改为 `INNER JOIN`，排除已删除对话的孤儿消息混入日页面
- **P1-1**：`calculate_heat` 时间衰减基准从 `created_at` 改为 `max(created_at, last_accessed)`，冷记忆被重新提起后热度回升

### 文件变更

| 文件 | 改动 |
|---|---|
| `main.py` | P0-1, P0-2, P0-3 |
| `database.py` | P0-4, P1-1 |

### 有意保留的差异（未同步）

- `_sse_status` 状态推送事件（需前端配套）
- `_gentle_text_chunks` 自然节奏切块
- 个人化文案 / 性能计时 / CORS 硬编码

## Test plan

- [ ] `py_compile` 通过 ✅
- [ ] 流式聊天（OpenAI 格式）：前端能收到 ev_memory 和 ev_dream 事件
- [ ] 流式聊天（Anthropic 格式）：同上
- [ ] 工具调用模式：ev_memory/ev_dream 在 [DONE] 之前到达
- [ ] 日页面不再显示已删除对话的消息
- [ ] 冷记忆被重新提起后热度回升

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRj7FcJ5GhuQSeQtcL5iwv

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRj7FcJ5GhuQSeQtcL5iwv)_