### PR TITLE
fix(sync): /sync/settings 如实回报被拒收的配置项

### DIFF
--- a/main.py
+++ b/main.py
@@ -4391,12 +4391,16 @@ async def api_sync_put_settings(request: Request):
     """批量更新同步配置"""
     try:
         data = await request.json()
-        updated = []
+        updated, rejected = [], []
         for key, value in data.items():
             ok = await set_config(key, str(value) if value is not None else "")
-            if ok:
-                updated.append(key)
-        return {"status": "ok", "updated": updated}
+            (updated if ok else rejected).append(key)
+        # rejected = set_config 拒收的键（不在 CONFIG_SCHEMA / 类型校验失败）。
+        # 必须如实回报，否则前端批量同步对"被静默丢弃的设置"毫无察觉
+        # （例如网关版本过旧、还没有某个新配置键时，对应设置会一直存不进却无任何提示）。
+        if rejected:
+            print(f"⚠️  /sync/settings 拒收配置项（未落库）: {rejected}")
+        return {"status": "ok", "updated": updated, "rejected": rejected}
     except Exception as e:
         return JSONResponse(status_code=500, content={"error": str(e)})
 


### PR DESCRIPTION
## 修复

与私人后端对齐：批量同步 `PUT /sync/settings` 对 `set_config` 拒收的键静默跳过仍返回 `{status:ok}`，改为同时返回 `rejected` 列表并打印日志，暴露"被静默丢弃的设置"。

## 验证

`py_compile main.py` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0184ijsWwVCZj5oyKVsc7eTw)_