### PR TITLE
fix(admin): 修复 Codex 反馈的 10 项功能/安全问题（前后端）

### DIFF
--- a/admin-panel/js/app.js
+++ b/admin-panel/js/app.js
@@ -8,6 +8,16 @@ import { get } from './api.js';
 
 const DEFAULT_ROUTE = 'dashboard';
 
+// 已从管理面板移除的旧路由 → key:中文名。命中后给明确提示，不再静默跳仪表盘。
+const REMOVED = {
+  journey: '消息旅程',
+  fileextract: '文件提取',
+  reminders: '提醒',
+  comments: '评论',
+  search: '对话搜索',
+  phrases: '指令与短语',
+};
+
 // ---------- 主题 ----------
 function applyTheme(t) {
   document.documentElement.setAttribute('data-theme', t);
@@ -65,6 +75,20 @@ async function route() {
   const content = document.getElementById('content');
   const titleEl = document.getElementById('page-title');
   const crumbEl = document.getElementById('page-crumb');
+
+  // 已移除的旧路由：给明确提示并提供返回链接，而非静默跳仪表盘。
+  if (REMOVED[key]) {
+    highlight('');
+    titleEl.textContent = '页面已移除';
+    crumbEl.textContent = 'kiwi-mem';
+    document.title = '页面已移除 · Kiwi-Mem';
+    content.scrollTop = 0;
+    closeSidebar();
+    try { currentMod?.unmount?.(); } catch {}
+    currentMod = null;
+    content.innerHTML = `<div class="banner banner-info"><span>💡</span><div>「${REMOVED[key]}」已从管理面板移除（相关功能已交给客户端）。<a href="#/${DEFAULT_ROUTE}">返回仪表盘</a></div></div>`;
+    return;
+  }
 
   if (!meta) { location.hash = '#/' + DEFAULT_ROUTE; return; }
 

--- a/admin-panel/js/config-schema.js
+++ b/admin-panel/js/config-schema.js
@@ -90,7 +90,7 @@ export const CONFIG_META = {
 
   // —— 工具抽屉 / 外部 MCP ——
   tool_drawer_enabled:    { label:'工具抽屉', type:'bool', def:'false', input:'bool', desc:'内部工具是否走向量路由按需展开。关闭则所有内部工具每次都传给模型。' },
-  mcp_mode:               { label:'外部 MCP 模式', type:'text', def:'auto', input:'text', desc:'off=全禁用，auto=按语义自动路由，manual=只启用手动选择的。只影响配置来源的外部抽屉。' },
+  mcp_mode:               { label:'外部 MCP 模式', type:'text', def:'auto', input:'select', options:['off','auto','manual'], desc:'off=全禁用，auto=按语义自动路由，manual=只启用手动选择的。只影响配置来源的外部抽屉。' },
   mcp_servers:            { label:'外部 MCP 服务器', type:'text', def:'', input:'json', desc:'外部 MCP server 列表（JSON 数组）。在「工具抽屉」页用专用编辑器维护。' },
   mcp_manual_ids:         { label:'手动 MCP 选择', type:'text', def:'', input:'json', desc:'manual 模式下启用的 MCP 服务器 ID 列表（JSON 数组）。' },
   ext_drawer_threshold:   { label:'外部抽屉相似度阈值', type:'float', def:'0.40', input:'float', desc:'外部工具与对话内容的语义相似度门槛，低于此值不展开。' },
@@ -108,6 +108,16 @@ export const CONFIG_META = {
 
   // —— 网关 / 性能 ——
   prompt_cache_enabled:   { label:'Prompt 缓存', type:'bool', def:'true', input:'bool', desc:'Claude 模型的显式缓存：重复的 system prompt 前缀只收 1/10 费用。非 Claude 自动跳过。' },
+
+  // —— 客户端同步项（不进功能页，仅「全部配置」可见）——
+  user_nickname:          { label:'用户昵称', type:'text', def:'', input:'text', desc:'用户昵称。（同步给客户端，一般不在面板编辑）' },
+  user_avatar:            { label:'用户头像', type:'text', def:'', input:'text', desc:'用户头像（URL 或标识）。（同步给客户端，一般不在面板编辑）' },
+  assistant_avatar:       { label:'助手头像', type:'text', def:'', input:'text', desc:'助手头像（URL 或标识）。（同步给客户端，一般不在面板编辑）' },
+  assistant_settings:     { label:'助手设置', type:'text', def:'', input:'json', desc:'助手相关设置（JSON）。（同步给客户端，一般不在面板编辑）' },
+  custom_skills:          { label:'自定义技能', type:'text', def:'', input:'json', desc:'自定义技能列表（JSON）。（同步给客户端，一般不在面板编辑）' },
+  quick_phrases:          { label:'快捷短语', type:'text', def:'', input:'json', desc:'快捷短语列表（JSON）。（同步给客户端，一般不在面板编辑）' },
+  mcp_switches:           { label:'MCP 开关', type:'text', def:'', input:'json', desc:'各 MCP 的开关状态（JSON）。（同步给客户端，一般不在面板编辑）' },
+  theme_preference:       { label:'主题偏好', type:'text', def:'', input:'text', desc:'客户端主题偏好。（同步给客户端，一般不在面板编辑）' },
 };
 
 // 各功能页的配置编排：master 总开关 + 分组旋钮

--- a/admin-panel/js/config.js
+++ b/admin-panel/js/config.js
@@ -41,6 +41,8 @@ function controlFor(key, val) {
       return `<input type="number" step="0.01" ${attr} value="${escHtml(v)}">`;
     case 'pass':
       return `<input type="password" ${attr} value="${escHtml(v)}" placeholder="••••••">`;
+    case 'select':
+      return `<select ${attr}>${(m.options || []).map(o => `<option value="${escAttr(o)}" ${String(o) === String(v) ? 'selected' : ''}>${escHtml(o)}</option>`).join('')}</select>`;
     case 'model':
       return `<select ${attr} data-model-select data-current="${escAttr(v)}">${modelOptions(v)}</select>`;
     case 'json':

--- a/admin-panel/js/health.js
+++ b/admin-panel/js/health.js
@@ -30,7 +30,9 @@ export async function runHealthChecks() {
     issues.push({ level: 'warn', title: '没有保存任何模型', detail: '前端模型列表（/v1/models）会回退到环境变量默认（通常是 OpenRouter），聊天可能路由不到你的供应商。去供应商页点「模型」保存。', route: 'providers' });
   }
 
-  if (on('memory_enabled') && embed && !embed.error && embed.total_memories > 0 && embed.without_embedding > 0) {
+  if (on('memory_enabled') && embed && !embed.error && embed.embedding_available === false) {
+    issues.push({ level: 'error', title: '向量服务不可用', detail: `嵌入模型「${embed.embedding_model || '?'}」没有可用供应商/Key，记忆向量化与语义搜索会失败。把该嵌入模型在某供应商下保存，或配置 API_KEY。`, route: 'providers' });
+  } else if (on('memory_enabled') && embed && !embed.error && embed.total_memories > 0 && embed.without_embedding > 0) {
     issues.push({ level: 'warn', title: `有 ${embed.without_embedding} 条记忆缺少向量`, detail: `向量覆盖 ${embed.coverage || ''}，语义搜索不完整。去记忆碎片页执行「向量迁移」。`, route: 'memories' });
   }
 

--- a/admin-panel/js/pages/projects.js
+++ b/admin-panel/js/pages/projects.js
@@ -9,12 +9,13 @@ export default {
     this.root = root;
     root.innerHTML = `
       <p class="page-intro">项目用于隔离不同主题的对话与记忆：每个项目可带专属指令与参考文件，文件会被切块、向量化后供该项目的对话检索。</p>
-      <div class="card-head"><div class="card-title">项目</div><span id="proj-count" class="info"></span></div>
+      <div class="card-head"><div class="card-title">项目 <span id="proj-count" class="info"></span></div><button class="btn btn-primary" data-act="new">+ 新建项目</button></div>
       <div id="proj-list">${loadingBlock()}</div>
     `;
     this.load();
 
     delegate(root, {
+      new: () => this.newForm(),
       detail: (el) => this.detail(el.dataset.id),
       edit: (el) => this.editForm(this.find(el.dataset.id)),
       del: (el) => this.remove(el.dataset.id),
@@ -164,6 +165,44 @@ export default {
       const fresh = this.find(pid);
       if (fresh && this._curMod && document.body.contains(this._curMod.root)) this.renderDetail(this._curMod, fresh);
     } catch { /* 静默：详情仍显示旧数据 */ }
+  },
+
+  // ===== 新建项目 =====
+  newForm() {
+    const mod = modal({
+      title: '新建项目',
+      wide: true,
+      body: `
+        <div class="grid grid-2">
+          <div class="field"><label>名称</label>${ctl.text('name', '', '项目名称')}</div>
+          <div class="field"><label>图标 icon</label>${ctl.text('icon', '📁', '如 📁 / 🚀')}</div>
+        </div>
+        <div class="field"><label>说明 description</label>${ctl.area('description', '', 2, '一句话说明这个项目…')}</div>
+        <div class="field"><label>指令 instructions</label>${ctl.areaMono('instructions', '', 8, '该项目对话的专属系统指令…')}</div>`,
+      footer: `<button class="btn btn-secondary" data-cancel>取消</button><button class="btn btn-primary" data-save>创建</button>`,
+    });
+    mod.root.querySelector('[data-cancel]').onclick = () => mod.close();
+    mod.root.querySelector('[data-save]').onclick = async (ev) => {
+      const name = mod.root.querySelector('[data-key="name"]').value.trim();
+      if (!name) { toast('项目名称不能为空', 'err'); return; }
+      const id = `proj-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+      const body = {
+        name,
+        icon: mod.root.querySelector('[data-key="icon"]').value.trim() || '📁',
+        description: mod.root.querySelector('[data-key="description"]').value,
+        instructions: mod.root.querySelector('[data-key="instructions"]').value,
+      };
+      setBusy(ev.currentTarget, true, '创建中');
+      try {
+        await put(`/sync/projects/${id}`, body);
+        toast('项目已创建', 'ok');
+        mod.close();
+        this.load();
+      } catch (e) {
+        toast('创建失败：' + e.message, 'err');
+        setBusy(ev.currentTarget, false);
+      }
+    };
   },
 
   // ===== 编辑项目 =====

--- a/admin-panel/js/pages/providers.js
+++ b/admin-panel/js/pages/providers.js
@@ -75,12 +75,14 @@ export default {
     });
     mod.root.querySelector('[data-cancel]').onclick = () => mod.close();
     mod.root.querySelector('[data-save]').onclick = async (ev) => {
+      const keyVal = mod.root.querySelector('[data-key="api_key"]').value;
       const body = {
         name: mod.root.querySelector('[data-key="name"]').value.trim(),
         api_base_url: mod.root.querySelector('[data-key="api_base_url"]').value.trim(),
-        api_key: mod.root.querySelector('[data-key="api_key"]').value,
         api_format: mod.root.querySelector('[data-key="api_format"]').value,
       };
+      // 编辑时留空 API Key ＝ 不修改：不带 api_key，后端就不会覆盖已存的。新增时照常发送。
+      if (isNew || keyVal.trim() !== '') body.api_key = keyVal;
       if (!body.name || !body.api_base_url) { toast('名称和 Base URL 必填', 'err'); return; }
       setBusy(ev.currentTarget, true, '保存中');
       try {

--- a/admin-panel/js/pages/websearch.js
+++ b/admin-panel/js/pages/websearch.js
@@ -6,6 +6,7 @@ export default {
   title: '联网搜索',
   engines: [],
   config: { engine: '', api_key: '', max_results: 5 },
+  hasKey: false,  // 后端已存在 API Key（不回显原文，留空＝不修改）
 
   async mount(root) {
     this.root = root;
@@ -39,9 +40,14 @@ export default {
         get('/admin/search-config'),
       ]);
       this.engines = eng.engines || [];
+      // 后端可能只回传遮罩/预览的 api_key，绝不回显原文。
+      // 「已配置」检测优先用显式布尔 has_api_key/api_key_set；否则看返回值是否像遮罩（含 … 或 *）或非空。
+      const rawKey = typeof cfg.api_key === 'string' ? cfg.api_key : '';
+      const looksMasked = rawKey.includes('…') || rawKey.includes('*');
+      this.hasKey = (cfg.has_api_key ?? cfg.api_key_set) ?? (looksMasked || rawKey.length > 0);
       this.config = {
         engine: cfg.engine ?? '',
-        api_key: cfg.api_key ?? '',
+        api_key: '',  // 永不回显，输入框始终留空
         max_results: cfg.max_results ?? 5,
       };
       this.renderForm();
@@ -77,8 +83,8 @@ export default {
         </div>
         <div class="field" id="ws-key-field" style="${this.needsKey() ? '' : 'display:none'}">
           <label>API Key</label>
-          <input type="password" id="ws-apikey" value="${escAttr(this.config.api_key)}" placeholder="所选引擎的 API Key">
-          <div class="field-hint">本地引擎无需 Key；切换引擎时此项会自动显隐。</div>
+          <input type="password" id="ws-apikey" value="" placeholder="${this.hasKey ? '（已配置，留空不修改）' : '所选引擎的 API Key'}">
+          <div class="field-hint">本地引擎无需 Key；切换引擎时此项会自动显隐。${this.hasKey ? '已配置 Key 不回显，留空＝不修改。' : ''}</div>
         </div>
         <div class="field">
           <label>结果条数</label>
@@ -110,11 +116,14 @@ export default {
     const form = this.readForm();
     if (!form.engine) { toast('请先选择搜索引擎', 'err'); return; }
     const body = { engine: form.engine, max_results: form.max_results };
-    if (this.needsKey()) body.api_key = form.api_key;
+    // 只有用户输入了非空 Key 才提交 api_key；留空＝保留已存的（不覆盖）。
+    if (this.needsKey() && form.api_key.trim() !== '') body.api_key = form.api_key;
     setBusy(btn, true, '保存中');
     try {
       await put('/admin/search-config', body);
-      this.config = form;
+      // 用户填了新 Key 即视为「已配置」；不回写明文到 config。
+      if (body.api_key !== undefined) this.hasKey = true;
+      this.config = { engine: form.engine, api_key: '', max_results: form.max_results };
       toast('已保存');
     } catch (e) {
       toast('保存失败：' + e.message, 'err');

--- a/config.py
+++ b/config.py
@@ -182,11 +182,32 @@ async def get_all_config() -> dict:
 # 写入配置
 # ============================================================
 
+_ENUM_VALUES = {"mcp_mode": {"off", "auto", "manual"}}
+
+
+def _mask_secret(value: str) -> str:
+    v = value or ""
+    return (v[:4] + "…" + v[-3:]) if len(v) > 10 else ("•" * min(len(v), 8))
+
+
+def _safe_log_value(key: str, value: str) -> str:
+    """日志脱敏：密钥类只显脱敏值；提示词/长文本只显长度，避免进 Zeabur 日志。"""
+    low = key.lower()
+    if "key" in low or "token" in low or "secret" in low or "password" in low:
+        return _mask_secret(value)
+    if key.startswith("prompt_") or key in (
+        "user_profile", "assistant_settings", "custom_skills", "quick_phrases",
+        "mcp_servers", "mcp_switches", "mcp_manual_ids", "user_avatar", "assistant_avatar",
+    ) or len(value or "") > 80:
+        return f"<{len(value or '')} 字符>"
+    return value
+
+
 async def set_config(key: str, value: str) -> bool:
     """设置配置值（存入数据库，带类型验证）"""
     if key not in CONFIG_SCHEMA:
         return False
-    
+
     # 类型验证
     _, _, _, val_type = CONFIG_SCHEMA[key]
     try:
@@ -200,6 +221,10 @@ async def set_config(key: str, value: str) -> bool:
         # text 类型不需要验证
     except ValueError:
         return False
+
+    # 枚举值校验：非法值直接拒绝，不再悄悄按默认跑
+    if key in _ENUM_VALUES and value not in _ENUM_VALUES[key]:
+        return False
     
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -209,7 +234,7 @@ async def set_config(key: str, value: str) -> bool:
             ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = NOW()
         """, key, value, CONFIG_SCHEMA[key][2])
     
-    print(f"⚙️  配置更新: {key} = {value}")
+    print(f"⚙️  配置更新: {key} = {_safe_log_value(key, value)}")
     return True
 
 

--- a/database.py
+++ b/database.py
@@ -645,41 +645,54 @@ async def init_tables():
 # Embedding 生成
 # ============================================================
 
+async def _resolve_embedding_endpoint():
+    """决定 embedding 的「模型 / 供应商 / 端点」。
+
+    · 模型：面板配置 default_embedding_model（空则回落 env EMBEDDING_MODEL）。
+    · 供应商：该模型在已保存供应商里解析到的 base+key（与聊天路由同源 resolve_provider_for_model）；
+              解析不到再回落 env API_KEY / API_BASE_URL。
+    返回 (url, api_key, model, source)；url 或 api_key 为 None 表示「向量服务不可用」。
+    """
+    model = EMBEDDING_MODEL
+    try:
+        from config import get_config
+        model = (await get_config("default_embedding_model")) or EMBEDDING_MODEL
+    except Exception:
+        pass
+    prov = None
+    try:
+        prov = await resolve_provider_for_model(model)
+    except Exception:
+        prov = None
+    if prov and prov.get("api_key"):
+        base = (prov.get("api_base_url") or "").rstrip("/")
+        for suffix in ("/chat/completions", "/messages", "/completions"):
+            if base.endswith(suffix):
+                base = base[: -len(suffix)]
+                break
+        return base + "/embeddings", prov["api_key"], model, (prov.get("provider_name") or "provider")
+    if API_KEY:
+        return _get_embedding_url(), API_KEY, model, "env"
+    return None, None, model, "none"
+
+
 async def get_embedding(text: str) -> Optional[List[float]]:
-    """
-    调用 OpenRouter Embedding API 生成向量
-    
-    使用与聊天相同的 API_KEY，接口完全兼容 OpenAI 格式
-    失败时返回 None（触发降级搜索）
-    """
-    if not API_KEY:
-        print("⚠️  API_KEY 未设置，无法生成 embedding")
+    """生成向量。优先走已保存供应商（按嵌入模型解析），否则回落环境变量。失败返回 None（触发降级搜索）。"""
+    url, key, model, _ = await _resolve_embedding_endpoint()
+    if not url or not key:
+        print("⚠️  无可用 embedding 供应商/Key：把默认嵌入模型在某供应商下保存，或设置 API_KEY")
         return None
-    
-    url = _get_embedding_url()
-    
     try:
         async with httpx.AsyncClient(timeout=15) as client:
             resp = await client.post(
                 url,
-                headers={
-                    "Authorization": f"Bearer {API_KEY}",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "model": EMBEDDING_MODEL,
-                    "input": text,
-                },
+                headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+                json={"model": model, "input": text},
             )
-            
             if resp.status_code == 200:
-                data = resp.json()
-                embedding = data["data"][0]["embedding"]
-                return embedding
-            else:
-                print(f"⚠️  Embedding API 返回 {resp.status_code}: {resp.text[:200]}")
-                return None
-                
+                return resp.json()["data"][0]["embedding"]
+            print(f"⚠️  Embedding API 返回 {resp.status_code}: {resp.text[:200]}")
+            return None
     except Exception as e:
         print(f"⚠️  Embedding 生成失败: {e}")
         return None
@@ -690,21 +703,22 @@ async def get_embeddings_batch(texts: List[str]) -> List[Optional[List[float]]]:
     批量生成 embedding（OpenRouter 支持批量输入）
     返回与 texts 等长的列表，失败的位置为 None
     """
-    if not API_KEY or not texts:
+    if not texts:
+        return []
+    url, key, model, _ = await _resolve_embedding_endpoint()
+    if not url or not key:
         return [None] * len(texts)
-    
-    url = _get_embedding_url()
-    
+
     try:
         async with httpx.AsyncClient(timeout=30) as client:
             resp = await client.post(
                 url,
                 headers={
-                    "Authorization": f"Bearer {API_KEY}",
+                    "Authorization": f"Bearer {key}",
                     "Content-Type": "application/json",
                 },
                 json={
-                    "model": EMBEDDING_MODEL,
+                    "model": model,
                     "input": texts,
                 },
             )
@@ -2030,11 +2044,15 @@ async def get_embedding_stats() -> dict:
         with_embedding = await conn.fetchval(
             "SELECT COUNT(*) FROM memories WHERE embedding IS NOT NULL"
         )
+    url, key, emb_model, source = await _resolve_embedding_endpoint()
     return {
         "total_memories": total,
         "with_embedding": with_embedding,
         "without_embedding": total - with_embedding,
         "coverage": f"{with_embedding/total*100:.1f}%" if total > 0 else "N/A",
+        "embedding_model": emb_model,
+        "embedding_source": source,                 # 供应商名 / "env" / "none"
+        "embedding_available": bool(url and key),    # 向量服务是否可用
     }
 
 async def get_all_providers():

--- a/main.py
+++ b/main.py
@@ -1276,9 +1276,8 @@ async def chat_completions(request: Request):
 
     # 先确定最终模型，后面的 prompt cache 判断要用它。
     # 如果客户端没传 model，这里会补上默认值，避免误判为“非 Claude”而跳过缓存。
-    model = body.get("model", DEFAULT_MODEL)
-    if not model:
-        model = DEFAULT_MODEL
+    # 未传 model 时优先用面板保存的默认聊天模型，再回落到环境变量 DEFAULT_MODEL
+    model = body.get("model") or await get_config("default_chat_model") or DEFAULT_MODEL
     body["model"] = model
 
     # ---------- 供应商路由（提前解析）----------
@@ -3572,6 +3571,9 @@ async def api_update_provider(provider_id: int, request: Request):
     """更新供应商"""
     try:
         data = await request.json()
+        # 编辑时留空的 api_key 视为「不修改」，避免把已存的 key 清空（前端会发空串）
+        if not (data.get("api_key") or "").strip():
+            data.pop("api_key", None)
         provider = await update_provider(provider_id, **data)
         if provider:
             return {"status": "updated", "provider": provider}
@@ -3937,13 +3939,15 @@ async def api_get_search_engines():
 
 @app.get("/admin/search-config")
 async def api_get_search_config():
-    """获取当前搜索配置"""
+    """获取当前搜索配置（api_key 脱敏，不回显明文）"""
     engine = await get_config("search_engine") or ""
     api_key = await get_config("search_api_key") or ""
     max_results = await get_config_int("search_max_results", fallback=5)
+    masked = (api_key[:4] + "…" + api_key[-3:]) if len(api_key) > 10 else ("•" * min(len(api_key), 8))
     return {
         "engine": engine,
-        "api_key": api_key,
+        "api_key": masked,
+        "api_key_set": bool(api_key),
         "max_results": max_results,
     }
 
@@ -3955,8 +3959,10 @@ async def api_set_search_config(request: Request):
         data = await request.json()
         if "engine" in data:
             await set_config("search_engine", data["engine"])
-        if "api_key" in data:
-            await set_config("search_api_key", data["api_key"])
+        # 仅当传入了非空、且不是脱敏回显的值时才覆盖（留空＝保持原 key）
+        _sk = (data.get("api_key") or "")
+        if _sk and "…" not in _sk and "•" not in _sk:
+            await set_config("search_api_key", _sk)
         if "max_results" in data:
             await set_config("search_max_results", str(data["max_results"]))
         return {"status": "updated"}

--- a/tool_drawer.py
+++ b/tool_drawer.py
@@ -723,7 +723,9 @@ async def route_tools(user_message, session_id, user_embedding=None, mem_enabled
     # 一致，消除两条路径对「auto 是否尊重钉选」给出相反答案的分叉。
     external_pinned = mode == "manual"
 
-    await refresh_external_drawers()
+    # off 模式：完全不刷新/探测外部 MCP（否则会对示例/失效 server 发探测请求，日志刷 405/连接失败）
+    if mode != "off":
+        await refresh_external_drawers()
     # Bug #4：在锁内对注册表做一次快照，避免遍历期间被并发刷新改成半成品。
     # 刷新（_unregister/_refresh_external_drawers_impl）是「pop 旧 + 赋新 dict」整体替换，
     # 故浅拷贝足够冻住本轮所需的引用：即使刷新随后清空/重建 live 字典，快照仍自洽。


### PR DESCRIPTION
基于 Codex 的全面测试反馈逐条修复。状态栏直刷修复由 Codex 的 `82bc5ef` 提供，本批基于其上。

## P1
1. **编辑供应商不再清空 API Key** — 前端编辑时留空不传 `api_key`；后端 `update_provider` 也把空 key 当「不修改」。
2. **向量配置接上已保存供应商** — `get_embedding`/batch 先按嵌入模型 `resolve_provider_for_model` 走其 base+key（与聊天路由同源），解析不到再回落 env；`/admin/embedding-stats` 增 `embedding_available / embedding_model / embedding_source`，健康自检据此报「⛔ 向量服务不可用」。
3. **默认聊天模型生效** — 未传 `model` 时 `get_config("default_chat_model")` → 再回落 `DEFAULT_MODEL`。
4. **搜索 API Key 不再明文回显** — `/admin/search-config` 返回脱敏值 + `api_key_set`；PUT 仅在传入非脱敏新值时覆盖；前端留空＝保持原值、永不回显。
5. **`mcp_mode=off` 不再探测外部 MCP** — `route_tools` 在 off 模式跳过 `refresh_external_drawers`，消除对示例/失效 server 的 405/连接失败探测。

## P2
6. **8 个「同步给客户端」配置键回填 `CONFIG_META`** — 仅在「全部配置」可见（不进功能页）。
7. **移除的 6 个旧路由不再静默跳转** — 给「页面已移除」提示页 + 返回仪表盘链接。
8. **`mcp_mode` 前端改三段下拉**（off/auto/manual）+ 后端 `set_config` 枚举校验，非法值直接拒绝。
9. **配置日志脱敏** — `set_config` 打印时密钥类只显脱敏值、提示词/长文本只显长度。
10. **项目页加「新建项目」入口**（`PUT /sync/projects/{id}`）。

## 验证
- 后端 `py_compile`（main/config/database/tool_drawer）全过。
- 前端 `node --check` 全过；冒烟 **19/19**、标签交互、配置防抖保存 + 确认删除回归均通过（Playwright）。

> embedding 改动严格增量（带 env 回落），最坏情况等同现状；建议合并后在真机验证「向量服务可用 / 默认聊天模型生效 / 编辑供应商不丢 key」这几条真链路。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhMzcRBU9wLTHFssHzwG4e)_