### PR TITLE
fix: config 空环境变量兜底 + adapter 流截断兜底/工具结果合并（Batch 2 + Batch 3）

### DIFF
--- a/anthropic_adapter.py
+++ b/anthropic_adapter.py
@@ -263,8 +263,18 @@ async def anthropic_stream_to_openai(response, model: str = "") -> AsyncGenerato
     output_tokens = 0
     cache_creation = 0
     cache_read = 0
+    done_sent = False
 
-    async for chunk in response.aiter_bytes(chunk_size=256):
+    # 手动迭代上游 SSE：流被截断 / 协议异常时 aiter_bytes 可能直接抛错，这里捕获后
+    # 跳出循环，由循环结束后的兜底逻辑补发 [DONE]，避免下游一直挂着等结束信号。
+    chunk_iter = response.aiter_bytes(chunk_size=256)
+    while True:
+        try:
+            chunk = await chunk_iter.__anext__()
+        except StopAsyncIteration:
+            break
+        except Exception:
+            break
         buffer += chunk.decode("utf-8", errors="ignore")
 
         while "\n" in buffer:
@@ -365,13 +375,20 @@ async def anthropic_stream_to_openai(response, model: str = "") -> AsyncGenerato
 
             # ── message_stop ──
             elif event_type == "message_stop":
+                done_sent = True
                 yield b"data: [DONE]\n\n"
 
             # ── error ──
             elif event_type == "error":
                 err_msg = data.get("error", {}).get("message", "Unknown error")
                 yield _sse(msg_id, model, {"content": f"⚠️ {err_msg}"})
+                done_sent = True
                 yield b"data: [DONE]\n\n"
+
+    # 兜底：上游正常结束或被截断却没发 message_stop / error 时，补一个 [DONE] 收尾，
+    # 否则下游（OpenAI SSE 消费方）会一直等不到结束标记。
+    if not done_sent:
+        yield b"data: [DONE]\n\n"
 
 
 # ============================================================
@@ -457,14 +474,23 @@ def _convert_messages(openai_msgs: list) -> list:
         content = msg.get("content", "")
 
         if role == "tool":
-            # ── tool result → 合并到 user message ──
+            # ── tool result → 合并进紧邻的 user message ──
+            # Anthropic 要求同一轮的 tool_result 并进同一条 user 消息，且不允许连续两条
+            # user。上一条已是 user 时：list 内容直接 append；纯字符串内容先转成 text
+            # block 再 append（而不是另起一条 user，避免触发"连续 user"报错）。
             block = {
                 "type": "tool_result",
                 "tool_use_id": msg.get("tool_call_id", ""),
                 "content": content if isinstance(content, str) else json.dumps(content, ensure_ascii=False),
             }
-            if result and result[-1]["role"] == "user" and isinstance(result[-1]["content"], list):
-                result[-1]["content"].append(block)
+            if result and result[-1]["role"] == "user":
+                prev = result[-1]["content"]
+                if isinstance(prev, list):
+                    prev.append(block)
+                else:
+                    result[-1]["content"] = (
+                        [{"type": "text", "text": prev}] if prev else []
+                    ) + [block]
             else:
                 result.append({"role": "user", "content": [block]})
 

--- a/config.py
+++ b/config.py
@@ -113,6 +113,20 @@ CONFIG_SCHEMA = {
 # 读取配置
 # ============================================================
 
+def _env_or_default(env_name: str, default_val: str) -> tuple:
+    """解析"环境变量 > 默认值"。
+
+    环境变量未设置、或被设成空串 / 纯空白时一律视为"未设置"，回落到默认值，
+    避免空环境变量（如 docker-compose 里 KEY=${KEY} 而 KEY 未定义）把默认值冲掉。
+    返回 (值, 来源)，来源为 'env' 或 'default'。
+    """
+    if env_name:
+        env_val = os.getenv(env_name)
+        if env_val is not None and env_val.strip() != "":
+            return env_val, "env"
+    return default_val, "default"
+
+
 async def get_config(key: str) -> Optional[str]:
     """
     获取单个配置值
@@ -129,9 +143,8 @@ async def get_config(key: str) -> Optional[str]:
     # 降级到环境变量和默认值
     if key in CONFIG_SCHEMA:
         env_name, default_val, _, _ = CONFIG_SCHEMA[key]
-        if env_name:
-            return os.getenv(env_name, default_val)
-        return default_val
+        value, _ = _env_or_default(env_name, default_val)
+        return value
     
     return None
 
@@ -142,12 +155,12 @@ async def get_all_config() -> dict:
     
     # 先填默认值和环境变量
     for key, (env_name, default_val, label, val_type) in CONFIG_SCHEMA.items():
-        env_val = os.getenv(env_name, default_val) if env_name else default_val
+        env_val, source = _env_or_default(env_name, default_val)
         result[key] = {
             "value": env_val,
             "label": label,
             "type": val_type,
-            "source": "env" if (env_name and os.getenv(env_name)) else "default",
+            "source": source,
         }
     
     # 覆盖数据库里的值
@@ -220,8 +233,13 @@ async def get_config_float(key: str, fallback: float = 0.0) -> float:
 
 
 async def get_config_bool(key: str, fallback: bool = False) -> bool:
-    """获取布尔配置"""
+    """获取布尔配置（接受 true/1/yes/on 与 false/0/no/off 等常见写法）"""
     val = await get_config(key)
     if val is None:
         return fallback
-    return val.lower() == "true"
+    v = val.strip().lower()
+    if v in ("true", "1", "yes", "on"):
+        return True
+    if v in ("false", "0", "no", "off"):
+        return False
+    return fallback


### PR DESCRIPTION
## 背景

对齐私有后端 ai-memory-gateway 同轮修复，补上 **Batch 2（config.py）** 与 **Batch 3（anthropic_adapter.py）**。

## Batch 2 — config.py

- **#8 空环境变量覆盖默认值**：新增 `_env_or_default()`，环境变量未设置 / 空串 / 纯空白视为未设置并回落默认值；`get_config` 与 `get_all_config` 统一走它（顺带修正 value=`""` 却标 source=`env` 的不一致）。
- **#22 `get_config_bool` 只认 `"true"`**：扩展为接受 `true/1/yes/on` 与 `false/0/no/off`，无法识别时返回 `fallback`。
- **#9（`boolean` → `bool`）不适用**：kiwi 的 `CONFIG_SCHEMA` 已统一为 `bool`，无需改动。

## Batch 3 — anthropic_adapter.py（与私有后端逐字节同源）

- **#10 流截断没兜底 `[DONE]`**：上游被截断、或正常结束却没发 `message_stop` 时，改为手动迭代上游并在循环结束后用 `done_sent` 兜底补一个 `[DONE]`，避免下游一直挂着等结束标记。
- **#11 tool_result 合并边界**：上一条是字符串内容的 user 时不再另起一条 user（避免连续两条 user），改为转成 text block 后并入同一条。常见路径（assistant[tool_use] → tool → tool）行为不变。

## 测试

- [x] `python3 -m py_compile config.py anthropic_adapter.py` 通过（仓库全量 `.py` 也通过）
- [ ] 真实 DB / 上游 API 联调（受环境限制未做）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DReEAPtAAePYDSV3Dp14r3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DReEAPtAAePYDSV3Dp14r3)_