### PR TITLE
fix: 工具抽屉 session 稳定性 + 注册表并发 + 错误可见性 (PR B: main + tool_drawer + mcp_client)

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ AI Memory Gateway — 带记忆系统的 LLM 转发网关
 
 import os
 import json
+import hashlib
 import uuid
 import asyncio
 import httpx
@@ -1430,7 +1431,16 @@ async def chat_completions(request: Request):
     # 优先用前端传来的 conversation_id：工具抽屉的"手动展开工具"状态按 session 存，
     # 设计上是"下一轮对话生效"。session_id 必须跨轮稳定，否则每轮新 uuid 会丢掉
     # 上一轮展开的类别，_drawer_request_tools 永远不会真正生效。
-    session_id = conversation_id or str(uuid.uuid4())[:8]
+    # Bug #3：前端不传 conversation_id 时，退回用「首条用户消息」的 hash —— 它在同一段
+    # 对话的多轮间稳定（不像 uuid 每轮都变），让上面说的“跨轮稳定”在无 conversation_id
+    # 时也成立。
+    if conversation_id:
+        session_id = conversation_id
+    else:
+        first_user = next((m.get("content") for m in messages if m.get("role") == "user"), "") or ""
+        if not isinstance(first_user, str):
+            first_user = json.dumps(first_user, ensure_ascii=False)
+        session_id = "auto-" + hashlib.md5(first_user.encode("utf-8")).hexdigest()[:8]
     
     # 请求 LLM 在流式响应中包含 token 用量
     if body.get("stream"):

--- a/mcp_client.py
+++ b/mcp_client.py
@@ -201,6 +201,9 @@ async def call_tool(tool_name: str, arguments: dict, tool_map: dict) -> str:
     except Exception as e:
         error_msg = f"工具调用失败 [{tool_name}]: {str(e)}"
         print(f"❌ {error_msg}")
+        # Bug #20：调用失败（404 / 未知工具等）可能意味着缓存的工具列表已过期，
+        # 驱逐该 URL 的缓存，下次重新拉取，避免坏数据卡满 _CACHE_TTL。
+        _tool_cache.pop(url, None)
         return error_msg
 
 

--- a/tool_drawer.py
+++ b/tool_drawer.py
@@ -6,6 +6,7 @@ tool_drawer.py - Vector Tool Drawer (Auto-Discovery)
 """
 
 import ast
+import asyncio
 import hashlib
 import json
 import os
@@ -98,6 +99,7 @@ CATEGORIES = {}        # cat_id -> {label, description, tool_names}
 _tool_to_category = {} # tool_name -> cat_id
 _external_categories = {}   # cat_id -> external drawer metadata + execution map
 _external_config_hash = None
+_refresh_lock = asyncio.Lock()   # Bug #4：串行化 refresh_external_drawers，避免半重建的注册表被并发读到
 
 # ============================================================
 # 4. Meta-tools (always available)
@@ -423,6 +425,13 @@ def _unregister_external_drawers():
 
 
 async def refresh_external_drawers(force=False):
+    # Bug #4：刷新会先清空注册表再逐个重建，期间有多个 await；并发刷新会让其他请求读到
+    # 半重建的注册表。用锁把整个刷新串行化。
+    async with _refresh_lock:
+        await _refresh_external_drawers_impl(force)
+
+
+async def _refresh_external_drawers_impl(force=False):
     """Register external MCP servers as dynamic tool drawer categories."""
     global _external_config_hash
 
@@ -706,6 +715,9 @@ async def route_tools(user_message, session_id, user_embedding=None, mem_enabled
     external_pinned = mode in ("auto", "manual")
 
     await refresh_external_drawers()
+    # Bug #4：在锁内对注册表做一次快照，避免遍历期间被并发刷新改成半成品
+    async with _refresh_lock:
+        cat_embeddings_snapshot = dict(_category_embeddings)
     if len(_sessions) > 200:
         _cleanup_sessions()
 
@@ -716,9 +728,9 @@ async def route_tools(user_message, session_id, user_embedding=None, mem_enabled
     external_keyword_hits = _external_keyword_match(user_message) if external_auto else set()
     external_scores = {}
 
-    if user_embedding and _category_embeddings:
+    if user_embedding and cat_embeddings_snapshot:
         scores = {}
-        for cat_id, cat_emb in _category_embeddings.items():
+        for cat_id, cat_emb in cat_embeddings_snapshot.items():
             is_external = cat_id in _external_categories
             if is_external and not external_auto:
                 continue
@@ -736,7 +748,7 @@ async def route_tools(user_message, session_id, user_embedding=None, mem_enabled
         else:
             print(f"\U0001f5c3\ufe0f  抽屉路由：未命中（top3: {top3_str}）")
         internal_keyword_hits = _keyword_match(user_message)
-        fallback_hits = {c for c in internal_keyword_hits if c not in _category_embeddings}
+        fallback_hits = {c for c in internal_keyword_hits if c not in cat_embeddings_snapshot}
         if fallback_hits:
             matched_categories |= fallback_hits
             print(f"\U0001f5c3\ufe0f  抽屉路由（关键词补位）：命中 {fallback_hits}")
@@ -919,6 +931,8 @@ async def execute_drawer_tool(tool_name, arguments):
         return f"[tool_error] {tool_name}: argument mismatch", extra
     except Exception as e:
         print(f"\u274c drawer\u5de5\u5177 {tool_name} \u6267\u884c\u5931\u8d25: {e}")
+        import traceback
+        traceback.print_exc()
         return f"[tool_error] {tool_name}: execution failed", extra
 
 # ============================================================


### PR DESCRIPTION
## PR B — main.py + tool_drawer.py + mcp_client.py（开源版）

对齐私有后端同组修复，文案保持泛化版。

### main.py
- **#3 session_id 对不传 conversation_id 的客户端失效**：无 conversation_id 时每轮新 uuid → 抽屉跨轮状态丢失。改为退回用**首条用户消息**的 md5 hash（跨轮稳定）。补 `import hashlib`。
  > brief 原方案 `messages[-2:]` 每轮都变、保不住跨轮；改用首条用户消息。无 conversation_id 时无法完全隔离，属固有限制。

### tool_drawer.py
- **#4 注册表并发竞争**：`refresh_external_drawers` 拆出 `_impl` 并整体加 `_refresh_lock` 串行化；`route_tools` 锁内对 `_category_embeddings` 取快照再遍历。补 `import asyncio`。
- **#17 `execute_drawer_tool` 吞 traceback**：异常分支补 `traceback.print_exc()`。

### mcp_client.py
- **#20 工具调用失败不清缓存**：`call_tool` 失败时 `_tool_cache.pop(url)` 驱逐，避免坏数据卡满 `_CACHE_TTL`（300s）。

### 测试
- [x] `python3 -m py_compile main.py tool_drawer.py mcp_client.py`（全量 `.py` 亦通过）
- [ ] 真实联调（环境限制未做）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DReEAPtAAePYDSV3Dp14r3

---
_Generated by [Claude Code](https://claude.ai/code/session_01DReEAPtAAePYDSV3Dp14r3)_