### PR TITLE
fix(drawer): 工具循环内展开抽屉的工具当场可用（同步私人后端）

### DIFF
--- a/main.py
+++ b/main.py
@@ -2166,9 +2166,38 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
                 tool_results.update(r)
             tasks.append(_run_mcp())
 
+        # 工具循环内补入展开抽屉：记录 meta 执行前的 expanded 快照，执行后取差集补工具
+        _expanded_before = set()
+        if meta_parsed:
+            try:
+                from tool_drawer import _get_session
+                _expanded_before = set(_get_session(session_id).get("expanded", set()))
+            except Exception:
+                _expanded_before = set()
+
         # 所有工具并发执行
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
+
+        # 若本轮通过 _drawer_request_tools 新展开了抽屉类别，把这些类别的工具增量补进当轮
+        # tools/tool_map，让模型「展开 → 同一次回复内下一步就能调用」，不必等下一轮对话。
+        if meta_parsed:
+            try:
+                from tool_drawer import _get_session, build_tools_for_category
+                _newly = set(_get_session(session_id).get("expanded", set())) - _expanded_before
+                if _newly:
+                    _existing = {t["function"]["name"] for t in tools if t.get("function")}
+                    for _cat in _newly:
+                        _schemas, _tmap = build_tools_for_category(_cat, project_id=project_id)
+                        for _s in _schemas:
+                            _nm = _s.get("function", {}).get("name")
+                            if _nm and _nm not in _existing:
+                                tools.append(_s)
+                                _existing.add(_nm)
+                        tool_map.update(_tmap)
+                    print(f"🗃️  循环内补入展开类别 {_newly}，现共 {len(tools)} 个工具")
+            except Exception as _merge_e:
+                print(f"⚠️  循环内补入展开工具失败: {_merge_e}")
 
         print(f"⚡ {len(parsed)} 个工具调用并发完成")
 

--- a/tests/test_drawer.py
+++ b/tests/test_drawer.py
@@ -120,6 +120,18 @@ async def run():
         td._external_keyword_match = _orig
     check("并发刷新清空 live registry 后，route_tools 仍从快照拿到工具", "get_weather" in names(tools))
 
+    # 4) build_tools_for_category：工具循环里展开抽屉后增量补工具用——
+    #    返回该类别的 schema + 正确的 external_mcp 路由（server_url / origin_name）。
+    setup_registry()
+    schemas, tmap = td.build_tools_for_category("weather", project_id=None)
+    got = {s["function"]["name"] for s in schemas if s.get("function")}
+    check("build_tools_for_category 返回该类别的工具 schema", "get_weather" in got)
+    info = tmap.get("get_weather", {})
+    check("外部工具路由为 external_mcp + 带 origin_name",
+          info.get("type") == "external_mcp" and info.get("origin_name") == "get_weather")
+    s2, t2 = td.build_tools_for_category("不存在的类别")
+    check("未知类别返回空", s2 == [] and t2 == {})
+
 
 asyncio.run(run())
 

--- a/tool_drawer.py
+++ b/tool_drawer.py
@@ -853,6 +853,44 @@ async def route_tools(user_message, session_id, user_embedding=None, mem_enabled
 
     return openai_tools, tool_map
 
+
+def build_tools_for_category(cat_id, project_id=None):
+    """返回某个类别的 (schemas, tool_map_entries)。
+
+    供工具循环里 _drawer_request_tools 展开抽屉后，把该类别的工具增量补进当轮工具表，
+    实现「展开 → 同一次回复内下一步就能调用」。读 live 注册表（执行期取当前状态即可）。
+    装配口径与 route_tools 末尾一致。
+    """
+    cat = CATEGORIES.get(cat_id)
+    if not cat:
+        return [], {}
+    schemas = []
+    tmap = {}
+    for tool_name in cat.get("tool_names", []):
+        schema = TOOL_SCHEMAS.get(tool_name)
+        if not schema:
+            continue
+        schemas.append(schema)
+        if tool_name.startswith("_gateway_"):
+            route_info = {"type": "gateway_builtin", "handler": _infer_handler(tool_name)}
+            if tool_name == "_gateway_search_conversations":
+                route_info["project_id"] = project_id
+            tmap[tool_name] = route_info
+        elif cat.get("external"):
+            ext_map = _external_categories.get(cat_id, {}).get("tool_map", {})
+            tmap[tool_name] = ext_map.get(tool_name, {
+                "type": "external_mcp",
+                "server_url": "",
+                "url": "",
+                "transport": "streamable_http",
+                "server_name": cat.get("label", cat_id),
+                "origin_name": tool_name,
+            })
+        else:
+            tmap[tool_name] = {"type": "drawer", "handler": tool_name}
+    return schemas, tmap
+
+
 def _infer_handler(tool_name):
     if "web_search" in tool_name: return "web_search"
     if "search_conversations" in tool_name: return "search_conversations"
@@ -909,7 +947,7 @@ async def handle_meta_tool(tool_name, args, session_id):
         session["rounds_no_use"] = 0
         names = ", ".join(cat["tool_names"])
         print(f"\U0001f5c3\ufe0f  手动展开：{category}（{names}）")
-        return f"已展开『{cat['label']}』类工具：{names}。下一轮对话即可使用。"
+        return f"已展开『{cat['label']}』类工具：{names}。下一步即可直接调用。"
 
     if tool_name == "_drawer_return_tools":
         if session["expanded"]:


### PR DESCRIPTION
与私人后端同一修复（对应 ai-memory-gateway 的 drawer-reroute-fix）。

## 根因

模型在一次回复的工具循环里调 `_drawer_request_tools` 展开外部 MCP 抽屉，但工具循环的 `tools`/`tool_map` 是进循环前一次性构建、循环内永不重建——展开只改 `session["expanded"]`，当轮工具表没有这些工具，模型当场调用落到「未知工具」。

## 修法（增量补入）

- `tool_drawer.py`：新增 `build_tools_for_category(cat_id, project_id)`（装配口径与 `route_tools` 一致）。
- `main.py` 工具循环：meta 执行前快照 `expanded`，执行后取差集把新展开类别的工具增量补进当轮 `tools`/`tool_map`。
- 提示语「下一轮对话即可使用」→「下一步即可直接调用」。
- `tests/test_drawer.py`：新增 `build_tools_for_category` 行为测试。

## 范围

auto=纯语义保留不变；只动 `main.py` + `tool_drawer.py` + 测试。compileall + 行为测试（含新 3 例）全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0184ijsWwVCZj5oyKVsc7eTw)_