### PR TITLE
feat(compress): 同步自动上下文压缩摘要后端 (v6.1)

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,6 +39,11 @@ CONFIG_SCHEMA = {
     # 上下文压缩（v3.9）
     "default_compress_model":("",                        "",     "上下文压缩模型",    "text"),
     "prompt_compress":       ("",                        "",     "上下文压缩提示词",  "text"),
+    # 自动上下文压缩（v6.1）
+    "auto_compress_enabled":    ("", "true",  "自动压缩开关",        "bool"),
+    "auto_compress_msg_limit":  ("", "40",    "压缩触发条数",        "int"),
+    "auto_compress_token_limit":("", "30000", "压缩触发 token 上限",  "int"),
+    "auto_compress_keep_last":  ("", "4",     "压缩后保留原文条数",   "int"),
     # 用户画像（v4.0）
     "user_profile":          ("",                        "",     "用户画像",          "text"),
     "prompt_user_profile":   ("",                        "",     "画像更新提示词",    "text"),

--- a/database.py
+++ b/database.py
@@ -293,6 +293,24 @@ async def init_tables():
             );
         """)
 
+        # v6.1：自动上下文压缩摘要（每次压缩单独存一条，为无缝换窗 v2 预留）
+        # conversation_id 是前端对话 ID，后端没有对应外键表，故不加外键约束
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS compression_summaries (
+                id              SERIAL PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                summary         TEXT NOT NULL,
+                model           TEXT DEFAULT '',
+                summary_type    TEXT DEFAULT 'auto',
+                msg_count       INT DEFAULT 0,
+                compressed_at   TIMESTAMPTZ DEFAULT NOW()
+            );
+        """)
+        await conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_comp_sum_conv
+            ON compression_summaries (conversation_id);
+        """)
+
         # v4.2：提醒系统
         await conn.execute("""
             CREATE TABLE IF NOT EXISTS reminders (
@@ -2340,12 +2358,18 @@ async def sync_upsert_conversation(conv: dict):
 
 
 async def sync_delete_conversation(conv_id: str):
-    """删除对话（级联删除消息）"""
+    """删除对话（chat_messages 由外键级联删除；compression_summaries 无外键，需手动清理）"""
     pool = await get_pool()
     async with pool.acquire() as conn:
-        result = await conn.execute(
-            "DELETE FROM chat_conversations WHERE id = $1", conv_id
-        )
+        async with conn.transaction():
+            result = await conn.execute(
+                "DELETE FROM chat_conversations WHERE id = $1", conv_id
+            )
+            # compression_summaries 没有外键约束，不会随对话级联删除，必须手动删，
+            # 否则无缝换窗 v2 读取时可能读到已删对话的旧窗口摘要
+            await conn.execute(
+                "DELETE FROM compression_summaries WHERE conversation_id = $1", conv_id
+            )
         return "DELETE" in result
 
 

--- a/main.py
+++ b/main.py
@@ -2959,6 +2959,60 @@ async def api_generate_year_summary(year: str = None):
         return {"error": str(e)}
 
 
+# ============================================================
+# 自动上下文压缩摘要（v6.1）
+# 压缩在前端执行，后端只负责存储/读取摘要，为无缝换窗 v2 预留
+# 两个端点都在 /admin/* 下，受 AdminAuthMiddleware 保护（前端用 authFetch 带 Bearer）
+# ============================================================
+
+@app.post("/admin/compression-summary")
+async def api_save_compression_summary(request: Request):
+    """前端压缩成功后调此端点存储摘要（为无缝换窗 v2 预留）"""
+    try:
+        body = await request.json()
+        conv_id = body.get("conversation_id")
+        summary = body.get("summary", "")
+        if not conv_id or not summary:
+            return JSONResponse(status_code=400, content={"error": "缺少 conversation_id 或 summary"})
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "INSERT INTO compression_summaries (conversation_id, summary, model, summary_type, msg_count) VALUES ($1, $2, $3, $4, $5)",
+                conv_id,
+                summary,
+                body.get("model", ""),
+                body.get("summary_type", "auto"),
+                body.get("msg_count", 0),
+            )
+        return JSONResponse(content={"ok": True})
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+@app.get("/admin/compression-summaries")
+async def api_get_compression_summaries(conversation_id: str):
+    """读取某对话的全部压缩摘要（按时间正序），供无缝换窗 v2 使用"""
+    try:
+        pool = await get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT summary, model, summary_type, msg_count, compressed_at FROM compression_summaries WHERE conversation_id = $1 ORDER BY compressed_at ASC",
+                conversation_id,
+            )
+        return JSONResponse(content=[
+            {
+                "summary": r["summary"],
+                "model": r["model"],
+                "summary_type": r["summary_type"],
+                "msg_count": r["msg_count"],
+                "compressed_at": str(r["compressed_at"]),
+            }
+            for r in rows
+        ])
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
 @app.get("/calendar/{date}")
 async def api_get_calendar_day(date: str, type: str = "day"):
     """获取指定日期的日历页面"""
@@ -4469,6 +4523,8 @@ async def api_sync_reset(request: Request):
             # 删除所有消息和对话（级联）
             deleted_convs = await conn.execute("DELETE FROM chat_conversations")
             deleted_projs = await conn.execute("DELETE FROM chat_projects")
+            # compression_summaries 无外键，不会随对话级联删除，手动清空
+            await conn.execute("DELETE FROM compression_summaries")
 
             # 清除同步设置
             sync_keys = ["user_avatar", "user_nickname", "assistant_avatar", "assistant_settings",


### PR DESCRIPTION
## 自动上下文压缩 — 后端同步到 kiwi-mem (3-2, v6.1)

把 `ai-memory-gateway` 已合并的 [PR #13](https://github.com/LucieEveille/ai-memory-gateway/pull/13) 后端改动同步过来。压缩在**前端**执行，后端只负责把每次压缩产生的摘要持久化，为无缝换窗 v2（3-2b）预留。

> kiwi-mem 与 gateway 的写法有差异，本 PR **保持对外 API 契约一致**（端点 path / 请求体字段 / 响应体），仅把端点的**内部写法适配 kiwi-mem 既有风格**，这样同一前端可同时对接两个后端。

### 改动（共 5 处，纯新增 / 局部替换，无破坏性）
- **config.py** — 紧跟 `prompt_compress` 新增 4 项配置：
  `auto_compress_enabled` / `auto_compress_msg_limit` / `auto_compress_token_limit` / `auto_compress_keep_last`
- **database.py**
  - `init_tables()` 新建 `compression_summaries` 表（`conversation_id` / `summary` / `model` / `summary_type` / `msg_count` / `compressed_at`）+ `idx_comp_sum_conv` 索引。`conversation_id` 是前端 ID，无对应外键表，故不加外键。建表随启动自动执行，无需手动迁移。
  - `sync_delete_conversation` 改为**事务内**连带删除该对话的摘要（无外键不会级联，必须手动删）。
- **main.py**
  - `POST /admin/compression-summary` — 存储一条摘要
  - `GET  /admin/compression-summaries?conversation_id=…` — 按时间正序读回（给 v2 用）
  - `/sync/reset` 重置端点连带清空 `compression_summaries`
  - 两个端点都在 `/admin/*` 下，受 `AdminAuthMiddleware` 保护（前端用 `authFetch` 带 Bearer）。

### 适配 kiwi-mem 风格的差异点（相对 gateway 写法）
- 端点函数采用 `api_` 命名、`request: Request` 入参、`body = await request.json()`
- 统一 `try/except` 包裹，错误走 `JSONResponse(status_code=…, content={"error": …})`
- 返回走 `JSONResponse(content=…)`（对齐 `reminders` 端点写法）
- 索引 DDL 用多行 `CREATE INDEX ... ON table (col)`（对齐邻近 `idx_chat_messages_conv` 写法）

### 验证
- `python3 -m py_compile config.py database.py main.py` ✅
- 行尾 LF ✅
- 未做运行时验证（本环境无 Postgres / 服务）。

### 给 3-2b（无缝换窗 v2）的提醒
- 每轮存的摘要是**累积**的（滚雪球），v2 读取时**取最新一条即可**，别把所有行拼起来。
- `summary_type` 区分 `auto` / `manual`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CBjFFKut38EajVWywZ2xU

---
_Generated by [Claude Code](https://claude.ai/code/session_011CBjFFKut38EajVWywZ2xU)_