### PR TITLE
Fix calendar summary token truncation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           python scripts/test_drawer_stability.py
           python scripts/test_gateway_tool_streaming.py
+          python scripts/test_calendar_summary_generation.py
 
       - name: 运行 S1-S6 永久真库行为守卫
         run: python scripts/test_kiwi_safety_sync.py

--- a/daily_digest.py
+++ b/daily_digest.py
@@ -1476,7 +1476,7 @@ async def generate_week_summary(start: str, end: str, model_override: str = None
 
     use_model = model_override or await get_config("default_digest_model") or await get_config("default_compress_model") or DIGEST_MODEL
 
-    result_json = await _call_model_for_json(prompt, f"请生成 {start} 至 {end} 的周总结。", use_model, max_tokens=2000)
+    result_json = await _call_model_for_json(prompt, f"请生成 {start} 至 {end} 的周总结。", use_model, max_tokens=6000)
     if not result_json:
         return {"status": "error", "error": "model returned invalid format"}
 
@@ -1562,7 +1562,7 @@ async def generate_month_summary(start: str, end: str, month_str: str, model_ove
 
     use_model = model_override or await get_config("default_digest_model") or await get_config("default_compress_model") or DIGEST_MODEL
 
-    result_json = await _call_model_for_json(prompt, f"请生成 {month_str} 的月总结。", use_model, max_tokens=2000)
+    result_json = await _call_model_for_json(prompt, f"请生成 {month_str} 的月总结。", use_model, max_tokens=3500)
     if not result_json:
         return {"status": "error", "error": "model returned invalid format"}
 
@@ -1667,7 +1667,7 @@ async def generate_period_summary(start: str, end: str, period_type: str,
 
     use_model = model_override or await get_config("default_digest_model") or await get_config("default_compress_model") or DIGEST_MODEL
 
-    result_json = await _call_model_for_json(prompt, f"请生成{label}的{period_type}总结。", use_model, max_tokens=2000)
+    result_json = await _call_model_for_json(prompt, f"请生成{label}的{period_type}总结。", use_model, max_tokens=2500)
     if not result_json:
         return {"status": "error", "error": "model returned invalid format"}
 
@@ -1720,7 +1720,18 @@ async def _call_model_for_json(prompt: str, user_msg: str, model: str, max_token
                 return None
 
             data = parse_background_response(response.json(), use_api_format)
-            text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+            choices = data.get("choices") or [{}]
+            choice = choices[0] if isinstance(choices[0], dict) else {}
+            message = choice.get("message") or {}
+            text = message.get("content") or ""
+            if choice.get("finish_reason") == "length":
+                usage = data.get("usage") or {}
+                print(
+                    "   ⚠️ 模型输出达到 token 上限："
+                    f"finish_reason=length completion_tokens={usage.get('completion_tokens')} "
+                    f"text_chars={len(text)} max_tokens={max_tokens}"
+                )
+                return None
             text = text.strip()
             if text.startswith("```json"):
                 text = text[7:]

--- a/scripts/test_calendar_summary_generation.py
+++ b/scripts/test_calendar_summary_generation.py
@@ -1,0 +1,234 @@
+"""No-network contracts for calendar summary token budgets and truncation."""
+
+import asyncio
+from contextlib import redirect_stdout
+import io
+import json
+import os
+import sys
+from unittest.mock import patch
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+import config
+import daily_digest
+import database
+
+
+SUMMARY_RESULT = {
+    "summary": "summary",
+    "digest": "digest",
+    "sections": {"emotion": "e", "life": "l", "growth": "g"},
+    "highlights": ["highlight"],
+    "diary": "diary",
+}
+
+DAY_RESULT = {
+    "summary": "day summary",
+    "digest": "day digest",
+    "sections": [{"period": "上午", "title": "记录", "content": "正文", "keywords": []}],
+    "diary": "day diary",
+    "all_keywords": ["day"],
+}
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _fake_async_client(payload, request_bodies):
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, *, headers=None, json=None):
+            request_bodies.append(json)
+            return _FakeResponse(payload)
+
+    return FakeAsyncClient
+
+
+class _FakeConnection:
+    async def fetch(self, *args, **kwargs):
+        return []
+
+
+class _FakeAcquire:
+    async def __aenter__(self):
+        return _FakeConnection()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakePool:
+    def acquire(self):
+        return _FakeAcquire()
+
+
+async def _empty_config(*args, **kwargs):
+    return ""
+
+
+async def _model_endpoint(*args, **kwargs):
+    return "https://model.test/v1/chat/completions", "test-key", "openai"
+
+
+async def _calendar_range(start, end, page_type):
+    pages = {
+        "day": [{
+            "type": "day",
+            "date": "2026-07-01",
+            "sections": [{"period": "上午", "title": "记录", "content": "day source"}],
+            "keywords": [],
+            "diary": "",
+        }],
+        "week": [{
+            "type": "week",
+            "date": "2026-07-01",
+            "sections": [{"emotion": "week source"}],
+            "keywords": [],
+            "diary": "",
+        }],
+        "month": [{
+            "type": "month",
+            "date": "2026-04-01",
+            "sections": [{"emotion": "month source"}],
+            "diary": "",
+        }],
+        "quarter": [{
+            "type": "quarter",
+            "date": "2026-01-01",
+            "sections": [{"emotion": "quarter source"}],
+            "diary": "",
+        }],
+    }
+    return pages.get(page_type, [])
+
+
+async def run_budget_contract():
+    request_bodies = []
+    save_calls = []
+
+    async def fake_messages(*args, **kwargs):
+        return [{"role": "user", "content": "hello"}]
+
+    async def fake_get_pool(*args, **kwargs):
+        return _FakePool()
+
+    async def fake_save(*args, **kwargs):
+        save_calls.append(kwargs)
+        return 101
+
+    day_payload = {
+        "choices": [{
+            "message": {"content": json.dumps(DAY_RESULT, ensure_ascii=False)},
+            "finish_reason": "stop",
+        }],
+        "usage": {"completion_tokens": 300},
+    }
+    with (
+        patch.object(database, "get_chat_messages_for_date", fake_messages),
+        patch.object(database, "get_pool", fake_get_pool),
+        patch.object(database, "resolve_model_endpoint", _model_endpoint),
+        patch.object(database, "save_calendar_page", fake_save),
+        patch.object(config, "get_config", _empty_config),
+        patch.object(daily_digest.httpx, "AsyncClient", _fake_async_client(day_payload, request_bodies)),
+    ):
+        result = await daily_digest.generate_day_page("2026-07-01", model_override="test-model")
+
+    assert result["status"] == "success"
+    assert request_bodies[0]["max_tokens"] == 6000
+
+    summary_budgets = []
+
+    async def fake_model(prompt, user_msg, model, max_tokens=2000):
+        summary_budgets.append(max_tokens)
+        return SUMMARY_RESULT
+
+    with (
+        patch.object(database, "get_calendar_range", _calendar_range),
+        patch.object(database, "save_calendar_page", fake_save),
+        patch.object(config, "get_config", _empty_config),
+        patch.object(daily_digest, "_call_model_for_json", fake_model),
+    ):
+        await daily_digest.generate_week_summary(
+            "2026-07-01", "2026-07-07", model_override="test-model"
+        )
+        await daily_digest.generate_month_summary(
+            "2026-07-01", "2026-07-31", "2026-07", model_override="test-model"
+        )
+        await daily_digest.generate_period_summary(
+            "2026-04-01", "2026-06-30", "quarter", "2026Q2", "月总结",
+            model_override="test-model",
+        )
+        await daily_digest.generate_period_summary(
+            "2026-01-01", "2026-12-31", "year", "2026", "季度总结",
+            model_override="test-model",
+        )
+
+    assert summary_budgets == [6000, 3500, 2500, 2500]
+
+
+async def run_length_contract():
+    secret = "PARSEABLE_TRUNCATED_BODY_MUST_NOT_BE_LOGGED_OR_SAVED"
+    text = json.dumps({"summary": secret})
+    payload = {
+        "choices": [{
+            "message": {"content": text},
+            "finish_reason": "length",
+        }],
+        "usage": {"completion_tokens": 6000},
+    }
+    request_bodies = []
+    save_calls = []
+
+    async def fake_save(*args, **kwargs):
+        save_calls.append(kwargs)
+        return 999
+
+    output = io.StringIO()
+    with (
+        patch.object(database, "get_calendar_range", _calendar_range),
+        patch.object(database, "resolve_model_endpoint", _model_endpoint),
+        patch.object(database, "save_calendar_page", fake_save),
+        patch.object(config, "get_config", _empty_config),
+        patch.object(daily_digest.httpx, "AsyncClient", _fake_async_client(payload, request_bodies)),
+        redirect_stdout(output),
+    ):
+        result = await daily_digest.generate_week_summary(
+            "2026-07-01", "2026-07-07", model_override="test-model"
+        )
+
+    log = output.getvalue()
+    assert result == {"status": "error", "error": "model returned invalid format"}
+    assert request_bodies[0]["max_tokens"] == 6000
+    assert save_calls == []
+    assert "finish_reason=length" in log
+    assert "completion_tokens=6000" in log
+    assert f"text_chars={len(text)}" in log
+    assert "max_tokens=6000" in log
+    assert secret not in log
+
+
+async def main():
+    await run_budget_contract()
+    await run_length_contract()
+    print("test_calendar_summary_generation: all tests passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What changed

- apply the calendar-summary token budgets from the private gateway: week 6000, month 3500, quarter/year 2500
- reject normalized `finish_reason=length` responses before the existing JSON parser
- preserve kiwi-mem's existing error return shape and prevent truncated results from reaching `save_calendar_page`
- add a no-network regression script and run it permanently in CI

## Root cause and impact

The previous 2000-token week-summary cap could truncate the requested JSON output. The guard makes truncation explicitly fail closed even when the partial response happens to be parseable.

## Validation

- `python scripts/test_calendar_summary_generation.py`
- Python compile checks and `git diff --check`
- independent final review and mutation checks for all budget values, removed/misplaced length guard, accidental save, and log leakage
- confirmed the baseline object `55dfb86:daily_digest.py` is `e364215fc6fcf343a6c873d0dfcdbd81c6ee8deb`

The Kiwi-Mem v1.3.0 identity and existing PostgreSQL safety job remain unchanged.