### PR TITLE
易用性：/v1/models 对齐供应商配置 + 移除访问密码（ACCESS_TOKEN）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,9 +29,6 @@ DEFAULT_MODEL=anthropic/claude-sonnet-4
 # 网关端口
 PORT=8080
 
-# 管理面板密码（不设则无需密码，建议生产环境设置）
-ACCESS_TOKEN=
-
 # 每次注入的最大记忆条数
 MAX_MEMORIES_INJECT=15
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+# 每次提 PR、或直接往 main 推代码时，自动跑一遍语法自检。
+# 绿勾 = 所有 .py 文件语法没问题；红叉 = 哪里写坏了，服务可能起不来。
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  syntax-check:
+    name: Python 语法自检
+    runs-on: ubuntu-latest
+    steps:
+      - name: 拉取代码
+        uses: actions/checkout@v4
+
+      - name: 准备 Python 3.12（与 Dockerfile 一致）
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: 编译检查所有 .py 文件（有语法错误这步就会变红）
+        run: python -m compileall -q .

--- a/README.md
+++ b/README.md
@@ -163,17 +163,15 @@ cp .env.example .env
 nano .env
 ```
 
-你会看到类似这样的内容。**只需要改两行**（其余保持默认）：
+配置文件里大部分都有合理默认值，**通常一行都不用改就能启动**（供应商在管理面板里配即可）：
 
 ```
-# 【必填】你的门禁密码——防止别人用你的网关
-# 随便起一个，比如 MySecret123，记住它，后面要用
-ACCESS_TOKEN=在这里填你的门禁密码
-
 # 【可选】如果你不用管理面板配供应商，可以在这里填 AI 服务的 API Key
 # 如果你打算在管理面板里配（推荐），这行留空就行
 API_KEY=
 ```
+
+> 🔓 **kiwi-mem 不带访问密码。** 网关和管理面板默认不需要任何登录口令——这样最省心，不会再有人卡在 401。代价是：**任何知道你网关地址的人都能访问 `/admin` 管理面板（查看/修改你的记忆和配置）。** 如果你的服务暴露在公网，请自行用 Cloudflare Access、反向代理的 Basic Auth、IP 白名单等手段保护 `/admin` 路径。
 
 保存后启动：
 ```bash
@@ -226,7 +224,7 @@ https://你的域名/admin
 ```
 （如果还没配域名，电脑上可以用 `http://服务器IP:8080/admin`）
 
-登录时输入你在 `.env` 里设的门禁密码（`ACCESS_TOKEN`）。
+管理面板默认不需要密码，直接就能进。
 
 进入管理面板后：
 
@@ -249,7 +247,7 @@ https://你的域名/admin
 | 设置项 | 填什么 | 说明 |
 |--------|--------|------|
 | API Base URL | `https://你的域名/v1` | 这是 kiwi-mem **网关**的地址，不是 AI 中转站的地址！ |
-| API Key | 你设的门禁密码 | 就是 `.env` 里的 `ACCESS_TOKEN` |
+| API Key | 随便填（比如 `kiwi`），不能留空 | kiwi-mem 网关不校验这个 Key，但很多前端要求非空。真正的中转站 Key 是填在管理面板里的 |
 
 > ⚠️ **最容易填错的地方**：API Base URL 要填你的 **kiwi-mem 网关地址**（`https://你的域名/v1`），**不要填 AI 中转站的地址**！中转站的地址是填在管理面板里的，不是填在前端客户端里的。请回头看本文最上面那张图。
 
@@ -260,7 +258,7 @@ https://你的域名/admin
 ### 常见问题
 
 **Q: 报错 401 Missing Authentication header**
-→ 你的前端客户端没有填 API Key，或者填的和 `.env` 里的 `ACCESS_TOKEN` 不一样。
+→ kiwi-mem 网关本身不需要密码。这个 401 来自上游 AI 中转站，说明管理面板里供应商的 API Key 没配对（或没配供应商）。去管理面板 → 供应商 → 检查地址和 Key。另外有些前端要求 API Key 字段非空，随便填个非空值（比如 `kiwi`）即可。
 
 **Q: 报错 500 API_KEY 未设置**
 → 你的管理面板里没有配置供应商，或者供应商的模型没有关联上。去管理面板 → 供应商 → 检查是否配好了地址和 Key、是否有模型。
@@ -417,7 +415,6 @@ cp seed_memories_example.py seed_memories.py
 | `MEMORY_ENABLED` | 记忆系统开关 | `true` |
 | `DEFAULT_MODEL` | 默认聊天模型 | `anthropic/claude-sonnet-4` |
 | `PORT` | 端口 | `8080` |
-| `ACCESS_TOKEN` | 管理面板密码 | 空（不设则无需密码） |
 | `MAX_MEMORIES_INJECT` | 每次注入最大记忆条数 | `15` |
 | `MEMORY_EXTRACT_INTERVAL` | 提取间隔（轮） | `3` |
 | `CORS_ORIGINS` | 前端域名白名单 | `http://localhost:5173` |

--- a/README_EN.md
+++ b/README_EN.md
@@ -242,7 +242,7 @@ Imported memories will appear in the admin panel's memory page.
 
 ### 🛡️ Deployment & management
 - Web admin panel · cloud sync · backup/restore
-- Reminder system · admin auth · Docker deploy
+- Reminder system · Docker deploy
 
 </details>
 
@@ -268,7 +268,6 @@ Imported memories will appear in the admin panel's memory page.
 | `MEMORY_ENABLED` | Enable memory system | `true` |
 | `DEFAULT_MODEL` | Default chat model | `anthropic/claude-sonnet-4` |
 | `PORT` | Gateway port | `8080` |
-| `ACCESS_TOKEN` | Admin panel password | empty (no auth) |
 | `MAX_MEMORIES_INJECT` | Max memories per injection | `15` |
 | `MEMORY_EXTRACT_INTERVAL` | Extract every N turns | `3` |
 | `CORS_ORIGINS` | Frontend origins, comma-separated | `http://localhost:5173` |

--- a/admin-panel/index.html
+++ b/admin-panel/index.html
@@ -337,23 +337,13 @@ tailwind.config = {
 // API Base & Auth
 // ============================================================
 const API = window.location.origin;
-let TOKEN = localStorage.getItem('kiwi_admin_token') || '';
 
 function authHeaders() {
-  const h = { 'Content-Type': 'application/json' };
-  if (TOKEN) h['Authorization'] = `Bearer ${TOKEN}`;
-  return h;
+  return { 'Content-Type': 'application/json' };
 }
 
 async function api(path, opts = {}) {
-  const sep = path.includes('?') ? '&' : '?';
-  const url = TOKEN && !opts.headers?.Authorization ? `${API}${path}${sep}token=${TOKEN}` : `${API}${path}`;
-  const res = await fetch(url, { headers: authHeaders(), ...opts });
-  if (res.status === 401) {
-    TOKEN = prompt('请输入 ACCESS_TOKEN：') || '';
-    localStorage.setItem('kiwi_admin_token', TOKEN);
-    return api(path, opts);
-  }
+  const res = await fetch(`${API}${path}`, { headers: authHeaders(), ...opts });
   if (res.status >= 500) {
     throw new Error(`服务器错误 (${res.status})，请检查后端日志`);
   }
@@ -1265,7 +1255,7 @@ async function triggerSeed() {
 }
 
 async function downloadBackup() {
-  window.open(`${API}/sync/export${TOKEN ? '?token='+TOKEN : ''}`, '_blank');
+  window.open(`${API}/sync/export`, '_blank');
 }
 
 async function triggerMigrate() {

--- a/database.py
+++ b/database.py
@@ -2102,6 +2102,29 @@ async def get_all_saved_models():
         return [dict(r) for r in rows]
 
 
+async def get_enabled_provider_models():
+    """获取所有【已启用】供应商的已保存模型，供对外的 /v1/models 使用。
+
+    口径与聊天路由（resolve_provider_for_model）保持一致：只返回 enabled=TRUE 的
+    供应商下、用户在管理面板里实际配置过的模型——这样前端下拉框里看到的模型，
+    就是真正能被路由成功的模型，不会再出现“列表里有、一发就 404”的错位。
+
+    排除 embedding 类型（聊天前端的模型选择器不需要它）。
+    """
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch("""
+            SELECT pm.model_id, pm.display_name, pm.model_type, pm.created_at,
+                   p.name as provider_name
+            FROM provider_models pm
+            JOIN providers p ON pm.provider_id = p.id
+            WHERE p.enabled = TRUE
+              AND COALESCE(pm.model_type, 'chat') <> 'embedding'
+            ORDER BY p.name ASC, pm.display_name ASC
+        """)
+        return [dict(r) for r in rows]
+
+
 async def add_provider_model(provider_id: int, model_id: str, display_name: str = '',
                              model_type: str = 'chat', input_modes: str = 'text',
                              output_modes: str = 'text', capabilities: str = '', api_format: str = None):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
       DEFAULT_MODEL: ${DEFAULT_MODEL:-anthropic/claude-sonnet-4}
       PORT: ${PORT:-8080}
       # ---- 可选 ----
-      ACCESS_TOKEN: ${ACCESS_TOKEN:-}
       MAX_MEMORIES_INJECT: ${MAX_MEMORIES_INJECT:-15}
       MEMORY_EXTRACT_INTERVAL: ${MEMORY_EXTRACT_INTERVAL:-3}
       CORS_ORIGINS: ${CORS_ORIGINS:-*}

--- a/main.py
+++ b/main.py
@@ -33,7 +33,7 @@ from database import (
     # v5.3 时间有效期 + 矛盾检测
     invalidate_memory, create_memory_edge, detect_contradictions,
     get_all_providers, get_provider, create_provider, update_provider, delete_provider,
-    get_provider_models, get_all_saved_models, add_provider_model, update_provider_model, delete_provider_model,
+    get_provider_models, get_all_saved_models, get_enabled_provider_models, add_provider_model, update_provider_model, delete_provider_model,
     resolve_provider_for_model,
     get_all_categories, create_category, update_category, delete_category, match_category_by_name,
     get_system_prompt_from_db, set_system_prompt_in_db,
@@ -1086,7 +1086,41 @@ async def admin_panel():
 
 @app.get("/v1/models")
 async def list_models():
-    """从 OpenRouter 拉取完整模型列表"""
+    """对外暴露的模型列表，供前端客户端拉取下拉选项。
+
+    口径优先级：
+      1) 管理面板里配置的供应商模型（已启用供应商 + 实际保存的模型）——这与聊天
+         路由 resolve_provider_for_model 完全一致，前端看到的就是真正能用的模型。
+      2) 没有配置任何模型时（例如只用 .env 直连、未加供应商），回退到旧行为：
+         从环境变量 API_BASE_URL 对应的服务商拉取 /models。
+      3) 都拿不到时，用 DEFAULT_MODEL 兜底，保证至少能选一个发出去。
+    """
+    # ── 1) 管理面板配置的供应商模型（首选）──
+    try:
+        saved = await get_enabled_provider_models()
+    except Exception as e:
+        print(f"⚠️ 读取已配置模型失败，回退环境变量: {e}")
+        saved = []
+
+    if saved:
+        data = []
+        seen = set()
+        for m in saved:
+            mid = (m.get("model_id") or "").strip()
+            # 同一模型可能被挂在多个供应商下，路由是 LIMIT 1，这里也去重保持列表干净
+            if not mid or mid in seen:
+                continue
+            seen.add(mid)
+            data.append({
+                "id": mid,
+                "object": "model",
+                "created": 1700000000,
+                "owned_by": m.get("provider_name") or "kiwi-mem",
+            })
+        if data:
+            return {"object": "list", "data": data}
+
+    # ── 2) 回退：从环境变量配置的服务商拉取（兼容纯 .env 部署）──
     try:
         # 从 API_BASE_URL 提取基础地址（去掉 /chat/completions 部分）
         base = API_BASE_URL.split("/chat/completions")[0].rstrip("/")
@@ -1099,7 +1133,8 @@ async def list_models():
                 return resp.json()
     except Exception as e:
         print(f"⚠️ 拉取模型列表失败: {e}")
-    # 失败时返回默认模型兜底
+
+    # ── 3) 兜底：默认模型 ──
     return {
         "object": "list",
         "data": [
@@ -1107,7 +1142,7 @@ async def list_models():
                 "id": DEFAULT_MODEL,
                 "object": "model",
                 "created": 1700000000,
-                "owned_by": "ai-memory-gateway",
+                "owned_by": "kiwi-mem",
             }
         ],
     }

--- a/main.py
+++ b/main.py
@@ -22,7 +22,6 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, UploadFile, File
 from fastapi.responses import StreamingResponse, JSONResponse, Response
 from fastapi.middleware.cors import CORSMiddleware
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from database import (
     init_tables, close_pool, get_pool, save_message, delete_latest_assistant_message, search_memories, save_memory,
@@ -79,9 +78,6 @@ MAX_MEMORIES_INJECT = int(os.getenv("MAX_MEMORIES_INJECT", "15"))
 
 # 记忆提取间隔：每隔几轮对话提取一次记忆（默认3轮）
 MEMORY_EXTRACT_INTERVAL = int(os.getenv("MEMORY_EXTRACT_INTERVAL", "3"))
-
-# 前端访问密码（不设就不需要密码）
-ACCESS_TOKEN = os.getenv("ACCESS_TOKEN", "")
 
 
 # ============================================================
@@ -266,51 +262,6 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Kiwi-Mem", version="1.3.0", lifespan=lifespan)
 
-
-# ============================================================
-# Admin 认证中间件 — 保护 /admin/* 和 /debug/* 端点
-# ============================================================
-
-class AdminAuthMiddleware(BaseHTTPMiddleware):
-    """当设置了 ACCESS_TOKEN 时，需要认证的路径前缀。
-
-    - /admin/、/debug/、/sync/：管理面板 / 调试 / 云同步导出导入
-    - /projects/：v5.8 项目文件上传与 chunk 管理（POST /projects/{id}/files/{fid}/process
-      与 DELETE /projects/{id}/files/{fid}/chunks），写操作必须保护
-    - /import/：导入种子记忆（如 /import/seed-memories），会写入数据库
-    """
-
-    PROTECTED_PREFIXES = ("/admin/", "/debug/", "/sync/", "/projects/", "/import/")
-    
-    async def dispatch(self, request: Request, call_next):
-        path = request.url.path
-        
-        # OPTIONS 预检请求直接放行
-        if request.method == "OPTIONS":
-            return await call_next(request)
-        
-        # /admin 面板页面本身不拦截（不带斜杠的精确匹配）
-        if path == "/admin":
-            return await call_next(request)
-        
-        # 只拦截受保护路径
-        if ACCESS_TOKEN and any(path.startswith(p) for p in self.PROTECTED_PREFIXES):
-            # 从 Authorization header 或 query param 读 token
-            auth = request.headers.get("Authorization", "")
-            token = auth.replace("Bearer ", "") if auth.startswith("Bearer ") else ""
-            if not token:
-                token = request.query_params.get("token", "")
-            
-            if token != ACCESS_TOKEN:
-                return JSONResponse(
-                    status_code=401,
-                    content={"error": "未授权访问，请提供有效的 ACCESS_TOKEN"}
-                )
-        
-        return await call_next(request)
-
-
-app.add_middleware(AdminAuthMiddleware)
 
 # ============================================================
 # CORS 配置 — 从环境变量读取允许的域名
@@ -1051,17 +1002,8 @@ async def favicon():
 
 @app.post("/auth/verify")
 async def auth_verify(request: Request):
-    """验证前端访问密码"""
-    if not ACCESS_TOKEN:
-        return {"status": "ok", "message": "无需密码"}
-    try:
-        data = await request.json()
-        token = data.get("token", "")
-        if token == ACCESS_TOKEN:
-            return {"status": "ok"}
-        return JSONResponse(status_code=401, content={"error": "密码错误"})
-    except Exception:
-        return JSONResponse(status_code=401, content={"error": "密码错误"})
+    """兼容旧前端的探活端点。kiwi-mem 已移除访问密码，这里始终放行。"""
+    return {"status": "ok", "message": "无需密码"}
 
 
 @app.get("/api/status")
@@ -2997,7 +2939,6 @@ async def api_generate_year_summary(year: str = None):
 # ============================================================
 # 自动上下文压缩摘要（v6.1）
 # 压缩在前端执行，后端只负责存储/读取摘要，为无缝换窗 v2 预留
-# 两个端点都在 /admin/* 下，受 AdminAuthMiddleware 保护（前端用 authFetch 带 Bearer）
 # ============================================================
 
 @app.post("/admin/compression-summary")

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -29,9 +29,8 @@ GATEWAY_PORT = int(os.getenv("PORT", "8080"))
 GATEWAY_BASE = f"http://127.0.0.1:{GATEWAY_PORT}"
 MCP_AUTH_TOKEN = os.getenv("MCP_AUTH_TOKEN", "")
 
-# 内部调用网关 API 时需要带上 ACCESS_TOKEN（认证中间件会检查）
-_access_token = os.getenv("ACCESS_TOKEN", "")
-GATEWAY_HEADERS = {"Authorization": f"Bearer {_access_token}"} if _access_token else {}
+# kiwi-mem 网关已移除访问密码，内部调用无需带认证头
+GATEWAY_HEADERS = {}
 
 
 # ============================================================


### PR DESCRIPTION
本 PR 包含两块易用性修复。

---

## 1) `/v1/models` 返回已配置供应商的模型，而非硬编码 OpenRouter

**问题**：第三方前端（ChatBox / Kelivo / NextChat / SillyTavern 等）连上网关后，通过标准 `GET /v1/models` 拉取模型下拉列表。但该端点过去直接读环境变量 `API_BASE_URL`（默认 OpenRouter）拉全量列表，**忽略管理面板里配置的供应商**；而聊天路由 `resolve_provider_for_model` 走的是数据库配置——两边口径错位，「列表里有、一发就路由不到」。自带前端读 `/admin/all-saved-models` 没暴露此问题。

**改动**：`/v1/models` 改用与聊天路由同一数据源，三级优先级：① 已启用供应商下实际保存的模型 → ② 未配置时回退环境变量 → ③ `DEFAULT_MODEL` 兜底。

- `database.py`：新增 `get_enabled_provider_models()`（只取 enabled 供应商、排除 embedding）
- `main.py`：重写 `GET /v1/models`，对同一模型多供应商去重

---

## 2) 移除访问密码（ACCESS_TOKEN）

**问题**：大量用户卡在 `ACCESS_TOKEN` 上报 401。这个密码**实际只保护 `/admin/`、`/sync/` 等路径，从不拦聊天接口**，却被 README 引导当成前端「API Key」去填，造成普遍的配置困惑与 401。

**改动**：开源版彻底移除访问密码，换取零门槛上手。

- `main.py`：删除 `ACCESS_TOKEN`、`AdminAuthMiddleware` 及注册；`/auth/verify` 收敛为始终放行的兼容空壳；移除无用 import
- `admin-panel/index.html`：去掉 token 存取、401 弹窗登录、sync 导出 token 参数
- `mcp_server.py`：内部调用不再附带认证头
- `.env.example` / `docker-compose.yml`：移除 `ACCESS_TOKEN` 配置项
- `README.md` / `README_EN.md`：删除门禁密码说明、改写 401 FAQ，新增安全提示

> ⚠️ **安全取舍（有意为之）**：移除后**管理面板 `/admin` 默认对外开放**——任何知道网关地址的人都能查看/修改记忆与配置。公网部署请自行用 Cloudflare Access、反代 Basic Auth 或 IP 白名单保护 `/admin`。README 已加此提示。
>
> 仅限开源版；私人后端 `ai-memory-gateway` 保持鉴权不变。

---

## 测试建议

- [ ] 配置供应商并保存模型 → `/v1/models` 只返回这些、`owned_by` 为供应商名；停用供应商后其模型消失
- [ ] 不设任何密码 → `/admin`、`/v1/chat/completions` 均可直接访问，无 401
- [ ] 前端 API Key 随便填非空值 → 聊天正常（网关不校验该 Key）
- [ ] 旧前端 `POST /auth/verify` → 返回 `{"status":"ok"}` 不报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)