### PR TITLE
自然周×自然月不嵌套：月总结只接纳完整落月周 + 两端日页面 + 素材三态 + 注入部分重叠三态

### DIFF
--- a/daily_digest.py
+++ b/daily_digest.py
@@ -1562,31 +1562,67 @@ def _month_gap_days(month_start, month_end, week_starts) -> list:
 
 
 async def generate_month_summary(start: str, end: str, month_str: str, model_override: str = None):
-    """从周总结生成月总结"""
-    from database import get_calendar_range, save_calendar_page
+    """从周总结 + 边缘日页面生成月总结（素材范围严格等于自然月）。
+
+    素材规则（自然周与自然月不嵌套，跨月周不串账）：
+    - 只整张采用「完整落在本月内」的自然周总结（周一、周日都在月内）；
+    - 跨越月界的两端自然周不采用——无论生成时它存不存在，结果都一致，
+      延迟生成或手动重建不会把下月头几天混进本月；
+    - 月首尾跨月段与月中缺失周段，一律用属于本月的日页面补齐。
+    缺口日子按三态处理：ready（日页面存在）/ empty（当天确认无聊天素材）/
+    missing（有素材但日页面缺失）。出现 missing 时延迟成文——月总结成文后
+    扫描永久跳过，此时缺的日子会被固化为永久缺失，宁可等日页面补齐。
+    """
+    from database import get_calendar_range, save_calendar_page, get_chat_messages_for_date
     from config import get_config
 
+    m_start = _coerce_date(start)
+    m_end = _coerce_date(end)
+
     week_pages = await get_calendar_range(start, end, "week")
-    if not week_pages:
-        # 没有周总结的话，尝试直接从日页面生成
-        day_pages = await get_calendar_range(start, end, "day")
-        if not day_pages:
-            print(f"   📭 {month_str} 没有周总结也没有日页面，跳过月总结")
-            return {"status": "skipped", "reason": "no data"}
-        # 用日页面的摘要代替
-        summaries_text = _format_day_pages_brief(day_pages)
-    else:
-        summaries_text = _format_week_summaries(week_pages)
-        # 补缺：跨月周整周归属周一所在月，月初被上月带走的日子单独补日页面
-        gap_days = _month_gap_days(start, end, [p["date"] for p in week_pages])
-        if gap_days:
-            gap_set = set(gap_days)
-            gap_pages = [p for p in await get_calendar_range(start, end, "day") if _coerce_date(p["date"]) in gap_set]
-            if gap_pages:
-                summaries_text += (
-                    "\n### 补充：本月未被以上周总结覆盖的日子（其所属自然周归属上个月）\n"
-                    + _format_day_pages_brief(gap_pages)
-                )
+    full_weeks = [
+        p for p in week_pages
+        if _coerce_date(p["date"]) + timedelta(days=6) <= m_end
+    ]
+
+    gap_days = _month_gap_days(m_start, m_end, [p["date"] for p in full_weeks])
+    gap_pages = []
+    missing_days = []
+    if gap_days:
+        day_by_date = {
+            _coerce_date(p["date"]): p
+            for p in await get_calendar_range(start, end, "day")
+        }
+        for d in gap_days:
+            page = day_by_date.get(d)
+            if page:
+                gap_pages.append(page)
+                continue
+            if await get_chat_messages_for_date(d.isoformat()):
+                missing_days.append(d)
+
+    if missing_days:
+        days_str = "、".join(d.isoformat() for d in missing_days)
+        print(f"   ⏸️ {month_str} 有 {len(missing_days)} 天有聊天素材但日页面缺失（{days_str}），延迟生成月总结")
+        return {
+            "status": "skipped",
+            "reason": "missing_day_pages",
+            "missing_dates": [d.isoformat() for d in missing_days],
+        }
+
+    if not full_weeks and not gap_pages:
+        print(f"   📭 {month_str} 没有周总结也没有日页面，跳过月总结")
+        return {"status": "skipped", "reason": "no data"}
+
+    parts = []
+    if full_weeks:
+        parts.append(_format_week_summaries(full_weeks))
+    if gap_pages:
+        parts.append(
+            "\n### 补充：本月未被以上周总结覆盖的日子（跨月周两端与缺失周由日页面补齐）\n"
+            + _format_day_pages_brief(gap_pages)
+        )
+    summaries_text = "".join(parts)
 
     prompt = MONTH_SUMMARY_PROMPT.replace("{month}", month_str).replace(
         "{week_summaries}", summaries_text)
@@ -1820,21 +1856,35 @@ def _format_week_summaries(week_pages: list) -> str:
     return text
 
 
+def _day_page_brief_text(p: dict) -> str:
+    """日页面兜底素材的正文选择：summary → diary → digest → sections 正文。
+
+    手写页（user_edit）往往只有 diary，旧数据可能只有 sections 正文；
+    只读 summary 会把这些页面写成「无记录」，正文被静默丢弃。
+    """
+    for key in ("summary", "diary", "digest"):
+        v = p.get(key)
+        if v and str(v).strip():
+            return str(v).strip()
+    parts = []
+    sections = p.get("sections") or []
+    for sec in (sections if isinstance(sections, list) else []):
+        if not isinstance(sec, dict):
+            continue
+        t = (sec.get("title") or "").strip()
+        c = (sec.get("content") or "").strip()
+        if t and c:
+            parts.append(f"{t}：{c}")
+        elif t or c:
+            parts.append(t or c)
+    return "；".join(parts)
+
+
 def _format_day_pages_brief(day_pages: list) -> str:
-    """格式化日页面为简要文本（异常降级用：没有周总结时，月总结直接从日页面生成的兜底路径）"""
+    """格式化日页面为简要文本（月总结缺口补齐与无周总结时的兜底路径）"""
     text = ""
     for p in day_pages:
         date_str = str(p["date"])
-        summary = p.get("summary", "")
-        if summary:
-            text += f"\n**{date_str}**：{summary}\n"
-        else:
-            # 没有概要（旧数据兼容）：从 sections 提取 title
-            sections = p.get("sections") or []
-            titles = []
-            for sec in (sections if isinstance(sections, list) else []):
-                t = sec.get("title", "")
-                if t:
-                    titles.append(t)
-            text += f"\n**{date_str}**：{'、'.join(titles) if titles else '（无记录）'}\n"
+        body = _day_page_brief_text(p)
+        text += f"\n**{date_str}**：{body if body else '（无记录）'}\n"
     return text

--- a/daily_digest.py
+++ b/daily_digest.py
@@ -12,7 +12,7 @@ import os
 import json
 import asyncio
 import httpx
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 # ============================================================
 # API 配置 —— 记忆整理用独立 key，避免和聊天抢额度
@@ -1534,6 +1534,11 @@ MONTH_SUMMARY_PROMPT = """你是用户的 AI 伴侣。请根据这个月的周�
 {week_summaries}"""
 
 
+def _coerce_date(value) -> date:
+    """calendar_pages 的 date 在真库（asyncpg）是 date 对象、在测试假库是 ISO 字符串，统一成 date。"""
+    return value if isinstance(value, date) else date.fromisoformat(str(value))
+
+
 def _month_gap_days(month_start, month_end, week_starts) -> list:
     """补缺法：算出 [month_start, month_end] 内没有被任何归属周覆盖的日子。
 
@@ -1543,10 +1548,12 @@ def _month_gap_days(month_start, month_end, week_starts) -> list:
     """
     covered = set()
     for w_start in week_starts:
+        w_start = _coerce_date(w_start)
         for offset in range(7):
             covered.add(w_start + timedelta(days=offset))
     gaps = []
-    d = month_start
+    d = _coerce_date(month_start)
+    month_end = _coerce_date(month_end)
     while d <= month_end:
         if d not in covered:
             gaps.append(d)
@@ -1558,7 +1565,6 @@ async def generate_month_summary(start: str, end: str, month_str: str, model_ove
     """从周总结生成月总结"""
     from database import get_calendar_range, save_calendar_page
     from config import get_config
-    from datetime import date as date_cls
 
     week_pages = await get_calendar_range(start, end, "week")
     if not week_pages:
@@ -1572,14 +1578,10 @@ async def generate_month_summary(start: str, end: str, month_str: str, model_ove
     else:
         summaries_text = _format_week_summaries(week_pages)
         # 补缺：跨月周整周归属周一所在月，月初被上月带走的日子单独补日页面
-        gap_days = _month_gap_days(
-            date_cls.fromisoformat(start),
-            date_cls.fromisoformat(end),
-            [p["date"] for p in week_pages],
-        )
+        gap_days = _month_gap_days(start, end, [p["date"] for p in week_pages])
         if gap_days:
             gap_set = set(gap_days)
-            gap_pages = [p for p in await get_calendar_range(start, end, "day") if p["date"] in gap_set]
+            gap_pages = [p for p in await get_calendar_range(start, end, "day") if _coerce_date(p["date"]) in gap_set]
             if gap_pages:
                 summaries_text += (
                     "\n### 补充：本月未被以上周总结覆盖的日子（其所属自然周归属上个月）\n"

--- a/daily_digest.py
+++ b/daily_digest.py
@@ -1534,10 +1534,31 @@ MONTH_SUMMARY_PROMPT = """你是用户的 AI 伴侣。请根据这个月的周�
 {week_summaries}"""
 
 
+def _month_gap_days(month_start, month_end, week_starts) -> list:
+    """补缺法：算出 [month_start, month_end] 内没有被任何归属周覆盖的日子。
+
+    周页面按「周一所在月」归属整周，所以月初最多有 6 天躺在上个月的周总结里。
+    这些天的内容不该在本月总结里缺席——调用方拿它们的日页面补进素材，
+    让月总结的素材范围严格等于自然月。返回升序 date 列表。
+    """
+    covered = set()
+    for w_start in week_starts:
+        for offset in range(7):
+            covered.add(w_start + timedelta(days=offset))
+    gaps = []
+    d = month_start
+    while d <= month_end:
+        if d not in covered:
+            gaps.append(d)
+        d += timedelta(days=1)
+    return gaps
+
+
 async def generate_month_summary(start: str, end: str, month_str: str, model_override: str = None):
     """从周总结生成月总结"""
     from database import get_calendar_range, save_calendar_page
     from config import get_config
+    from datetime import date as date_cls
 
     week_pages = await get_calendar_range(start, end, "week")
     if not week_pages:
@@ -1550,6 +1571,20 @@ async def generate_month_summary(start: str, end: str, month_str: str, model_ove
         summaries_text = _format_day_pages_brief(day_pages)
     else:
         summaries_text = _format_week_summaries(week_pages)
+        # 补缺：跨月周整周归属周一所在月，月初被上月带走的日子单独补日页面
+        gap_days = _month_gap_days(
+            date_cls.fromisoformat(start),
+            date_cls.fromisoformat(end),
+            [p["date"] for p in week_pages],
+        )
+        if gap_days:
+            gap_set = set(gap_days)
+            gap_pages = [p for p in await get_calendar_range(start, end, "day") if p["date"] in gap_set]
+            if gap_pages:
+                summaries_text += (
+                    "\n### 补充：本月未被以上周总结覆盖的日子（其所属自然周归属上个月）\n"
+                    + _format_day_pages_brief(gap_pages)
+                )
 
     prompt = MONTH_SUMMARY_PROMPT.replace("{month}", month_str).replace(
         "{week_summaries}", summaries_text)

--- a/database.py
+++ b/database.py
@@ -3274,17 +3274,26 @@ async def get_calendar_for_injection(lookback_days: int = 365):
             result.append({**p, "label": f"{m_start.year}年{m_start.month}月总结"})
 
     # 周总结：覆盖周一~周日（date 字段存的是周一）
+    # 自然周与自然月不嵌套，与月/季/年的重叠按三态处理：
+    #   七天全未被高层覆盖 → 整周入选并认领七天；
+    #   七天全被覆盖 → 跳过整周（高层总结已包含），天数计入 week_covered_dates；
+    #   部分覆盖（跨月周撞上月/季/年总结）→ 跳过整周且不认领任何日子——
+    #   否则未被高层覆盖的那几天会被这张不注入的周"占位"，
+    #   等它们离开最近几天窗口后日页面也不再入选，形成记忆空洞。
     week_covered_dates = set()  # 单独追踪周总结覆盖的日期
     for p in by_type.get("week", []):
         w_start = p["date"]
-        is_covered_by_higher = w_start in covered_dates
-        for d_offset in range(7):
-            d = w_start + timedelta(days=d_offset)
-            if d not in covered_dates:
-                covered_dates.add(d)
-            week_covered_dates.add(d)
         w_end = w_start + timedelta(days=6)
-        if not is_covered_by_higher and has_source_day(w_start, w_end):
+        week_days = [w_start + timedelta(days=i) for i in range(7)]
+        covered_count = sum(1 for d in week_days if d in covered_dates)
+        if covered_count == 7:
+            week_covered_dates.update(week_days)
+            continue
+        if covered_count > 0:
+            continue
+        covered_dates.update(week_days)
+        week_covered_dates.update(week_days)
+        if has_source_day(w_start, w_end):
             result.append({**p, "label": f"{w_start.strftime('%m/%d')}-{w_end.strftime('%m/%d')}周总结"})
 
     # ── 日页面三级注入（v6.1）──

--- a/scripts/test_calendar_summary_generation.py
+++ b/scripts/test_calendar_summary_generation.py
@@ -159,8 +159,12 @@ async def run_budget_contract():
         summary_budgets.append(max_tokens)
         return SUMMARY_RESULT
 
+    async def fake_no_messages(*args, **kwargs):
+        return []
+
     with (
         patch.object(database, "get_calendar_range", _calendar_range),
+        patch.object(database, "get_chat_messages_for_date", fake_no_messages),
         patch.object(database, "save_calendar_page", fake_save),
         patch.object(config, "get_config", _empty_config),
         patch.object(daily_digest, "_call_model_for_json", fake_model),
@@ -224,9 +228,230 @@ async def run_length_contract():
     assert secret not in log
 
 
+# ============================================================
+# 月总结素材契约（自然周与自然月不嵌套，跨月周不串账）
+# 2026-07：周一为 6/29、7/6、7/13、7/20、7/27；6/29 与 7/27 两周跨月界
+# ============================================================
+
+
+def _week_page(monday: str) -> dict:
+    return {
+        "type": "week",
+        "date": monday,
+        "sections": [{"emotion": f"周素材 {monday}"}],
+        "keywords": [],
+        "diary": "",
+    }
+
+
+def _day_page(datestr: str, **overrides) -> dict:
+    page = {
+        "type": "day",
+        "date": datestr,
+        "summary": f"日素材 {datestr}",
+        "digest": "",
+        "sections": [],
+        "keywords": [],
+        "diary": "",
+    }
+    page.update(overrides)
+    return page
+
+
+def _make_calendar_range(weeks: list, days: list):
+    from datetime import date as date_cls
+
+    async def _range(start, end, page_type=None):
+        s, e = date_cls.fromisoformat(start), date_cls.fromisoformat(end)
+        pool = {"week": weeks, "day": days}.get(page_type, [])
+        return [p for p in pool if s <= date_cls.fromisoformat(p["date"]) <= e]
+
+    return _range
+
+
+async def _run_july_month(weeks: list, days: list, message_dates=None):
+    """跑一次 2026-07 月总结，返回 (result, prompts, saves)。"""
+    prompts, saves = [], []
+    message_dates = set(message_dates or [])
+
+    async def fake_model(prompt, user_msg, model, max_tokens=2000):
+        prompts.append(prompt)
+        return SUMMARY_RESULT
+
+    async def fake_save(*args, **kwargs):
+        saves.append(kwargs)
+        return 202
+
+    async def fake_messages(datestr, *args, **kwargs):
+        if datestr in message_dates:
+            return [{"role": "user", "content": "material"}]
+        return []
+
+    with (
+        patch.object(database, "get_calendar_range", _make_calendar_range(weeks, days)),
+        patch.object(database, "get_chat_messages_for_date", fake_messages),
+        patch.object(database, "save_calendar_page", fake_save),
+        patch.object(config, "get_config", _empty_config),
+        patch.object(daily_digest, "_call_model_for_json", fake_model),
+    ):
+        result = await daily_digest.generate_month_summary(
+            "2026-07-01", "2026-07-31", "2026-07", model_override="test-model"
+        )
+    return result, prompts, saves
+
+
+async def run_month_material_contract():
+    july_days = [_day_page(f"2026-07-{d:02d}") for d in range(1, 32)]
+    weeks_on_time = [_week_page("2026-06-29"), _week_page("2026-07-06"),
+                     _week_page("2026-07-13"), _week_page("2026-07-20")]
+
+    # 场景 A：8/1 按时生成——7/27 周尚不存在，两端由日页面补齐
+    result, prompts, _ = await _run_july_month(weeks_on_time, july_days)
+    assert result["status"] == "success", result
+    material = prompts[0]
+    for monday in ("2026-07-06", "2026-07-13", "2026-07-20"):
+        assert f"周素材 {monday}" in material, monday
+    assert "2026-06-29" not in material          # 跨入的上月周不采用
+    for d in (1, 2, 3, 4, 5, 27, 28, 29, 30, 31):
+        assert f"**2026-07-{d:02d}**" in material, d   # 两端日页面补齐
+    for d in (6, 15, 26):
+        assert f"**2026-07-{d:02d}**" not in material, d  # 周覆盖的日子不重复进
+
+    # 场景 B：8/3 后延迟/手动重建——7/27 周已存在，仍不得整张采用（防混入 8/1–2）
+    weeks_late = weeks_on_time + [_week_page("2026-07-27")]
+    result, prompts, _ = await _run_july_month(weeks_late, july_days)
+    assert result["status"] == "success", result
+    material = prompts[0]
+    assert "周素材 2026-07-27" not in material    # 跨出的周整张排除
+    for d in (27, 28, 29, 30, 31):
+        assert f"**2026-07-{d:02d}**" in material, d
+    # 与场景 A 素材一致：无论何时生成/重建，结果确定
+
+    # 场景 C：月中缺一张周总结（7/13 周缺失）→ 那七天由日页面兜底
+    weeks_gap = [_week_page("2026-07-06"), _week_page("2026-07-20")]
+    result, prompts, _ = await _run_july_month(weeks_gap, july_days)
+    assert result["status"] == "success", result
+    material = prompts[0]
+    for d in range(13, 20):
+        assert f"**2026-07-{d:02d}**" in material, d
+
+    # 场景 D：缺口日页面缺失但当天有聊天素材 → 延迟成文，不落库
+    days_missing_28 = [p for p in july_days if p["date"] != "2026-07-28"]
+    result, prompts, saves = await _run_july_month(
+        weeks_on_time, days_missing_28, message_dates={"2026-07-28"}
+    )
+    assert result["status"] == "skipped", result
+    assert result["reason"] == "missing_day_pages", result
+    assert result["missing_dates"] == ["2026-07-28"], result
+    assert prompts == [] and saves == []
+
+    # 场景 D'：缺口日无页面也无素材（empty）→ 正常成文
+    result, prompts, _ = await _run_july_month(weeks_on_time, days_missing_28)
+    assert result["status"] == "success", result
+    assert "**2026-07-28**" not in prompts[0]
+
+    # 场景 E：diary-only 手写日页面，正文不得写成「无记录」
+    diary_only = [_day_page("2026-07-01", summary="", diary="手写的一天")]
+    result, prompts, _ = await _run_july_month([], diary_only)
+    assert result["status"] == "success", result
+    assert "手写的一天" in prompts[0]
+    assert "（无记录）" not in prompts[0]
+
+    print("month material contract: ok")
+
+
+# ============================================================
+# 注入端契约：周与月/季/年部分重叠时的三态处理
+# ============================================================
+
+
+class _RowsConnection:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def fetch(self, *args, **kwargs):
+        return self._rows
+
+
+class _RowsAcquire:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def __aenter__(self):
+        return _RowsConnection(self._rows)
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _RowsPool:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def acquire(self):
+        return _RowsAcquire(self._rows)
+
+
+async def run_injection_overlap_contract():
+    from datetime import date as date_cls, datetime, timedelta
+    import calendar as cal_mod
+
+    today = datetime.now(database.TZ_CST).date()
+
+    # 找一个足够久远（跨月周七天都在"最近三天/七天"窗口之外）、
+    # 且最后一天不是周日的月份，保证存在跨月自然周
+    y, m = today.year, today.month
+    while True:
+        m -= 1
+        if m == 0:
+            y, m = y - 1, 12
+        last = date_cls(y, m, cal_mod.monthrange(y, m)[1])
+        if last.weekday() != 6 and last + timedelta(days=6) < today - timedelta(days=7):
+            break
+    month_start = date_cls(y, m, 1)
+    month_end = last
+    w_cross = month_end - timedelta(days=month_end.weekday())  # 含月末的那周的周一
+    assert w_cross + timedelta(days=6) > month_end
+    cross_days = [w_cross + timedelta(days=i) for i in range(7)]
+    spill_days = [d for d in cross_days if d > month_end]      # 溢入下月的日子
+    in_month_days = [d for d in cross_days if d <= month_end]
+    w_full = w_cross - timedelta(days=7)                       # 完整落在月内的一周
+
+    rows = [
+        {"date": month_start, "type": "month", "digest": "月总结正文", "summary": "", "keywords": []},
+        {"date": w_full, "type": "week", "digest": "整月内周正文", "summary": "", "keywords": []},
+        {"date": w_cross, "type": "week", "digest": "跨月周正文", "summary": "", "keywords": []},
+    ] + [
+        {"date": d, "type": "day", "digest": f"日正文 {d}", "summary": "", "keywords": []}
+        for d in cross_days
+    ]
+
+    async def fake_get_pool(*args, **kwargs):
+        return _RowsPool(rows)
+
+    with patch.object(database, "get_pool", fake_get_pool):
+        entries = await database.get_calendar_for_injection(lookback_days=365)
+
+    types_dates = {(e["type"], e["date"]) for e in entries}
+
+    # 月总结入选；两张周都不得入选（一张被整月覆盖、一张部分重叠）
+    assert ("month", month_start) in types_dates, entries
+    assert not any(t == "week" for t, _ in types_dates), entries
+    # 部分重叠的周不认领日子：溢入下月的日页面必须入选
+    for d in spill_days:
+        assert ("day", d) in types_dates, (d, entries)
+    # 月内日子已被月总结覆盖，不重复入选
+    for d in in_month_days:
+        assert ("day", d) not in types_dates, (d, entries)
+
+    print("injection overlap contract: ok")
+
+
 async def main():
     await run_budget_contract()
     await run_length_contract()
+    await run_month_material_contract()
+    await run_injection_overlap_contract()
     print("test_calendar_summary_generation: all tests passed")
 
 


### PR DESCRIPTION
## 背景

kiwi-mem 的自然周与自然月无法组成严格父子树：跨月周（如 6/29–7/5、7/27–8/2）在月总结素材和注入覆盖两侧都会串账或留洞。初版补缺法只修了按时生成路径，Codex 复审指出四项阻塞（延迟重建串账 / 缺口不齐仍成文 / diary-only 丢正文 / 注入部分重叠留洞），本 PR 按其规格逐条修复。

## 素材规则（`generate_month_summary`）

```
完整落在本月内的自然周（周一、周日都在月内）→ 整张采用周总结
跨越月界的两端 + 月中缺失的周           → 用属于本月的日页面补齐
```

- 跨月周**无论生成时存不存在**一律不整张采用——延迟生成与手动重建的素材从此确定一致，7 月不会混入 8/1–2，季度/年度不再继承重复内容。
- 缺口日子三态：`ready`（日页面在）/ `empty`（当天确认无聊天素材，跳过）/ `missing`（有聊天素材但日页面缺失）。出现 missing **延迟成文**并在返回值列出缺失日期，防止月总结固化后（成文即跳过）永久缺失。
- 日页面兜底正文选择器改为 `summary → diary → digest → sections 正文`，diary-only 手写页不再被写成「无记录」。

## 注入规则（`get_calendar_for_injection` 周层）

- 七天全未被月/季/年覆盖 → 整周入选并认领七天；
- 七天全被覆盖 → 跳过整周，天数计入 `week_covered_dates`（维持 4~7 天概要档原语义）；
- **部分覆盖 → 跳过整周且不认领任何日子**，未覆盖侧交还日页面——消除「月总结成文后，跨月周替下月头几天占位、离开最近几天窗口即消失」的记忆空洞。

## 持久回归测试（进 CI，`scripts/test_calendar_summary_generation.py`）

以 2026-07 为基准（周一 6/29、7/6、7/13、7/20、7/27，两端跨月）断言素材**吃了哪些日期**，而不只是 token 预算：

1. 8/1 按时生成：三张整月周 + 7/1–5、7/27–31 日页面，6/29 周不采用
2. 8/3 后延迟/手动重建：7/27 周已存在仍整张排除，素材与场景 1 一致
3. 月中缺 7/13 周：那七天由日页面兜底
4. 缺口日页面缺失且当天有素材：`skipped/missing_day_pages`，不调模型不落库
5. 缺口日无页面也无素材（empty）：正常成文
6. diary-only 手写日页面：正文入素材，无「无记录」
7. 注入部分重叠：跨月周不入选且不占位，溢出侧日页面正常入选；整月内周被月总结正常压掉

已知边界（不在本 PR 修）：missing 状态依赖夜间日页面补生成（最近 7 天窗口）；更早的缺日需手动 `/admin/day-page` 补齐后月总结自动恢复生成，延迟日志会列出具体日期。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqDHH269LJZ4CY8W8R2zhf