### PR TITLE
Raise calendar generation timeouts

### DIFF
--- a/daily_digest.py
+++ b/daily_digest.py
@@ -1150,7 +1150,7 @@ async def _generate_day_page_impl(target_date: str = None, model_override: str =
             use_api_key, use_api_format, _body,
             referer="https://midsummer-gateway.local", title="Day Page Generation",
         )
-        async with httpx.AsyncClient(timeout=120) as client:
+        async with httpx.AsyncClient(timeout=400) as client:
             response = await client.post(use_api_url, headers=_headers, json=_send_body)
 
             if response.status_code != 200:
@@ -1713,7 +1713,7 @@ async def _call_model_for_json(prompt: str, user_msg: str, model: str, max_token
             use_api_key, use_api_format, _body,
             referer="https://midsummer-gateway.local", title="Memory Summary",
         )
-        async with httpx.AsyncClient(timeout=120) as client:
+        async with httpx.AsyncClient(timeout=400) as client:
             response = await client.post(use_api_url, headers=_headers, json=_send_body)
             if response.status_code != 200:
                 print(f"   ⚠️ 模型请求失败: {response.status_code}")

--- a/scripts/test_calendar_summary_generation.py
+++ b/scripts/test_calendar_summary_generation.py
@@ -46,7 +46,7 @@ class _FakeResponse:
 def _fake_async_client(payload, request_bodies):
     class FakeAsyncClient:
         def __init__(self, *args, **kwargs):
-            pass
+            assert kwargs.get("timeout") == 400
 
         async def __aenter__(self):
             return self


### PR DESCRIPTION
## Summary
- raise the day-page generation timeout from `120s` to `400s`
- raise the shared calendar JSON generation timeout from `120s` to `400s`
- keep all kiwi token budgets and product-side injection settings unchanged

## Verification
- `scripts/test_calendar_summary_generation.py`
- both timeout paths are asserted through their real `AsyncClient` construction points
- existing token-budget, length fail-closed, zero-save, and log-privacy seals remain green
- `py_compile` and `git diff --check`