### PR TITLE
chore(low): 顺手清理一批低危技术债（与私人后端同步）

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -34,27 +34,26 @@
 
 ## 三、低危技术债（登记备查）
 
+> ✅ 已在「顺手清低危」批次修复（不再列为待办）：
+> - Dream 软化参数改读已有配置 `auto_soften_*`（不再写死 5/15、不漏 cooldown）
+> - `update_user_profile` 回退链补 `default_digest_model`
+> - `/admin/credits` 环境兜底改用通用查询 `_query_generic_credits`（不再只认 OpenRouter）
+> - OpenAI URL 拼接前归一化后缀（误填 `.../messages`、`.../chat/completions` 不再拼错）
+> - 本地搜索解析到 0 条但页面非空时打告警日志（区分「解析失败」与「真无结果」）
+
 ### 工具 / MCP / 搜索
-- 外部 MCP **不支持鉴权**：`_normalize_external_servers` 丢弃 `auth`/`headers`，
-  client 也不透传；需要 Bearer 的外部 MCP 会 401，且失败被吞成「该 server 无工具」。
-- 自家 MCP 靠 URL 子串 `"/memory/mcp"`/`"/calendar/mcp"` 识别（`tool_drawer.py` ~394），
-  改挂载路径会失效、导致自家工具被当外部重复注册。
-- 本地搜索引擎（Bing/Google/Baidu）用正则匹配结果页 class（`web_search.py` ~252）；
-  页面改版会静默返回 0 条，与「真无结果」无法区分（建议加解析失败告警日志）。
-- `record_tool_use` 在 session 被 LRU 淘汰后静默 no-op（`tool_drawer.py` ~940）；影响极小。
+- 外部 MCP **不支持鉴权**：`_normalize_external_servers` 丢弃 `auth`/`headers`，client 也不透传；
+  需要 Bearer 的外部 MCP 会 401、且失败被吞成「该 server 无工具」。
+  → 属「加能力」而非小修（要给 transport client 透传 header），单独评估，暂留。
+- 自家 MCP 靠 URL 子串 `"/memory/mcp"`/`"/calendar/mcp"` 识别（`tool_drawer.py`），改挂载路径会失效。
+  → 现行挂载下有效，硬化收益有限，暂留。
+- 本地搜索引擎正则匹配结果页 class（`web_search.py`），页面改版会解析到 0 条。
+  → **已加告警日志**区分「解析失败」与「真无结果」；但正则本身仍随页面改版失效，根治需换解析方式。
+- `record_tool_use` 在 session 被 LRU 淘汰后静默 no-op（`tool_drawer.py`）；影响极小，暂留。
 
 ### 认知后台（Dream / 整理 / 提取）
-- Dream 自动触发阈值 `5/7/3` 硬编码（`dream.py` ~780），且与可配的
+- Dream 自动触发 `should_dream` 的 `5/7/3` 阈值硬编码（`dream.py` ~784），与可配的
   `dream_drowsy_threshold`（默认 30）两套标准不一致。
-- Dream 软化参数 `min_age=5, limit=15` 硬编码（`dream.py` ~183），与 `daily_digest`
-  里可配的软化参数（`auto_soften_min_age` 等）不同源。
-- `update_user_profile` 模型回退链漏读 `default_digest_model`（`daily_digest.py` ~143），
-  与同模块其它整理任务不一致。
-- 后台任务兜底默认模型名硬编码 `anthropic/claude-haiku-4`（OpenRouter 命名风格），
-  非 OpenRouter 供应商上该 model_id 可能 404（dream / daily_digest / memory_extractor）。
-
-### 主服务
-- `/admin/credits` 余额查询的环境变量兜底只认 OpenRouter（`main.py` ~3995）；
-  纯 .env 的非 OpenRouter 部署拿不到余额（仅影响余额展示）。
-- OpenAI 格式 URL 拼接假设单一 `/chat/completions` 后缀（`main.py` ~1465）；
-  用户把 base 误填成带其它后缀时会拼出错误路径。
+  → 统一需新增配置项 + schema（属功能改动，非「顺手」），留待后续。
+- 后台任务兜底默认模型名硬编码 `anthropic/claude-haiku-4`（OpenRouter 命名风格），非 OpenRouter
+  供应商上该 model_id 可能 404。→ 改默认值会影响零配置开箱体验，暂留。

--- a/daily_digest.py
+++ b/daily_digest.py
@@ -390,8 +390,12 @@ async def update_user_profile(digest_text: str = None, model_override: str = Non
             parts.append(f"AI 的话：{row['diary']}")
         digest_text = "\n\n".join(parts)
     
-    # 3. 确定模型（优先用传入的 > 压缩模型 > 标题模型 > 环境变量）
+    # 3. 确定模型（优先用传入的 > 每日整理模型 > 压缩模型 > 标题模型 > 环境变量）
+    # 画像更新属于「每日整理」家族，回退链首位补 default_digest_model，与日页面 / 周月季年
+    # 总结等同模块任务同源；用户在后台配的「整理模型」对画像更新也生效。
     use_model = model_override
+    if not use_model:
+        use_model = await get_config("default_digest_model") or ""
     if not use_model:
         use_model = await get_config("default_compress_model") or ""
     if not use_model:

--- a/dream.py
+++ b/dream.py
@@ -153,7 +153,7 @@ async def run_dream(trigger_type: str = "manual", model_override: str = None):
             create_dream_log, update_dream_log, mark_memories_dreamed,
             soft_delete_memories, promote_memory, create_mem_scene, update_mem_scene,
         )
-        from config import get_config, set_config
+        from config import get_config, set_config, get_config_int
         import httpx
 
         # 1. 创建 dream log
@@ -179,8 +179,12 @@ async def run_dream(trigger_type: str = "manual", model_override: str = None):
         # 辅助素材：未处理碎片（用于清理标记）
         unprocessed = await get_unprocessed_memories()
 
-        # v5.9：适合软化的老碎片（已处理过但正在变冷）
-        aging = await get_aging_memories(min_age_days=5, limit=15)
+        # v5.9：适合软化的老碎片（已处理过但正在变冷）。软化参数与每日自动软化同源
+        # （读同一批配置 auto_soften_*），不再写死，避免改了配置 Dream 这条路径不跟随。
+        soften_min_age = max(0, await get_config_int("auto_soften_min_age", fallback=5))
+        soften_limit = max(0, await get_config_int("auto_soften_daily_limit", fallback=10))
+        soften_cooldown = max(0, await get_config_int("soften_cooldown_days", fallback=21))
+        aging = await get_aging_memories(min_age_days=soften_min_age, limit=soften_limit, cooldown_days=soften_cooldown)
 
         if not day_pages and not unprocessed and not aging:
             await update_dream_log(dream_id, status="completed", finished_at=datetime.now(TZ_CST),

--- a/main.py
+++ b/main.py
@@ -1278,7 +1278,13 @@ async def chat_completions(request: Request):
             chat_api_url = get_anthropic_url(base)
             print(f"🔀 路由到供应商 [{provider_info['provider_name']}] (Anthropic 格式): {chat_api_url}")
         else:
-            chat_api_url = base if base.endswith("/chat/completions") else f"{base}/chat/completions"
+            # 归一化：先剥掉可能已带的聊天端点后缀，再统一拼 /chat/completions，
+            # 避免用户把 base 填成 .../chat/completions 或误填 .../messages 时拼出错误路径。
+            for _suffix in ("/chat/completions", "/messages"):
+                if base.endswith(_suffix):
+                    base = base[: -len(_suffix)]
+                    break
+            chat_api_url = f"{base}/chat/completions"
             print(f"🔀 路由到供应商 [{provider_info['provider_name']}]: {base}")
     else:
         chat_api_key = API_KEY
@@ -4062,11 +4068,17 @@ async def api_get_credits():
         enabled = [p for p in providers if p.get("enabled")]
         
         if not enabled:
-            # 没有配置供应商，用全局环境变量兜底（向后兼容）
-            if API_KEY and "openrouter" in API_BASE_URL:
-                result = await _query_openrouter_credits(API_KEY)
+            # 没有配置供应商，用全局环境变量兜底（向后兼容）。
+            # 非 OpenRouter 的环境变量供应商也走通用查询，不再只认 OpenRouter。
+            if API_KEY:
+                if "openrouter" in API_BASE_URL.lower():
+                    result = await _query_openrouter_credits(API_KEY)
+                    name = "OpenRouter"
+                else:
+                    result = await _query_generic_credits(API_BASE_URL, API_KEY)
+                    name = "环境变量供应商"
                 if result:
-                    result["provider_name"] = "OpenRouter"
+                    result["provider_name"] = name
                     return {"providers": [result]}
             return {"providers": []}
         

--- a/web_search.py
+++ b/web_search.py
@@ -283,6 +283,8 @@ async def _search_bing_local(query: str, max_results: int) -> list[SearchResult]
     results = []
     # Bing results: <li class="b_algo">...<h2><a href="...">Title</a></h2>...<p class="b_lineclamp...">snippet</p>
     blocks = re.findall(r'<li class="b_algo">(.*?)</li>', html, re.DOTALL)
+    if not blocks and html:
+        print(f"⚠️ 本地搜索[bing] 拿到页面但解析到 0 条（可能页面结构已变），query={query[:50]}")
     for block in blocks[:max_results]:
         title_match = re.search(r'<h2><a[^>]*href="([^"]*)"[^>]*>(.*?)</a></h2>', block, re.DOTALL)
         snippet_match = re.search(r'<p[^>]*>(.*?)</p>', block, re.DOTALL)
@@ -309,7 +311,9 @@ async def _search_google_local(query: str, max_results: int) -> list[SearchResul
     blocks = re.findall(r'<div class="[^"]*g[^"]*">(.*?)</div>\s*(?=<div class="|$)', html, re.DOTALL)
     if not blocks:
         blocks = re.findall(r'<div class="g">(.*?)</div></div></div>', html, re.DOTALL)
-    
+    if not blocks and html:
+        print(f"⚠️ 本地搜索[google] 拿到页面但解析到 0 条（可能页面结构已变），query={query[:50]}")
+
     for block in blocks[:max_results + 5]:
         link_match = re.search(r'<a[^>]*href="(https?://[^"]*)"[^>]*>', block)
         title_match = re.search(r'<h3[^>]*>(.*?)</h3>', block, re.DOTALL)
@@ -347,7 +351,9 @@ async def _search_baidu_local(query: str, max_results: int) -> list[SearchResult
     blocks = re.findall(r'<div[^>]*class="[^"]*result[^"]*c-container[^"]*"[^>]*>(.*?)</div>\s*<!--', html, re.DOTALL)
     if not blocks:
         blocks = re.findall(r'<div[^>]*class="result c-container[^"]*"[^>]*>(.*?)</div>\s*<div', html, re.DOTALL)
-    
+    if not blocks and html:
+        print(f"⚠️ 本地搜索[baidu] 拿到页面但解析到 0 条（可能页面结构已变），query={query[:50]}")
+
     for block in blocks[:max_results + 5]:
         title_match = re.search(r'<h3[^>]*><a[^>]*href="([^"]*)"[^>]*>(.*?)</a></h3>', block, re.DOTALL)
         snippet_match = re.search(r'<span[^>]*class="[^"]*content[^"]*"[^>]*>(.*?)</span>', block, re.DOTALL)


### PR DESCRIPTION
与私人后端同批，把 `KNOWN_ISSUES.md` 里**能干净修（小、安全、不需新增配置项）**的低危项一并处理。逐处对照 kiwi 写法改（如 `update_user_profile` 在 kiwi 里是 `daily_digest.py:351` 而非私人后端的另一处）。

## ✅ 修了（5 条）

| 项 | 改动 |
|---|---|
| Dream 软化参数写死 | `dream.py` 改读已有配置 `auto_soften_*`，不再写死 5/15、补 cooldown |
| `update_user_profile` 漏读整理模型 | `daily_digest.py` 回退链首位补 `default_digest_model` |
| credits 只认 OpenRouter | `main.py` 环境兜底非 OpenRouter 改用 `_query_generic_credits` |
| URL 后缀假设单一 | `main.py` 拼接前归一化后缀 |
| 本地搜索静默归零 | `web_search.py` 解析 0 条但页面非空时打告警日志 |

## ⏸️ 没修（KNOWN_ISSUES 标注原因）

外部 MCP 鉴权（加能力）、Dream 自动触发 5/7/3（需新增配置 schema）、兜底模型名（零配置取舍）、自家 MCP 子串识别 / `record_tool_use` LRU（价值近零）。

> 📝 顺带纠正：之前以为「Dream 阈值登记对不上 kiwi」，复核后发现两仓库 `should_dream`（`dream.py:784`）**一致都硬编码 5/7/3**——我当时只看到 drowsy 检查那行、漏看了 should_dream。登记是准确的，KNOWN_ISSUES 无需为此分叉。

## 验证

`compileall` 通过；行为测试全绿（CI 再跑）。`get_aging_memories` 接受 `cooldown_days`、`get_config_int` 均已核实存在。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0184ijsWwVCZj5oyKVsc7eTw)_