### PR TITLE
fix(extract): prepare_background_request 归因头防御性 ASCII 清洗

### DIFF
--- a/anthropic_adapter.py
+++ b/anthropic_adapter.py
@@ -224,6 +224,18 @@ def from_anthropic_response(anthropic_data: dict, model: str = "") -> dict:
 # 配合 database.resolve_model_endpoint 返回的 (url, key, api_format)。
 # ============================================================
 
+def _ascii_header(value: str) -> str:
+    """HTTP 头只接受 ASCII/latin-1；含非 ASCII（如 É = \\xc9）会让 httpx 编码时直接抛
+    'ascii' codec can't encode...，把整个后台请求带崩。归因头（HTTP-Referer / X-Title）
+    本就是给上游看的标识，这里降级清洗成 ASCII，丢弃无法编码的字符。"""
+    try:
+        value.encode("ascii")
+        return value
+    except (UnicodeEncodeError, AttributeError):
+        cleaned = value.encode("ascii", "ignore").decode("ascii").strip()
+        return cleaned or "Eveille"
+
+
 def prepare_background_request(api_key: str, api_format: str, openai_body: dict,
                                referer: str = None, title: str = None) -> tuple:
     """根据 api_format 构造后台请求，返回 (headers, send_body)。
@@ -237,9 +249,9 @@ def prepare_background_request(api_key: str, api_format: str, openai_body: dict,
         return to_anthropic_headers(api_key), to_anthropic_request(openai_body)
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
     if referer:
-        headers["HTTP-Referer"] = referer
+        headers["HTTP-Referer"] = _ascii_header(referer)
     if title:
-        headers["X-Title"] = title
+        headers["X-Title"] = _ascii_header(title)
     return headers, openai_body
 
 

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -113,6 +113,33 @@ print(f"  [INFO] 已知残余：纯数字/单字更新可能漏判（当前 7 in
 
 
 # ============================================================
+# 3. prepare_background_request：归因头必须 ASCII 安全
+#    含 É(\xc9) 等非 ASCII 的 X-Title 会让 httpx 编码直接抛 'ascii' codec can't
+#    encode，把整个后台请求带崩。kiwi 各处 title 本就是 ASCII，这里守护清洗逻辑本身。
+# ============================================================
+from anthropic_adapter import prepare_background_request
+
+
+def _headers_ascii_safe(headers):
+    try:
+        for v in headers.values():
+            v.encode("ascii")
+        return True
+    except UnicodeEncodeError:
+        return False
+
+
+h, _ = prepare_background_request("sk-x", "openai", {"model": "m"},
+                                  referer="https://gateway.eveille.love",
+                                  title="Éveille Memory Extraction")
+check("含 É 的 X-Title 被清洗成 ASCII（不再让 httpx 编码崩溃）", _headers_ascii_safe(h))
+check("清洗后 X-Title 仍非空（保留可读标识）", bool(h.get("X-Title")))
+
+h2, _ = prepare_background_request("sk-x", "openai", {"model": "m"}, title="未命名场景")
+check("纯非 ASCII 标题清洗后回退占位符", _headers_ascii_safe(h2) and h2.get("X-Title") == "Eveille")
+
+
+# ============================================================
 if _failures:
     print(f"\n❌ {len(_failures)} 个用例失败：{_failures}")
     sys.exit(1)


### PR DESCRIPTION
## 背景

私人后端记忆提取实测踩到：含非 ASCII（`É=\xc9`）的 `X-Title` 让 httpx 编码请求头时抛 `'ascii' codec can't encode`，带崩整个后台任务。

kiwi 各处 `prepare_background_request` 的 `title` 本就是 ASCII，目前没有这个崩溃，但缺防御层。本 PR 与私人后端对齐，杜绝未来回归。

## 修复

- `anthropic_adapter.prepare_background_request`：新增 `_ascii_header()`，`HTTP-Referer` / `X-Title` 降级为 ASCII。
- `tests/test_logic.py`：补 3 条回归断言守护清洗逻辑。

## 验证

`py_compile` 通过；新增断言 3/3 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0184ijsWwVCZj5oyKVsc7eTw)_