### PR TITLE
kiwi-mem 同步梦境总开关 dream_enabled（后端闸门 + 管理面板）

### DIFF
--- a/admin-panel/js/config-schema.js
+++ b/admin-panel/js/config-schema.js
@@ -58,6 +58,7 @@ export const CONFIG_META = {
   scene_inject_min_sim:   { label:'场景注入相似度', type:'float', def:'0.5', input:'float', desc:'场景与当前对话的最低相似度。' },
 
   // —— Dream ——
+  dream_enabled:          { label:'梦境系统', type:'bool', def:'true', input:'bool', desc:'AI 通过做梦融合记忆场景、生成前瞻。关闭后不再自动触发梦境（犯困提示一并静默）；「状态」页的手动开始 Dream 不受影响。' },
   dream_model:            { label:'Dream 模型', type:'text', def:'', input:'model', desc:'Dream 记忆整合用的模型。' },
   prompt_dream:           { label:'Dream 提示词', type:'text', def:'', input:'prompt', hasDefault:true, desc:'指导 Dream 如何清理、融合碎片并推断前瞻。留空用内置默认。' },
   dream_drowsy_threshold: { label:'犯困碎片阈值', type:'int', def:'30', input:'int', desc:'未处理碎片积累超过此数量后，AI 开始表现犯困、提示该睡了。' },
@@ -144,7 +145,7 @@ export const CONFIG_PAGES = {
   },
   dream: {
     groups: [
-      { title:'Dream 整合', keys:['dream_model','dream_drowsy_threshold','last_dream_date','prompt_dream'] },
+      { title:'Dream 整合', master:'dream_enabled', keys:['dream_model','dream_drowsy_threshold','last_dream_date','prompt_dream'] },
       { title:'🎬 场景注入', desc:'Dream 产出的叙事场景在聊天时自动注入。', master:'scene_inject_enabled', keys:['scene_inject_limit','scene_inject_min_sim'] },
     ],
   },

--- a/config.py
+++ b/config.py
@@ -51,6 +51,7 @@ CONFIG_SCHEMA = {
     "user_profile":          ("",                        "",     "用户画像",          "text"),
     "prompt_user_profile":   ("",                        "",     "画像更新提示词",    "text"),
     # Dream 记忆整合（v5.1）
+    "dream_enabled":         ("",                        "true", "梦境系统",          "bool"),
     "dream_model":           ("",                        "",     "Dream 模型",        "text"),
     "prompt_dream":          ("",                        "",     "Dream 提示词",      "text"),
     "prompt_daily_digest_page":("",                      "",     "日页面生成提示词",  "text"),

--- a/dream.py
+++ b/dream.py
@@ -698,8 +698,12 @@ async def get_drowsy_prompt() -> str:
     2. 距上次Dream超过7天
     3. 有3天以上的日页面未被Dream处理
     """
-    from config import get_config
+    from config import get_config, get_config_bool
     from database import get_unprocessed_memories, get_pool
+
+    # 梦境系统总开关：关闭时不再注入犯困提示（手动触发路径不走这里，不受影响）
+    if not await get_config_bool("dream_enabled", fallback=True):
+        return ""
 
     last_dream = await get_config("last_dream_date")
     drowsy_threshold = int(await get_config("dream_drowsy_threshold") or "30")
@@ -782,8 +786,12 @@ async def auto_dream_check():
     检查是否需要自动触发 Dream（24小时无活动）
     由定时任务每小时调用一次
     """
-    from config import get_config
+    from config import get_config, get_config_bool
     from database import get_pool, get_unprocessed_memories
+
+    # 梦境系统总开关：只拦自动触发；手动触发（"去睡吧"指令 / 前端按钮 / /dream 端点）无视此开关
+    if not await get_config_bool("dream_enabled", fallback=True):
+        return False
 
     # 跳过 0:00-1:00 时段，避免与 daily_digest_scheduler（0:05）竞争
     now_hour = datetime.now(TZ_CST).hour


### PR DESCRIPTION
把 ai-memory-gateway PR #28 的 `dream_enabled` 梦境总开关同步进 kiwi-mem，并按指示在管理面板 Dream 页的「参数」tab 里加上总开关。

## 改动内容（3 文件，+13 −3）

### 后端闸门（与 gateway PR #28 同语义）
- **config.py**：`CONFIG_SCHEMA` 注册 `dream_enabled`（bool，默认 `"true"`，即默认开启、行为与现状一致）
- **dream.py** 两处自动触发闸门：
  - `get_drowsy_prompt()`——关闭后不再注入犯困提示（犯困提示归自动机制管，一并静默）
  - `auto_dream_check()`——关闭后跳过 24 小时自动 Dream
- **手动路径全部豁免**：「去睡吧」指令、前端月亮按钮、`/dream/start` 端点、管理面板「状态」页的「开始 Dream」都不受开关影响，随时可手动做梦

### 管理面板
- **admin-panel/js/config-schema.js**：`dream_enabled` 字段注册 + Dream 页「Dream 整合」组挂 `master` 总开关——与下方「场景注入」组同一交互范式：关闭时该组参数变暗、拨动即时保存

## 兼容性
- 旧库无 `dream_enabled` 行：`get_config` 落到 schema 默认 `"true"`，读取处再有 `get_config_bool(..., fallback=True)` 双重回退——升级后行为不变，无需迁移
- 「Dream 整合」组此前无 master，纯增量；「场景注入」组的既有开关不受影响

## 验证
- `py_compile` config.py / dream.py 通过；esbuild 解析 config-schema.js 通过
- 闸门行为 mock 验证 4/4：关→犯困提示返回空串 + 自动检查返回 False；开→照常放行；键缺省→回退为开
- Playwright 渲染验证 9/9（mock 同源 API + 静态面板挂 `/admin/` 前缀）：master 渲染、「梦境系统」标题、「已启用/已关闭」状态、knobs 挂接、关闭变暗、PUT 写回 `false`、场景注入组不受影响，双态截图目检通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAt3fWqNeALSZSwmriGzth

---
_Generated by [Claude Code](https://claude.ai/code/session_01YAt3fWqNeALSZSwmriGzth)_