### PR TITLE
fix(ci): 去掉行为测试档（开源版已不携带 tests/）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,22 +23,6 @@ jobs:
       - name: 编译检查所有 .py 文件（有语法错误这步就会变红）
         run: python -m compileall -q .
 
-  behavior-tests:
-    name: 行为测试（纯函数逻辑）
-    runs-on: ubuntu-latest
-    steps:
-      - name: 拉取代码
-        uses: actions/checkout@v4
-
-      - name: 准备 Python 3.12（与 Dockerfile 一致）
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-
-      - name: 安装测试所需依赖（detect_contradictions 在 database.py 里需要这三个）
-        run: pip install asyncpg httpx jieba
-
-      - name: 跑行为测试（思考链约束 + 矛盾检测 + 工具抽屉路由语义/并发快照）
-        run: |
-          python tests/test_logic.py
-          python tests/test_drawer.py
+  # 注：开源版不随仓库携带 tests/（见提交 a0968f6「删除测试用文件」），
+  # 故这里不再跑 behavior-tests；语法自检即开源版 CI 的绿勾标准。
+  # 行为测试仍保留在私人后端 gateway 仓库里。


### PR DESCRIPTION
## 问题

提交 `a0968f6 删除测试用文件` 把 `tests/test_logic.py`、`tests/test_drawer.py` 从开源版 kiwi 移除（开源版保持精简，行为测试仍保留在私人后端 gateway 仓库）。但 `ci.yml` 仍在跑这两个文件 → 此后**每个 kiwi PR 的「行为测试」job 都因 `No such file or directory` 变红**，与 PR 改动本身无关（#36 即被此卡住）。

## 修复

`ci.yml` 去掉 `behavior-tests` job，只保留「Python 语法自检」（`compileall`）。一次修复，之后所有 kiwi PR 不再因缺测试文件而红。

## 验证

本 PR 的 CI 走的就是新 `ci.yml`（只剩语法自检），绿勾即自证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0184ijsWwVCZj5oyKVsc7eTw)_