### PR TITLE
fix: 同步私人后端逻辑修复到开源版（4 高危 + 双布尔 + 路由稳定 + 抽屉 + 测试）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,23 @@ jobs:
 
       - name: 编译检查所有 .py 文件（有语法错误这步就会变红）
         run: python -m compileall -q .
+
+  behavior-tests:
+    name: 行为测试（纯函数逻辑）
+    runs-on: ubuntu-latest
+    steps:
+      - name: 拉取代码
+        uses: actions/checkout@v4
+
+      - name: 准备 Python 3.12（与 Dockerfile 一致）
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: 安装测试所需依赖（detect_contradictions 在 database.py 里需要这三个）
+        run: pip install asyncpg httpx jieba
+
+      - name: 跑行为测试（思考链约束 + 矛盾检测 + 工具抽屉路由语义/并发快照）
+        run: |
+          python tests/test_logic.py
+          python tests/test_drawer.py

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,0 +1,60 @@
+# 已知问题登记（Known Issues）
+
+本文件登记代码审计发现、但**当前批次有意未修**的项：要么是设计取舍、要么是低危技术债、
+要么需要产品决策。修过的高危项见 git 历史，不在此列。
+
+> 行号为审计时的近似位置，经多次改动后可能有偏移，以函数名为准。
+
+---
+
+## 一、设计取舍（不视为 bug）
+
+- **纯 `.env` 部署只支持 OpenAI 格式。** Anthropic 原生必须经管理面板配置供应商
+  （README 已说明）。因此以下「硬编码 OpenAI / Bearer」是符合该约束的，不修：
+  - `/v1/models` 的环境变量兜底分支（`main.py` `list_models`）用 `Authorization: Bearer`。
+  - 切窗摘要压缩的异常兜底（`main.py` 约 3348）固定 `use_api_format="openai"`。
+  - `resolve_model_endpoint` 的环境变量兜底（`database.py` 约 3691）。
+- **`API_BASE_URL` 默认 OpenRouter** 是零配置默认值，刻意保留。
+
+---
+
+## 二、中危：待产品决策 / 需谨慎处理（暂缓）
+
+> ✅ 工具抽屉 auto 钉选语义分叉、并发快照不完整 —— 两项已在后续小 PR 修复：
+> auto 统一为纯语义路由（不读 `mcp_manual_ids`，与 `handle_meta_tool` 一致）、
+> 锁内一并快照 `_category_embeddings`/`CATEGORIES`/`TOOL_SCHEMAS`/`_external_categories`，
+> 并补了 `tests/test_drawer.py` 行为测试。不再列为待办。
+
+- **矛盾检测漏「纯数字/单字事实更新」**（`database.py` `detect_contradictions`）。
+  字符重叠兜底对「我女儿五岁 → 六岁」这类整句几乎相同、只改一个字的更新，会算成
+  近重复（>0.85）而漏判。`tests/test_logic.py` 有 INFO 标注当前行为。
+  → 根治需语义/数值感知，非字符重叠能解决，留待后续。
+
+---
+
+## 三、低危技术债（登记备查）
+
+### 工具 / MCP / 搜索
+- 外部 MCP **不支持鉴权**：`_normalize_external_servers` 丢弃 `auth`/`headers`，
+  client 也不透传；需要 Bearer 的外部 MCP 会 401，且失败被吞成「该 server 无工具」。
+- 自家 MCP 靠 URL 子串 `"/memory/mcp"`/`"/calendar/mcp"` 识别（`tool_drawer.py` ~394），
+  改挂载路径会失效、导致自家工具被当外部重复注册。
+- 本地搜索引擎（Bing/Google/Baidu）用正则匹配结果页 class（`web_search.py` ~252）；
+  页面改版会静默返回 0 条，与「真无结果」无法区分（建议加解析失败告警日志）。
+- `record_tool_use` 在 session 被 LRU 淘汰后静默 no-op（`tool_drawer.py` ~940）；影响极小。
+
+### 认知后台（Dream / 整理 / 提取）
+- Dream 自动触发阈值 `5/7/3` 硬编码（`dream.py` ~780），且与可配的
+  `dream_drowsy_threshold`（默认 30）两套标准不一致。
+- Dream 软化参数 `min_age=5, limit=15` 硬编码（`dream.py` ~183），与 `daily_digest`
+  里可配的软化参数（`auto_soften_min_age` 等）不同源。
+- `update_user_profile` 模型回退链漏读 `default_digest_model`（`daily_digest.py` ~143），
+  与同模块其它整理任务不一致。
+- 后台任务兜底默认模型名硬编码 `anthropic/claude-haiku-4`（OpenRouter 命名风格），
+  非 OpenRouter 供应商上该 model_id 可能 404（dream / daily_digest / memory_extractor）。
+
+### 主服务
+- `/admin/credits` 余额查询的环境变量兜底只认 OpenRouter（`main.py` ~3995）；
+  纯 .env 的非 OpenRouter 部署拿不到余额（仅影响余额展示）。
+- OpenAI 格式 URL 拼接假设单一 `/chat/completions` 后缀（`main.py` ~1465）；
+  用户把 base 误填成带其它后缀时会拼出错误路径。

--- a/anthropic_adapter.py
+++ b/anthropic_adapter.py
@@ -87,6 +87,12 @@ def to_anthropic_request(openai_body: dict) -> dict:
             budget = 5000
         elif effort == "high":
             budget = 20000
+        # Anthropic 硬性要求 budget_tokens < max_tokens（max_tokens 含思考 + 可见输出）。
+        # 默认 max_tokens=8192 < 默认 budget=10000（high 时 20000）会被 API 直接 400。
+        # 开启思考时，若 max_tokens 不足以容纳 budget，则上调到 budget 之上并留出可见
+        # 输出余量；只在会非法时才动，不影响调用方显式给的更大 max_tokens。
+        if body["max_tokens"] <= budget:
+            body["max_tokens"] = budget + 4096
         body["thinking"] = {"type": "enabled", "budget_tokens": budget}
         # Anthropic extended thinking 要求 temperature == 1
         body["temperature"] = 1

--- a/database.py
+++ b/database.py
@@ -2188,6 +2188,11 @@ async def resolve_provider_for_model(model_id: str):
     """根据 model_id 查找对应的已启用供应商，返回 {api_base_url, api_key, api_format, provider_name} 或 None
 
     api_format 优先级：模型级 > 供应商级 > 默认 'openai'
+
+    同一个 model_id 可能在多个已启用供应商下注册。用确定性 ORDER BY（供应商名→id）
+    选第一个，保证：① 路由结果稳定，不随 Postgres 物理顺序漂移；② 与对外 /v1/models
+    （get_enabled_provider_models 按 p.name 排序）口径一致——前端看到的同名模型归属，
+    就是实际路由到的那个供应商。
     """
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -2198,6 +2203,7 @@ async def resolve_provider_for_model(model_id: str):
             FROM provider_models pm
             JOIN providers p ON pm.provider_id = p.id
             WHERE pm.model_id = $1 AND p.enabled = TRUE
+            ORDER BY p.name ASC, p.id ASC
             LIMIT 1
         """, model_id)
         return dict(row) if row else None
@@ -3549,9 +3555,22 @@ def detect_contradictions(new_title: str, new_content: str, similar_results: lis
         if title_sim < title_threshold:
             continue
         
-        # 内容相似度：用 search_memories 已经算好的 similarity
-        content_sim = mem.get("similarity", 0)
-        
+        # 内容相似度：优先用 search_memories 已经算好的向量 similarity
+        content_sim = mem.get("similarity", 0) or 0
+
+        # 修复：关键词命中路径会把 similarity 硬编码成 0.0，embedding 服务降级时整批结果
+        # 也全是 0.0——此时 0 表示「没算过」而非「不相似」，不能直接判否漏掉矛盾。
+        # 退化为字符重叠度（与上面标题、与去重检测同一套简单算法，口径一致、不引新阈值）。
+        # 注意：仅在向量相似度缺失时才兜底，不改变正常向量路径的行为，避免误伤。
+        if content_sim <= 0:
+            old_content = mem.get("content", "") or ""
+            if new_content and old_content:
+                new_content_chars = set(c for c in new_content if '一' <= c <= '鿿' or c.isalpha())
+                old_content_chars = set(c for c in old_content if '一' <= c <= '鿿' or c.isalpha())
+                if len(new_content_chars) >= 2 and len(old_content_chars) >= 2:
+                    overlap_c = new_content_chars & old_content_chars
+                    content_sim = len(overlap_c) / max(len(new_content_chars), len(old_content_chars))
+
         # 相似度在 0.4-0.85 之间 = 相关但不同（疑似矛盾/更新）
         # > 0.85 已经被去重检测处理了，< 0.4 说明不是同一件事
         if 0.4 <= content_sim <= 0.85:

--- a/main.py
+++ b/main.py
@@ -1258,6 +1258,35 @@ async def chat_completions(request: Request):
         model = DEFAULT_MODEL
     body["model"] = model
 
+    # ---------- 供应商路由（提前解析）----------
+    # 提前解析供应商，使本次请求链路里所有「是否走 Anthropic / 是否 OpenRouter」的判断
+    # 都基于权威来源 api_format，而不是靠 URL 或模型名字符串去猜（历史 bug 的根因）。
+    # 解析出两个布尔，本函数后续统一使用：
+    #   is_anthropic_fmt —— 该供应商是否走 Anthropic 原生格式（来自 DB 的 api_format）
+    #   is_openrouter    —— 上游是否 OpenRouter（仅用于 OpenRouter 专属字段/请求头）
+    try:
+        provider_info = await resolve_provider_for_model(model)
+    except Exception:
+        provider_info = None
+
+    api_format = "openai"  # 默认 OpenAI 格式
+    if provider_info:
+        chat_api_key = provider_info["api_key"]
+        api_format = provider_info.get("api_format", "openai") or "openai"
+        base = provider_info["api_base_url"].rstrip("/")
+        if api_format == "anthropic":
+            chat_api_url = get_anthropic_url(base)
+            print(f"🔀 路由到供应商 [{provider_info['provider_name']}] (Anthropic 格式): {chat_api_url}")
+        else:
+            chat_api_url = base if base.endswith("/chat/completions") else f"{base}/chat/completions"
+            print(f"🔀 路由到供应商 [{provider_info['provider_name']}]: {base}")
+    else:
+        chat_api_key = API_KEY
+        chat_api_url = API_BASE_URL
+
+    is_anthropic_fmt = (api_format == "anthropic")
+    is_openrouter = "openrouter" in chat_api_url.lower()
+
     mem_enabled = await get_memory_enabled()
     prompt_meta = {}
     if not skip_prompt:
@@ -1287,13 +1316,10 @@ async def chat_completions(request: Request):
                 messages.insert(0, {"role": "system", "content": enhanced_prompt})
             
             # ---- Prompt Caching：把 system message 拆成静态/动态两个 content block ----
-            # Anthropic/Claude 支持 OpenAI 兼容格式里的显式 cache_control 断点。
-            # Gemini/DeepSeek 等模型的缓存机制和请求格式不统一，避免在这里强行改写。
-            _model_for_cache = body.get("model", "").lower()
-            supports_explicit_cache = any(
-                name in _model_for_cache
-                for name in ("claude", "anthropic")
-            )
+            # 是否支持显式 cache_control 断点，以供应商的 api_format 为准（权威来源），
+            # 不再靠模型名里有没有 "claude"/"anthropic" 猜——否则 Anthropic 直连但模型
+            # 用了自定义别名时会漏打缓存断点，白白多花输入费用。
+            supports_explicit_cache = is_anthropic_fmt
             cache_enabled_val = await get_config("prompt_cache_enabled")
             cache_on = supports_explicit_cache and (cache_enabled_val is None or str(cache_enabled_val).lower() != 'false')
             
@@ -1372,28 +1398,9 @@ async def chat_completions(request: Request):
     # model 已在 prompt cache 判断前标准化，避免缺省 model 请求跳过缓存。
     
     # ---------- 供应商路由 ----------
-    # 根据 model_id 查找已配置的供应商，找不到就用全局环境变量
-    # 如果数据库不可用（DATABASE_URL 未设置），也降级到环境变量
-    try:
-        provider_info = await resolve_provider_for_model(model)
-    except Exception:
-        provider_info = None
+    # 已在前面（确定 model 后）提前解析：provider_info / api_format / chat_api_key /
+    # chat_api_url / is_anthropic_fmt / is_openrouter 均已就绪，这里不再重复解析。
 
-    api_format = "openai"  # 默认 OpenAI 格式
-    if provider_info:
-        chat_api_key = provider_info["api_key"]
-        api_format = provider_info.get("api_format", "openai") or "openai"
-        base = provider_info["api_base_url"].rstrip("/")
-        if api_format == "anthropic":
-            chat_api_url = get_anthropic_url(base)
-            print(f"🔀 路由到供应商 [{provider_info['provider_name']}] (Anthropic 格式): {chat_api_url}")
-        else:
-            chat_api_url = base if base.endswith("/chat/completions") else f"{base}/chat/completions"
-            print(f"🔀 路由到供应商 [{provider_info['provider_name']}]: {base}")
-    else:
-        chat_api_key = API_KEY
-        chat_api_url = API_BASE_URL
-    
     # ---------- MCP 工具调用 ----------
     mcp_mode_raw = body.pop("mcp_mode", None)
     # Explicit request-body MCP servers are a compatibility path and are not governed by mcp_mode.
@@ -1423,15 +1430,16 @@ async def chat_completions(request: Request):
     if body.get("stream"):
         body.setdefault("stream_options", {})["include_usage"] = True
     
-    # OpenRouter：配置思考链参数
-    if "openrouter" in chat_api_url:
+    # 思考链参数：OpenRouter 用 reasoning 字段；Anthropic 直连也设 reasoning.enabled，
+    # 由 to_anthropic_request 转换成 extended thinking——否则 Anthropic 直连永远拿不到思考链。
+    if is_openrouter or is_anthropic_fmt:
         reasoning_effort = body.pop("reasoning_effort", None)
         reasoning_cfg = {"enabled": True}
         if reasoning_effort and reasoning_effort in ("low", "medium", "high"):
             reasoning_cfg["effort"] = reasoning_effort
         body["reasoning"] = reasoning_cfg
     else:
-        # 非 OpenRouter 供应商，reasoning_effort 保持原样传给 API（DeepSeek 等会忽略不认识的参数）
+        # 其它 OpenAI 兼容供应商，reasoning_effort 保持原样传给 API（DeepSeek 等会忽略不认识的参数）
         pass
     
     # ---------- Prompt 缓存（v5.5 → v5.7 修正）----------
@@ -1441,20 +1449,20 @@ async def chat_completions(request: Request):
     # ---------- Claude Provider 偏好 ----------
     # 优先走 Anthropic 直连（缓存支持最好），允许回退
     model_lower_for_provider = model.lower()
-    if ("claude" in model_lower_for_provider or "anthropic" in model_lower_for_provider) and "openrouter" in chat_api_url:
+    if is_openrouter and ("claude" in model_lower_for_provider or "anthropic" in model_lower_for_provider):
         if "provider" not in body:
             body["provider"] = {"order": ["Anthropic"], "allow_fallbacks": True}
             print(f"🔀 Provider 偏好：优先 Anthropic 直连")
 
     # ---------- 转发请求 ----------
-    if api_format == "anthropic":
+    if is_anthropic_fmt:
         headers = to_anthropic_headers(chat_api_key)
     else:
         headers = {
             "Authorization": f"Bearer {chat_api_key}",
             "Content-Type": "application/json",
         }
-        if "openrouter" in chat_api_url:
+        if is_openrouter:
             headers["HTTP-Referer"] = EXTRA_REFERER
             headers["X-Title"] = EXTRA_TITLE
     
@@ -1727,6 +1735,12 @@ async def _execute_gateway_tool(tool_name: str, arguments: dict, tool_info: dict
             search_api_key = await get_config("search_api_key") or ""
             search_max = await get_config_int("search_max_results", fallback=5)
 
+            # 未配置搜索引擎时明确告知，不能让它落到 web_search 返回空、伪装成「搜了但无结果」
+            # ——否则模型会以为搜过了没找到，进而编造答案，掩盖了「根本没配引擎」的真因。
+            if not search_engine:
+                print(f"⚠️ [auto] 模型请求联网搜索，但未配置搜索引擎")
+                return "联网搜索未配置搜索引擎，无法搜索。请在管理面板配置后再试。", extra
+
             print(f"🌐 [auto] 模型请求联网搜索: [{search_engine}] {query[:80]}")
             results = await web_search(
                 query=query[:200],
@@ -1899,6 +1913,10 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
     _api_url = api_url or API_BASE_URL
     _api_key = api_key or API_KEY
 
+    # 与主请求链路同口径：用 api_format（权威来源）+ URL 判断收敛成两个布尔
+    _is_anthropic_fmt = (api_format == "anthropic")
+    _is_openrouter = "openrouter" in _api_url.lower()
+
     # 先发送衔接提示（如果有无缝切窗）
     if prompt_meta and prompt_meta.get("handoff"):
         yield f"data: {json.dumps({'ev_handoff': prompt_meta['handoff']}, ensure_ascii=False)}\n\n"
@@ -1907,14 +1925,14 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
     for evt in (tool_events or []):
         yield f"data: {json.dumps({'ev_tool': evt}, ensure_ascii=False)}\n\n"
 
-    if api_format == "anthropic":
+    if _is_anthropic_fmt:
         headers = to_anthropic_headers(_api_key)
     else:
         headers = {
             "Authorization": f"Bearer {_api_key}",
             "Content-Type": "application/json",
         }
-        if "openrouter" in _api_url:
+        if _is_openrouter:
             headers["HTTP-Referer"] = EXTRA_REFERER
             headers["X-Title"] = EXTRA_TITLE
 
@@ -1931,9 +1949,10 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
             "temperature": temperature,
             "stream": False,
         }
-        # OpenRouter：非流式也启用思考链，这样最终回复直接输出时不丢思考内容
-        # （Anthropic 直连不需要这个 OpenRouter 私有字段）
-        if api_format == "openai" and "openrouter" in _api_url:
+        # 非流式也启用思考链，这样最终回复直接输出时不丢思考内容。
+        # OpenRouter 用 reasoning 字段；Anthropic 直连也设上，由 to_anthropic_request 转成
+        # extended thinking——否则 Anthropic 直连在工具循环里同样拿不到思考链。
+        if _is_openrouter or _is_anthropic_fmt:
             body["reasoning"] = {"enabled": True}
 
         # Anthropic 格式转换

--- a/tests/test_drawer.py
+++ b/tests/test_drawer.py
@@ -1,0 +1,129 @@
+"""
+工具抽屉路由行为测试（无需数据库 / 不联网）。
+
+通过直接设置 tool_drawer 的模块级注册表 + 打桩 config/refresh，验证 route_tools 的三条
+关键语义（对应 PR 约定）：
+
+  1. auto 模式 = 纯语义路由：切到 auto 后，手动钉选（mcp_manual_ids）的外部 MCP 工具
+     不被强制展开（无语义命中时不出现）。
+  2. manual 模式 = 只尊重手动钉选：mcp_manual_ids 命中的外部类别被展开。
+  3. 并发刷新安全：route_tools 在锁内对注册表做快照后，即使 live registry 在遍历前被
+     并发刷新清空，本轮仍从快照拿到工具，不读半更新状态。
+
+运行：python tests/test_drawer.py   （退出码非 0 表示有用例失败）
+"""
+
+import sys
+import os
+import json
+import asyncio
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import tool_drawer as td
+import config
+
+_failures = []
+
+
+def check(name, cond):
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+    if not cond:
+        _failures.append(name)
+
+
+# ── 打桩：避免触网 / 触库 ─────────────────────────────────────
+async def _noop_refresh():
+    return
+
+
+async def _get_config_float(key, fallback=0.0):
+    return fallback
+
+
+async def _get_config_int(key, fallback=0):
+    return fallback
+
+
+_manual_ids = {"ids": []}
+
+
+async def _get_config(key, default=None):
+    if key == "mcp_manual_ids":
+        return json.dumps(_manual_ids["ids"])
+    return default
+
+
+td.refresh_external_drawers = _noop_refresh
+config.get_config_float = _get_config_float
+config.get_config_int = _get_config_int
+config.get_config = _get_config
+
+
+def setup_registry():
+    """重置注册表，只放一个外部类别 weather（含一个工具 + 对齐 [1,0] 的 embedding）。"""
+    for d in (td.CATEGORIES, td._external_categories, td.TOOL_SCHEMAS, td._category_embeddings, td._sessions):
+        d.clear()
+    td.CATEGORIES["weather"] = {
+        "label": "Weather", "description": "天气查询", "keywords": ["weather"],
+        "tool_names": ["get_weather"], "external": True,
+    }
+    td._external_categories["weather"] = {
+        "label": "Weather", "server_name": "weather",
+        "tool_map": {"get_weather": {"type": "external_mcp", "origin_name": "get_weather"}},
+    }
+    td.TOOL_SCHEMAS["get_weather"] = {
+        "type": "function",
+        "function": {"name": "get_weather", "description": "", "parameters": {"type": "object", "properties": {}}},
+    }
+    td._category_embeddings["weather"] = [1.0, 0.0]
+
+
+def names(openai_tools):
+    return {t["function"]["name"] for t in openai_tools if "function" in t}
+
+
+async def run():
+    print("== route_tools：auto / manual 钉选语义 + 并发快照 ==")
+
+    # 1) auto + 钉选 weather + 无语义命中（embedding 正交、消息无关键词）→ 不应展开
+    setup_registry()
+    _manual_ids["ids"] = ["weather"]
+    tools, _ = await td.route_tools("hello there", "s1", user_embedding=[0.0, 1.0],
+                                    mem_enabled=True, search_enabled=True, mcp_mode="auto")
+    check("auto：钉选的外部工具不被强制展开（无语义命中时）", "get_weather" not in names(tools))
+
+    # 2) manual + 钉选 weather → 应展开
+    setup_registry()
+    _manual_ids["ids"] = ["weather"]
+    tools, _ = await td.route_tools("hello there", "s2", user_embedding=[0.0, 1.0],
+                                    mem_enabled=True, search_enabled=True, mcp_mode="manual")
+    check("manual：钉选的外部工具被展开", "get_weather" in names(tools))
+
+    # 3) 并发刷新：auto 下 weather 语义命中（embedding 对齐 [1,0]），但在快照之后、遍历之前
+    #    通过打桩 _external_keyword_match 清空 live registry，模拟并发刷新把注册表清掉。
+    #    若 route_tools 读 live → 工具丢失；读快照 → 仍在。
+    setup_registry()
+    _manual_ids["ids"] = []
+    _orig = td._external_keyword_match
+
+    def _wipe_then_match(msg, ext=None, cats=None):
+        for d in (td.CATEGORIES, td._external_categories, td.TOOL_SCHEMAS, td._category_embeddings):
+            d.clear()
+        return set()
+
+    td._external_keyword_match = _wipe_then_match
+    try:
+        tools, _ = await td.route_tools("weather", "s3", user_embedding=[1.0, 0.0],
+                                        mem_enabled=True, search_enabled=True, mcp_mode="auto")
+    finally:
+        td._external_keyword_match = _orig
+    check("并发刷新清空 live registry 后，route_tools 仍从快照拿到工具", "get_weather" in names(tools))
+
+
+asyncio.run(run())
+
+if _failures:
+    print(f"\n❌ {len(_failures)} 个用例失败：{_failures}")
+    sys.exit(1)
+print("\n✅ 全部用例通过")

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,119 @@
+"""
+纯函数行为测试（无需数据库 / 不联网）。
+
+专门守护那类「读代码看不出、实跑才暴露」的逻辑：
+
+  1. anthropic_adapter.to_anthropic_request 的 extended thinking 约束
+     —— Anthropic 硬性要求 budget_tokens < max_tokens，否则请求被 API 直接 400。
+        这是 PR review 实测发现的阻断点，必须有回归守护。
+
+  2. database.detect_contradictions 的矛盾检测
+     —— 保护逻辑（手动 / 锁定记忆不自动失效）+ similarity 缺失（关键词命中 /
+        embedding 降级）时的字符重叠兜底。
+
+运行：python tests/test_logic.py   （退出码非 0 表示有用例失败）
+CI 在装好依赖后运行本文件。
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from anthropic_adapter import to_anthropic_request
+from database import detect_contradictions
+
+_failures = []
+
+
+def check(name, cond):
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+    if not cond:
+        _failures.append(name)
+
+
+# ============================================================
+# 1. to_anthropic_request：思考链 budget < max_tokens
+# ============================================================
+def _req(reasoning=None, max_tokens=None):
+    body = {"model": "x", "messages": [{"role": "user", "content": "hi"}]}
+    if reasoning is not None:
+        body["reasoning"] = reasoning
+    if max_tokens is not None:
+        body["max_tokens"] = max_tokens
+    return to_anthropic_request(body)
+
+
+print("== to_anthropic_request：extended thinking 约束 ==")
+
+b = _req({"enabled": True})
+check("默认 effort：budget < max_tokens", b["thinking"]["budget_tokens"] < b["max_tokens"])
+
+b = _req({"enabled": True, "effort": "low"})
+check("low effort：budget < max_tokens", b["thinking"]["budget_tokens"] < b["max_tokens"])
+
+b = _req({"enabled": True, "effort": "high"})
+check("high effort：budget < max_tokens", b["thinking"]["budget_tokens"] < b["max_tokens"])
+
+b = _req({"enabled": True, "effort": "high"}, max_tokens=40000)
+check("显式大 max_tokens 不被压低", b["max_tokens"] == 40000 and b["thinking"]["budget_tokens"] < b["max_tokens"])
+
+b = _req()
+check("无 reasoning 时不生成 thinking", "thinking" not in b)
+
+b = _req({"enabled": False})
+check("reasoning.enabled=False 时不生成 thinking", "thinking" not in b)
+
+
+# ============================================================
+# 2. detect_contradictions：保护逻辑 + similarity 兜底
+# ============================================================
+def mem(id, title, content, similarity=0, source="extracted", is_permanent=False):
+    return {"id": id, "title": title, "content": content,
+            "similarity": similarity, "source": source, "is_permanent": is_permanent}
+
+
+print("== detect_contradictions：保护逻辑 + similarity 兜底 ==")
+
+# 基础：标题相同、向量相似度 0.6（相关但不同）→ 判为疑似矛盾
+res = detect_contradictions("工作单位", "我现在在阿里巴巴工作",
+                            [mem(1, "工作单位", "我现在在腾讯工作", similarity=0.6)])
+check("中等相似度的更新被判为矛盾", 1 in res)
+
+# 保护：手动录入（user_explicit）永不自动失效
+res = detect_contradictions("工作单位", "我现在在阿里巴巴工作",
+                            [mem(2, "工作单位", "我现在在腾讯工作", similarity=0.6, source="user_explicit")])
+check("手动记忆(user_explicit)不被标矛盾", 2 not in res)
+
+# 保护：锁定记忆（is_permanent）永不自动失效
+res = detect_contradictions("工作单位", "我现在在阿里巴巴工作",
+                            [mem(3, "工作单位", "我现在在腾讯工作", similarity=0.6, is_permanent=True)])
+check("锁定记忆(is_permanent)不被标矛盾", 3 not in res)
+
+# 兜底修复：关键词路径 similarity=0，但内容字符重叠为中等 → 仍能检出矛盾
+res = detect_contradictions("工作单位", "我现在在阿里巴巴上班工作",
+                            [mem(4, "工作单位", "我现在在腾讯公司上班工作", similarity=0)])
+check("similarity=0 时靠字符重叠兜底仍能检出矛盾", 4 in res)
+
+# 边界：内容完全无关 → 不判矛盾（即使标题相同）
+res = detect_contradictions("工作单位", "我现在在阿里巴巴上班工作",
+                            [mem(5, "工作单位", "今天天气很好出去散步看电影", similarity=0)])
+check("内容无关时不判矛盾", 5 not in res)
+
+# 边界：近乎重复（向量 0.95 > 0.85）→ 交给去重处理，不判矛盾
+res = detect_contradictions("工作单位", "我现在在阿里巴巴工作",
+                            [mem(6, "工作单位", "我现在在阿里巴巴工作", similarity=0.95)])
+check("近重复(>0.85)不判矛盾(交给去重)", 6 not in res)
+
+# 已知残余风险（仅打印提醒，不作失败断言）：纯数字/单字更新且整句几乎相同时，
+# 字符重叠会算成近重复而漏判。详见 KNOWN_ISSUES.md（中危第二批后续项）。
+res = detect_contradictions("女儿年龄", "我女儿今年六岁",
+                            [mem(7, "女儿年龄", "我女儿今年五岁", similarity=0)])
+print(f"  [INFO] 已知残余：纯数字/单字更新可能漏判（当前 7 in res = {7 in res}），见 KNOWN_ISSUES.md")
+
+
+# ============================================================
+if _failures:
+    print(f"\n❌ {len(_failures)} 个用例失败：{_failures}")
+    sys.exit(1)
+print("\n✅ 全部用例通过")

--- a/tool_drawer.py
+++ b/tool_drawer.py
@@ -343,13 +343,17 @@ def _external_keywords(server_name, origin_names):
     return list(dict.fromkeys(keywords))
 
 
-def _external_keyword_match(user_message):
+def _external_keyword_match(user_message, external_categories=None, categories=None):
+    # 默认读 live 全局；route_tools 传入本轮快照，保证与 embedding 快照同口径、
+    # 不在并发刷新时读到半更新的注册表。
+    external_categories = external_categories if external_categories is not None else _external_categories
+    categories = categories if categories is not None else CATEGORIES
     msg = (user_message or "").lower()
     matched = set()
     if not msg:
         return matched
-    for cat_id in _external_categories:
-        keywords = CATEGORIES.get(cat_id, {}).get("keywords", [])
+    for cat_id in external_categories:
+        keywords = categories.get(cat_id, {}).get("keywords", [])
         for kw in keywords:
             keyword = str(kw or "").lower()
             if not keyword:
@@ -565,8 +569,10 @@ async def force_refresh_external_drawers():
     await refresh_external_drawers(force=True)
 
 
-async def _get_pinned_external_categories():
-    if not _external_categories:
+async def _get_pinned_external_categories(external_categories=None):
+    # 默认读 live 全局；route_tools 传入本轮快照，保证与其它快照同口径。
+    external_categories = external_categories if external_categories is not None else _external_categories
+    if not external_categories:
         return set()
     try:
         from config import get_config
@@ -582,7 +588,7 @@ async def _get_pinned_external_categories():
         return set()
 
     pinned = set()
-    for cat_id, meta in _external_categories.items():
+    for cat_id, meta in external_categories.items():
         names = {
             cat_id.lower(),
             str(meta.get("label", "")).lower(),
@@ -712,26 +718,36 @@ async def route_tools(user_message, session_id, user_embedding=None, mem_enabled
     if mode not in ("off", "auto", "manual"):
         mode = "auto"
     external_auto = mode == "auto"
-    external_pinned = mode in ("auto", "manual")
+    # auto = 纯语义路由：切到 auto 后不保留手动钉选，外部工具完全交给语义/关键词决定。
+    # 只有 manual 模式才尊重 mcp_manual_ids。这与 handle_meta_tool 的判定（mode=='manual'）
+    # 一致，消除两条路径对「auto 是否尊重钉选」给出相反答案的分叉。
+    external_pinned = mode == "manual"
 
     await refresh_external_drawers()
-    # Bug #4：在锁内对注册表做一次快照，避免遍历期间被并发刷新改成半成品
+    # Bug #4：在锁内对注册表做一次快照，避免遍历期间被并发刷新改成半成品。
+    # 刷新（_unregister/_refresh_external_drawers_impl）是「pop 旧 + 赋新 dict」整体替换，
+    # 故浅拷贝足够冻住本轮所需的引用：即使刷新随后清空/重建 live 字典，快照仍自洽。
+    # 注意：这些快照在同一把锁内同一瞬间取，彼此口径一致。
     async with _refresh_lock:
         cat_embeddings_snapshot = dict(_category_embeddings)
+        categories_snapshot = dict(CATEGORIES)
+        external_categories_snapshot = dict(_external_categories)
+        tool_schemas_snapshot = dict(TOOL_SCHEMAS)
+        meta_tools_snapshot = list(META_TOOLS)
     if len(_sessions) > 200:
         _cleanup_sessions()
 
     session = _get_session(session_id)
     session["mcp_mode"] = mode
     matched_categories = set()
-    pinned_external = await _get_pinned_external_categories() if external_pinned else set()
-    external_keyword_hits = _external_keyword_match(user_message) if external_auto else set()
+    pinned_external = await _get_pinned_external_categories(external_categories_snapshot) if external_pinned else set()
+    external_keyword_hits = _external_keyword_match(user_message, external_categories_snapshot, categories_snapshot) if external_auto else set()
     external_scores = {}
 
     if user_embedding and cat_embeddings_snapshot:
         scores = {}
         for cat_id, cat_emb in cat_embeddings_snapshot.items():
-            is_external = cat_id in _external_categories
+            is_external = cat_id in external_categories_snapshot
             if is_external and not external_auto:
                 continue
             score = cosine_similarity(user_embedding, cat_emb)
@@ -757,7 +773,7 @@ async def route_tools(user_message, session_id, user_embedding=None, mem_enabled
         if matched_categories:
             print(f"\U0001f5c3\ufe0f  抽屉路由（关键词降级）：命中 {matched_categories}")
 
-    external_category_ids = set(_external_categories.keys())
+    external_category_ids = set(external_categories_snapshot.keys())
     if external_auto:
         external_candidates = (matched_categories & external_category_ids) | external_keyword_hits
         if external_keyword_hits:
@@ -798,11 +814,11 @@ async def route_tools(user_message, session_id, user_embedding=None, mem_enabled
     openai_tools = []
     tool_map = {}
     for cat_id in active_categories:
-        cat = CATEGORIES.get(cat_id)
+        cat = categories_snapshot.get(cat_id)
         if not cat:
             continue
         for tool_name in cat["tool_names"]:
-            schema = TOOL_SCHEMAS.get(tool_name)
+            schema = tool_schemas_snapshot.get(tool_name)
             if not schema:
                 continue
             openai_tools.append(schema)
@@ -812,7 +828,7 @@ async def route_tools(user_message, session_id, user_embedding=None, mem_enabled
                     route_info["project_id"] = project_id
                 tool_map[tool_name] = route_info
             elif cat.get("external"):
-                ext_map = _external_categories.get(cat_id, {}).get("tool_map", {})
+                ext_map = external_categories_snapshot.get(cat_id, {}).get("tool_map", {})
                 tool_map[tool_name] = ext_map.get(tool_name, {
                     "type": "external_mcp",
                     "server_url": "",
@@ -824,12 +840,12 @@ async def route_tools(user_message, session_id, user_embedding=None, mem_enabled
             else:
                 tool_map[tool_name] = {"type": "drawer", "handler": tool_name}
 
-    # Always include meta-tools
-    for mt in META_TOOLS:
+    # Always include meta-tools（同样读本轮快照，与其它注册表口径一致）
+    for mt in meta_tools_snapshot:
         openai_tools.append(mt)
         tool_map[mt["function"]["name"]] = {"type": "meta", "handler": "drawer_meta"}
 
-    expanded_count = len(openai_tools) - len(META_TOOLS)
+    expanded_count = len(openai_tools) - len(meta_tools_snapshot)
     if expanded_count > 0:
         print(f"\U0001f5c3\ufe0f  展开 {expanded_count} 个工具 + {len(META_TOOLS)} meta = {len(openai_tools)} total")
     else:


### PR DESCRIPTION
开源 kiwi-mem 是从私人后端移植的，**私人后端审计修掉的那批 bug，这里全数同样存在**（已逐处核实）。本 PR 把整套修复对照 kiwi 的写法移植过来，并带上行为测试。对应私人后端的 #16/#17/#18。

## 高危（开源用户实打实命中）

| # | 问题 | 修法 |
|---|---|---|
| H1 | 缓存断点靠模型名判断，Anthropic 直连用自定义别名时漏缓存、白花钱 | 改用 `is_anthropic_fmt` |
| H2 | `reasoning` 只在 `"openrouter" in url` 时设，Anthropic 直连永远没思考链 | `is_openrouter or is_anthropic_fmt`，经 `to_anthropic_request` 转 extended thinking；主路径 + 工具循环都修 |
| — | 开 thinking 时 `budget(10000) > max_tokens(8192)` 会被 Anthropic 直接 **400** | 按需上调 max_tokens，保证 `budget < max_tokens` |
| H3 | 矛盾失效：关键词/embedding 降级时 `similarity=0` 漏判矛盾 | 视为「没算过」按字符重叠兜底；**保留手动/锁定记忆不失效的保护** |
| H4 | 联网搜索 auto 未配引擎时伪装成「搜了但无结果」，诱导模型编答案 | 明确返回「未配置搜索引擎」 |

## 根治重构 + 中危

- **双布尔收敛**：确定 model 后提前解析供应商，算出 `is_anthropic_fmt` / `is_openrouter`（权威来源 = DB 的 `api_format`），主请求链路 + 工具循环统一使用，替换散落各处的 `"openrouter" in url` / `"claude" in model_name`「猜」。
- **路由稳定（M-d）**：`resolve_provider_for_model` 加确定性 `ORDER BY p.name, p.id`，消除同模型多供应商路由漂移、与 `/v1/models` 展示口径对齐。

## 工具抽屉

- **auto = 纯语义路由**：`external_pinned` 仅 `mode == "manual"` 启用，切到 auto 不保留手动钉选；与 `handle_meta_tool` 一致。
- **并发快照修全**：`_refresh_lock` 内一并快照 embedding / CATEGORIES / TOOL_SCHEMAS / `_external_categories` / META_TOOLS，`route_tools` 后续全读快照，并发刷新不再丢工具。

## 测试 + CI

- 新增 `tests/test_logic.py`（思考链约束 + 矛盾检测保护/兜底）、`tests/test_drawer.py`（auto/manual 钉选语义 + 并发快照），**本地全绿**。
- CI 新增 `behavior-tests` job。
- 新增 `KNOWN_ISSUES.md` 登记设计取舍（纯 .env=OpenAI 格式等）与低危项。

## 说明

逐处对照 kiwi 写法移植，非照搬。kiwi 与私人后端这些函数结构高度一致，故修法等价；行为测试在 kiwi 上同样全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0184ijsWwVCZj5oyKVsc7eTw)_