### PR TITLE
fix(admin): 供应商保存失败时如实报错（不再假成功导致"存不上"）

### DIFF
--- a/admin-panel/index.html
+++ b/admin-panel/index.html
@@ -815,17 +815,18 @@ async function saveProvider() {
     api_format: document.getElementById('pf-format').value,
   };
   try {
-    if (id) {
-      await api(`/admin/providers/${id}`, { method: 'PUT', body: JSON.stringify(body) });
-      toast('✅ 供应商已更新');
-    } else {
-      await api('/admin/providers', { method: 'POST', body: JSON.stringify(body) });
-      toast('✅ 供应商已添加');
-    }
+    const res = id
+      ? await api(`/admin/providers/${id}`, { method: 'PUT', body: JSON.stringify(body) })
+      : await api('/admin/providers', { method: 'POST', body: JSON.stringify(body) });
+    // 后端对校验失败 / 异常会返回 HTTP 200 + {error}，必须读 body 判定；
+    // 否则会对一次"根本没入库"的保存误报成功，刷新后供应商消失（看着像"存不上"）。
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || data.error) throw new Error(data.error || `HTTP ${res.status}`);
+    toast(id ? '✅ 供应商已更新' : '✅ 供应商已添加');
     hideProviderForm();
     loadProviders();
   } catch(e) {
-    toast('❌ 保存失败', false);
+    toast(`❌ 保存失败：${e.message || '请检查后端日志'}`, false);
   }
 }
 

--- a/main.py
+++ b/main.py
@@ -3563,6 +3563,7 @@ async def api_create_provider(request: Request):
         provider = await create_provider(name, api_base_url, api_key, enabled, api_format=data.get("api_format", "openai"))
         return {"status": "created", "provider": provider}
     except Exception as e:
+        print(f"⚠️  创建供应商失败: {e}")
         return {"error": str(e)}
 
 
@@ -3576,6 +3577,7 @@ async def api_update_provider(provider_id: int, request: Request):
             return {"status": "updated", "provider": provider}
         return {"error": "供应商不存在"}
     except Exception as e:
+        print(f"⚠️  更新供应商失败: {e}")
         return {"error": str(e)}
 
 


### PR DESCRIPTION
## 现象

在 kiwi 管理面板加自己的中转站（供应商），点保存弹「✅ 供应商已添加」，**刷新后却没了**，看着就是"存不上"。

## 根因：保存假成功，掩盖了真实失败

admin-panel 的 `api()` 只在 **HTTP ≥ 500** 时抛错；而 `/admin/providers` 的 POST/PUT 对校验失败 / 异常返回的是 **HTTP 200 + `{error}`**。`saveProvider` 完全没读响应 body，于是哪怕后端**根本没入库**，也照样弹「✅ 已添加」——刷新后供应商消失，且用户拿不到任何失败原因。（与之前 `updateConfig` 的"假已保存"同一类。）

## 改动（kiwi-only）

- `admin-panel saveProvider`：读响应 body，`res.ok` 为假或带 `error` 时抛真实原因，toast 显示「❌ 保存失败：<原因>」。
- 后端 `create_provider` / `update_provider` 的 `except` 补 `print`，失败原因同时进**网关日志**，便于照日志定位（DB / 字段 / 约束等）。

> 说明：后端 create/insert 路径本身（含 `api_format` 列的迁移）看代码是对的；本 PR 不臆测具体失败原因，而是**把被掩盖的真实错误暴露出来**——部署后重试即可在面板 toast + 网关日志里看到真正的失败原因。

## 验证

`py_compile main.py` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0184ijsWwVCZj5oyKVsc7eTw)_