### PR TITLE
同步 provider_model_id 路由 + AiHubMix 缓存修复（与 ai-memory-gateway 对齐）

### DIFF
--- a/database.py
+++ b/database.py
@@ -235,6 +235,7 @@ async def init_tables():
                 id              TEXT PRIMARY KEY,
                 title           TEXT DEFAULT '新对话',
                 model           TEXT DEFAULT '',
+                provider_model_id INTEGER REFERENCES provider_models(id) ON DELETE SET NULL,
                 project_id      TEXT,
                 pinned          BOOLEAN DEFAULT FALSE,
                 sort_order      INTEGER DEFAULT 0,
@@ -242,6 +243,16 @@ async def init_tables():
                 updated_at      TIMESTAMPTZ DEFAULT NOW()
             );
         """)
+
+        has_conv_provider_model_id = await conn.fetchval("""
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'chat_conversations' AND column_name = 'provider_model_id'
+            )
+        """)
+        if not has_conv_provider_model_id:
+            await conn.execute("ALTER TABLE chat_conversations ADD COLUMN provider_model_id INTEGER REFERENCES provider_models(id) ON DELETE SET NULL")
+            print("✅ chat_conversations 表已添加 provider_model_id 列（精确供应商模型路由）")
 
         # v6.1 handoff config migration.
         # handoff_msg_count was removed from the config schema, so read it with raw SQL.
@@ -2265,10 +2276,12 @@ async def delete_provider_model(model_pk_id: int):
         return "DELETE 1" in result
 
 
-async def resolve_provider_for_model(model_id: str):
+async def resolve_provider_for_model(model_id: str, provider_model_id: int = None):
     """根据 model_id 查找对应的已启用供应商，返回 {api_base_url, api_key, api_format, provider_name} 或 None
 
     api_format 优先级：模型级 > 供应商级 > 默认 'openai'
+    provider_model_id 存在时优先按保存模型行精确路由，避免多个供应商保存同一个
+    model_id 时被供应商名排序抢走。
 
     同一个 model_id 可能在多个已启用供应商下注册。用确定性 ORDER BY（供应商名→id）
     选第一个，保证：① 路由结果稳定，不随 Postgres 物理顺序漂移；② 与对外 /v1/models
@@ -2277,10 +2290,29 @@ async def resolve_provider_for_model(model_id: str):
     """
     pool = await get_pool()
     async with pool.acquire() as conn:
+        if provider_model_id is not None:
+            row = await conn.fetchrow("""
+                SELECT p.api_base_url, p.api_key,
+                       COALESCE(pm.api_format, p.api_format, 'openai') as api_format,
+                       p.name as provider_name,
+                       pm.model_id,
+                       pm.id as provider_model_id
+                FROM provider_models pm
+                JOIN providers p ON pm.provider_id = p.id
+                WHERE pm.id = $1
+                  AND p.enabled = TRUE
+                  AND ($2::text IS NULL OR pm.model_id = $2)
+                LIMIT 1
+            """, provider_model_id, model_id or None)
+            if row:
+                return dict(row)
+
         row = await conn.fetchrow("""
             SELECT p.api_base_url, p.api_key,
                    COALESCE(pm.api_format, p.api_format, 'openai') as api_format,
-                   p.name as provider_name
+                   p.name as provider_name,
+                   pm.model_id,
+                   pm.id as provider_model_id
             FROM provider_models pm
             JOIN providers p ON pm.provider_id = p.id
             WHERE pm.model_id = $1 AND p.enabled = TRUE
@@ -2414,7 +2446,7 @@ async def sync_get_conversations():
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch("""
-            SELECT id, title, model, project_id, pinned, sort_order, created_at, updated_at
+            SELECT id, title, model, provider_model_id, project_id, pinned, sort_order, created_at, updated_at
             FROM chat_conversations
             ORDER BY pinned DESC, updated_at DESC
         """)
@@ -2445,11 +2477,12 @@ async def sync_upsert_conversation(conv: dict):
     pool = await get_pool()
     async with pool.acquire() as conn:
         await conn.execute("""
-            INSERT INTO chat_conversations (id, title, model, project_id, pinned, sort_order, created_at, updated_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            INSERT INTO chat_conversations (id, title, model, provider_model_id, project_id, pinned, sort_order, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             ON CONFLICT (id) DO UPDATE SET
                 title = EXCLUDED.title,
                 model = EXCLUDED.model,
+                provider_model_id = EXCLUDED.provider_model_id,
                 project_id = EXCLUDED.project_id,
                 pinned = EXCLUDED.pinned,
                 sort_order = EXCLUDED.sort_order,
@@ -2458,6 +2491,7 @@ async def sync_upsert_conversation(conv: dict):
             str(conv.get("id", "")),
             conv.get("title", "新对话") or "新对话",
             conv.get("model") or "",
+            _safe_int(conv.get("providerModelId") or conv.get("provider_model_id")),
             conv.get("projectId") or conv.get("project_id") or None,
             bool(conv.get("pinned", False)),
             int(conv.get("sortOrder", conv.get("sort_order", 0)) or 0),
@@ -2667,6 +2701,15 @@ def _parse_time(val):
         return _dt.fromisoformat(val.replace("Z", "+00:00"))
     except (ValueError, AttributeError):
         return _dt.now(_tz.utc)
+
+
+def _safe_int(val):
+    try:
+        if val is None or val == "":
+            return None
+        return int(val)
+    except (TypeError, ValueError):
+        return None
 
 
 # ============================================================

--- a/main.py
+++ b/main.py
@@ -1306,6 +1306,11 @@ async def chat_completions(request: Request):
     # 未传 model 时优先用面板保存的默认聊天模型，再回落到环境变量 DEFAULT_MODEL
     model = body.get("model") or await get_config("default_chat_model") or DEFAULT_MODEL
     body["model"] = model
+    provider_model_id_raw = body.pop("provider_model_id", None)
+    try:
+        provider_model_id = int(provider_model_id_raw) if provider_model_id_raw not in (None, "") else None
+    except (TypeError, ValueError):
+        provider_model_id = None
 
     # ---------- 供应商路由（提前解析）----------
     # 提前解析供应商，使本次请求链路里所有「是否走 Anthropic / 是否 OpenRouter」的判断
@@ -1314,12 +1319,16 @@ async def chat_completions(request: Request):
     #   is_anthropic_fmt —— 该供应商是否走 Anthropic 原生格式（来自 DB 的 api_format）
     #   is_openrouter    —— 上游是否 OpenRouter（仅用于 OpenRouter 专属字段/请求头）
     try:
-        provider_info = await resolve_provider_for_model(model)
+        provider_info = await resolve_provider_for_model(model, provider_model_id=provider_model_id)
     except Exception:
         provider_info = None
 
     api_format = "openai"  # 默认 OpenAI 格式
     if provider_info:
+        resolved_model = provider_info.get("model_id")
+        if resolved_model and resolved_model != model:
+            model = resolved_model
+            body["model"] = model
         chat_api_key = provider_info["api_key"]
         api_format = provider_info.get("api_format", "openai") or "openai"
         base = provider_info["api_base_url"].rstrip("/")
@@ -1358,6 +1367,8 @@ async def chat_completions(request: Request):
             # v5.4：即使记忆关闭，也从数据库优先读取 system prompt（降级到文件版本）
             enhanced_prompt = await get_active_system_prompt() or SYSTEM_PROMPT
             # 记忆关闭时也注入当前时间（追加在末尾，前面的人设仍可命中前缀缓存）
+            if "<!-- CACHE_B1 -->" not in enhanced_prompt and "<!-- CACHE_BOUNDARY -->" not in enhanced_prompt:
+                enhanced_prompt += "\n\n<!-- CACHE_B1 -->\n\n<!-- CACHE_B2 -->"
             _now_cst = datetime.now(TZ_CST)
             _weekdays_cn = ['星期一', '星期二', '星期三', '星期四', '星期五', '星期六', '星期日']
             enhanced_prompt += f"\n\n【当前时间】{_now_cst.strftime('%Y-%m-%d %H:%M')} {_weekdays_cn[_now_cst.weekday()]}"
@@ -1398,17 +1409,24 @@ async def chat_completions(request: Request):
                 messages.insert(0, {"role": "system", "content": enhanced_prompt})
             
             # ---- Prompt Caching：把 system message 拆成多段 content block ----
-            # 是否支持显式 cache_control 断点，以供应商的 api_format 为准（权威来源），
-            # 不再靠模型名里有没有 "claude"/"anthropic" 猜——否则 Anthropic 直连但模型
-            # 用了自定义别名时会漏打缓存断点，白白多花输入费用。
+            # 是否支持显式 cache_control 断点。Anthropic 原生格式直接支持；
+            # OpenAI 兼容格式只给已验证会透传 Claude cache_control 的供应商放行。
             _model_lower = (model or "").lower()
+            _api_url_lower = (chat_api_url or "").lower()
+            is_claude_target = "claude" in _model_lower or "anthropic" in _model_lower
+            is_aihubmix = "aihubmix" in _api_url_lower
             supports_explicit_cache = is_anthropic_fmt or (
-                is_openrouter and ("claude" in _model_lower or "anthropic" in _model_lower)
+                is_claude_target and (is_openrouter or is_aihubmix)
             )
             cache_enabled_val = await get_config("prompt_cache_enabled")
             cache_on = supports_explicit_cache and (cache_enabled_val is None or str(cache_enabled_val).lower() != 'false')
-            
+            cache_markers_present = (
+                "<!-- CACHE_B1 -->" in enhanced_prompt
+                or "<!-- CACHE_BOUNDARY -->" in enhanced_prompt
+            )
+
             if cache_on:
+                cache_applied = False
                 for i, msg in enumerate(messages):
                     if msg.get("role") == "system" and isinstance(msg.get("content"), str):
                         content = msg["content"]
@@ -1446,6 +1464,7 @@ async def chat_completions(request: Request):
                             bp_count = sum(1 for b in content_blocks if "cache_control" in b)
                             sizes = " + ".join(f"~{len(b['text'])}字" for b in content_blocks)
                             print(f"💾 Prompt 缓存：{bp_count} 个断点（{sizes}）")
+                            cache_applied = True
 
                         elif "<!-- CACHE_BOUNDARY -->" in content:
                             # 旧版单断点兼容
@@ -1461,7 +1480,20 @@ async def chat_completions(request: Request):
                             
                             messages[i]["content"] = content_blocks
                             print(f"💾 Prompt 缓存（旧版）：静态 ~{len(static_part)}字")
+                            cache_applied = True
                         break
+                if not cache_applied:
+                    print(f"💾 Prompt 缓存跳过：未找到可拆分的 system 缓存边界（api_format={api_format}, model={model}）")
+            elif cache_markers_present:
+                if cache_enabled_val is not None and str(cache_enabled_val).lower() == 'false':
+                    cache_skip_reason = "prompt_cache_enabled=false"
+                else:
+                    cache_skip_reason = (
+                        "provider/model not enabled for explicit cache "
+                        f"(api_format={api_format}, is_openrouter={is_openrouter}, "
+                        f"is_aihubmix={is_aihubmix}, is_claude={is_claude_target}, model={model})"
+                    )
+                print(f"💾 Prompt 缓存跳过：{cache_skip_reason}")
     
     # 替换前端传来的 skill prompt 中的模板变量
     for msg in messages:


### PR DESCRIPTION
把 ai-memory-gateway 的后端修复原样移植到 kiwi-mem，保持两个后端一致。

## 改动
- `database.py`：`chat_conversations` 加 `provider_model_id`（列 + 幂等迁移）；`resolve_provider_for_model(provider_model_id=)` 按保存模型行精确路由；对话同步读写 `provider_model_id`；新增 `_safe_int` 助手。
- `main.py`：请求读取 `provider_model_id` 并据此路由（找不到回退旧的名排序）；采用解析出的 `model_id`；把 `AiHubMix + Claude` 的 OpenAI 兼容路径加入缓存白名单；记忆关闭时补缓存边界；新增缓存跳过诊断日志。

kiwi-mem 无 `tests/` 测试目录，故未移植 adapter 测试。

## 验证
- `py_compile main.py database.py` 通过
- 与 ai-memory-gateway CODEX-2 逐段对照，逻辑一致；`provider_models` 先于 `chat_conversations` 建表，内联外键安全。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESvZP277YbesJzP575udBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESvZP277YbesJzP575udBw)_