### PR TITLE
fix: capture streaming tail events before downstream yield

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         run: |
           python scripts/test_drawer_stability.py
           python scripts/test_gateway_tool_streaming.py
+          python scripts/test_stream_capture.py
           python scripts/test_calendar_summary_generation.py
 
       - name: 运行 S1-S6 永久真库行为守卫

--- a/main.py
+++ b/main.py
@@ -2963,6 +2963,43 @@ async def _finalize_stream_memories(mem_enabled, session_id, user_message, assis
         emotion_level=emotion_level, project_id=project_id, is_regenerate=is_regenerate,
     )
 
+
+def _capture_openai_sse_event(event: str, full_response: list) -> tuple[int, dict | None]:
+    """Capture assistant text from one complete OpenAI-compatible SSE event.
+
+    This helper is intentionally pure apart from appending to the request-local
+    ``full_response`` list.  In particular it never writes to the database or
+    starts extraction work.  Usage-only events are left untouched for downstream
+    forwarding and do not become assistant text.
+    """
+    reasoning_chunks = 0
+    first_delta = None
+
+    for line in event.split("\n"):
+        line = line.strip()
+        if not line.startswith("data: ") or line == "data: [DONE]":
+            continue
+        try:
+            data = json.loads(line[6:])
+            choices = data.get("choices") or []
+            if not choices:
+                continue
+            delta = choices[0].get("delta") or {}
+            if not isinstance(delta, dict):
+                continue
+            if first_delta is None and delta:
+                first_delta = delta
+            if delta.get("reasoning_content") or delta.get("reasoning") or delta.get("reasoning_details"):
+                reasoning_chunks += 1
+            content = delta.get("content", "")
+            if isinstance(content, str) and content:
+                full_response.append(content)
+        except (json.JSONDecodeError, AttributeError, KeyError, IndexError, TypeError):
+            continue
+
+    return reasoning_chunks, first_delta
+
+
 async def stream_and_capture(headers: dict, body: dict, session_id: str, user_message: str, model: str, tool_events: list = None, api_url: str = None, project_id: str = None, prompt_meta: dict = None, api_format: str = "openai", api_key: str = None, is_regenerate: bool = False, mem_enabled: bool = True):
     """流式响应 + 捕获完整回复 + 工具事件"""
     _api_url = api_url or API_BASE_URL
@@ -3040,28 +3077,25 @@ async def stream_and_capture(headers: dict, body: dict, session_id: str, user_me
                             event = event.strip()
                             if not event or event == "data: [DONE]":
                                 continue
+                            captured_reasoning, _ = _capture_openai_sse_event(event, full_response)
+                            _reasoning_chunks += captured_reasoning
                             yield (event + "\n\n").encode("utf-8")
-                            try:
-                                for line in event.split("\n"):
-                                    line = line.strip()
-                                    if line.startswith("data: "):
-                                        data = json.loads(line[6:])
-                                        delta = data.get("choices", [{}])[0].get("delta", {})
-                                        content = delta.get("content", "")
-                                        if content:
-                                            full_response.append(content)
-                                        if delta.get("reasoning_content"):
-                                            _reasoning_chunks += 1
-                            except Exception:
-                                pass
                     _tail = _ev_buf.strip()
                     if _tail and _tail != "data: [DONE]":
+                        captured_reasoning, _ = _capture_openai_sse_event(_tail, full_response)
+                        _reasoning_chunks += captured_reasoning
                         yield (_tail + "\n\n").encode("utf-8")
         else:
             # OpenAI 格式：直接转发
             buffer = ""
+            stream_headers = {
+                key: value
+                for key, value in (headers or {}).items()
+                if key.lower() != "accept-encoding"
+            }
+            stream_headers["Accept-Encoding"] = "identity"
             async with httpx.AsyncClient(timeout=300) as client:
-                async with client.stream("POST", _api_url, headers=headers, json=body) as response:
+                async with client.stream("POST", _api_url, headers=stream_headers, json=body) as response:
                     if response.status_code != 200:
                         error_body = b""
                         async for chunk in response.aiter_bytes():
@@ -3082,36 +3116,25 @@ async def stream_and_capture(headers: dict, body: dict, session_id: str, user_me
                             event = event.strip()
                             if not event or event == "data: [DONE]":
                                 continue
+                            captured_reasoning, first_delta = _capture_openai_sse_event(event, full_response)
+                            _reasoning_chunks += captured_reasoning
+
+                            # 🔍 调试日志：记录第一个有效delta的所有字段
+                            if not _logged_first_delta and first_delta:
+                                keys = list(first_delta.keys())
+                                if keys and keys != ['role']:
+                                    print(f"🔍 [流式调试] 首个delta字段: {keys}, 模型: {model}")
+                                    for k in ('reasoning_content', 'reasoning', 'reasoning_details'):
+                                        if k in first_delta:
+                                            sample = str(first_delta[k])[:100]
+                                            print(f"🔍 [流式调试] {k} 示例: {sample}")
+                                    _logged_first_delta = True
+
                             yield (event + "\n\n").encode("utf-8")
-                            for line in event.split("\n"):
-                                line = line.strip()
-                                if not line.startswith("data: "):
-                                    continue
-                                try:
-                                    data = json.loads(line[6:])
-                                    delta = data.get("choices", [{}])[0].get("delta", {})
-
-                                    # 🔍 调试日志：记录第一个有效delta的所有字段
-                                    if not _logged_first_delta and delta:
-                                        keys = list(delta.keys())
-                                        if keys and keys != ['role']:
-                                            print(f"🔍 [流式调试] 首个delta字段: {keys}, 模型: {model}")
-                                            for k in ('reasoning_content', 'reasoning', 'reasoning_details'):
-                                                if k in delta:
-                                                    sample = str(delta[k])[:100]
-                                                    print(f"🔍 [流式调试] {k} 示例: {sample}")
-                                            _logged_first_delta = True
-
-                                    if delta.get('reasoning_content') or delta.get('reasoning') or delta.get('reasoning_details'):
-                                        _reasoning_chunks += 1
-
-                                    content = delta.get("content", "")
-                                    if content:
-                                        full_response.append(content)
-                                except (json.JSONDecodeError, KeyError, IndexError):
-                                    pass
                     _tail = buffer.strip()
                     if _tail and _tail != "data: [DONE]":
+                        captured_reasoning, _ = _capture_openai_sse_event(_tail, full_response)
+                        _reasoning_chunks += captured_reasoning
                         yield (_tail + "\n\n").encode("utf-8")
     finally:
         # 断连（取消/GeneratorExit）或正常完成都在此把收尾 task 与 Dream 兜底同步补出生。

--- a/scripts/test_stream_capture.py
+++ b/scripts/test_stream_capture.py
@@ -139,7 +139,7 @@ def fake_spawn(coro):
 
 def new_stream(api_format="openai"):
     return gateway.stream_and_capture(
-        {"Authorization": "Bearer test"},
+        {"Authorization": "Bearer test", "accept-encoding": "gzip"},
         {"model": "test-model", "messages": []},
         "test-session",
         "test-user-message",
@@ -211,6 +211,7 @@ async def case_openai_normal_usage_tail():
     headers = ACTIVE_PLAN.requests[0]["headers"]
     check(headers.get("Authorization") == "Bearer test", "OpenAI headers must be preserved")
     check(headers.get("Accept-Encoding") == "identity", "OpenAI stream must disable compression")
+    check("accept-encoding" not in headers, "OpenAI stream must replace case-insensitive encoding headers")
 
 
 async def case_openai_cancel_after_complete_event():
@@ -235,6 +236,20 @@ async def case_anthropic_capture_before_yield_and_tail():
     check(headers.get("Accept-Encoding") == "identity", "Anthropic identity header must remain")
 
 
+async def case_anthropic_cancel_after_complete_event():
+    reset(UpstreamPlan([sse_content("anthropic-delivered") + b"\n\n", sse_content("unread") + b"\n\n"]))
+    await close_after_matching_event(new_stream("anthropic"), "anthropic-delivered")
+    assert_single_finalize("anthropic-delivered")
+
+
+async def case_upstream_done_is_deduplicated():
+    reset(UpstreamPlan([sse_content("done") + b"\n\ndata: [DONE]\n\n"]))
+    events = await collect_stream(new_stream("openai"))
+    assert_single_finalize("done")
+    check(events.count("data: [DONE]\n\n") == 1, "upstream [DONE] must be replaced by one final event")
+    check(events[-1] == "data: [DONE]\n\n", "[DONE] must remain last")
+
+
 async def main():
     patches = (
         patch.object(gateway.httpx, "AsyncClient", FakeAsyncClient),
@@ -252,6 +267,8 @@ async def main():
             case_openai_cancel_after_complete_event,
             case_openai_cancel_after_residual_tail,
             case_anthropic_capture_before_yield_and_tail,
+            case_anthropic_cancel_after_complete_event,
+            case_upstream_done_is_deduplicated,
         )
         for case in cases:
             try:

--- a/scripts/test_stream_capture.py
+++ b/scripts/test_stream_capture.py
@@ -1,0 +1,271 @@
+"""No-network regression checks for ``stream_and_capture``.
+
+The fake upstream emits real SSE byte fragments through the production async
+generator.  The checks intentionally close the downstream generator directly
+after a yielded model event so a capture-after-yield regression loses the same
+chunk that the client has already received.
+"""
+
+import asyncio
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from unittest.mock import patch
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+import main as gateway
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def sse_content(text):
+    return (
+        "data: "
+        + json.dumps(
+            {"choices": [{"delta": {"content": text}, "finish_reason": None}]},
+            ensure_ascii=False,
+        )
+    ).encode("utf-8")
+
+
+def sse_usage():
+    return (
+        "data: "
+        + json.dumps(
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 7,
+                    "completion_tokens": 2,
+                    "total_tokens": 9,
+                },
+            }
+        )
+    ).encode("utf-8")
+
+
+@dataclass
+class UpstreamPlan:
+    chunks: list[bytes]
+    requests: list[dict] = field(default_factory=list)
+
+
+ACTIVE_PLAN = None
+FINALIZE_CALLS = []
+SPAWNED_TASKS = []
+
+
+class FakeResponse:
+    status_code = 200
+
+    async def aiter_bytes(self, chunk_size=None):
+        del chunk_size
+        for chunk in ACTIVE_PLAN.chunks:
+            yield chunk
+
+
+class FakeStreamContext:
+    async def __aenter__(self):
+        return FakeResponse()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def stream(self, method, url, headers=None, json=None):
+        ACTIVE_PLAN.requests.append(
+            {
+                "method": method,
+                "url": url,
+                "headers": dict(headers or {}),
+                "json": dict(json or {}),
+            }
+        )
+        return FakeStreamContext()
+
+
+async def fake_anthropic_adapter(_response, _model):
+    for chunk in ACTIVE_PLAN.chunks:
+        yield chunk
+
+
+async def fake_finalize(
+    mem_enabled,
+    session_id,
+    user_message,
+    assistant_msg,
+    model,
+    emotion_level,
+    project_id,
+    is_regenerate,
+):
+    FINALIZE_CALLS.append(
+        {
+            "mem_enabled": mem_enabled,
+            "session_id": session_id,
+            "user_message": user_message,
+            "assistant_msg": assistant_msg,
+            "model": model,
+            "emotion_level": emotion_level,
+            "project_id": project_id,
+            "is_regenerate": is_regenerate,
+        }
+    )
+    return {"action": "skip"}
+
+
+def fake_spawn(coro):
+    task = asyncio.create_task(coro)
+    SPAWNED_TASKS.append(task)
+    return task
+
+
+def new_stream(api_format="openai"):
+    return gateway.stream_and_capture(
+        {"Authorization": "Bearer test"},
+        {"model": "test-model", "messages": []},
+        "test-session",
+        "test-user-message",
+        "test-model",
+        api_url="https://upstream.invalid/v1/chat/completions",
+        api_format=api_format,
+        api_key="test-key",
+        mem_enabled=True,
+    )
+
+
+async def wait_for_spawned():
+    if SPAWNED_TASKS:
+        await asyncio.gather(*SPAWNED_TASKS)
+
+
+def reset(plan):
+    global ACTIVE_PLAN
+    ACTIVE_PLAN = plan
+    FINALIZE_CALLS.clear()
+    SPAWNED_TASKS.clear()
+
+
+async def collect_stream(stream):
+    events = []
+    async for chunk in stream:
+        events.append(chunk.decode("utf-8"))
+    await wait_for_spawned()
+    return events
+
+
+async def close_after_matching_event(stream, marker):
+    events = []
+    while True:
+        chunk = await anext(stream)
+        text = chunk.decode("utf-8")
+        events.append(text)
+        if marker in text:
+            check(not FINALIZE_CALLS, "delta loop must not finalize or write before downstream closes")
+            await stream.aclose()
+            await wait_for_spawned()
+            return events
+
+
+def assert_single_finalize(expected_text):
+    check(len(FINALIZE_CALLS) == 1, f"finalizer must run once, got {len(FINALIZE_CALLS)}")
+    check(
+        FINALIZE_CALLS[0]["assistant_msg"] == expected_text,
+        f"saved assistant text must be {expected_text!r}, got {FINALIZE_CALLS[0]['assistant_msg']!r}",
+    )
+
+
+async def case_openai_normal_usage_tail():
+    reset(
+        UpstreamPlan(
+            [
+                sse_content("alpha") + b"\n\n" + sse_content("beta")[:19],
+                sse_content("beta")[19:] + b"\n\n",
+                sse_usage(),
+            ]
+        )
+    )
+    events = await collect_stream(new_stream("openai"))
+
+    assert_single_finalize("alphabeta")
+    check(events[-1] == "data: [DONE]\n\n", "[DONE] must remain the final downstream event")
+    check(any('"usage"' in event for event in events), "usage tail must still be forwarded")
+    check("usage" not in FINALIZE_CALLS[0]["assistant_msg"], "usage must not enter assistant text")
+    headers = ACTIVE_PLAN.requests[0]["headers"]
+    check(headers.get("Authorization") == "Bearer test", "OpenAI headers must be preserved")
+    check(headers.get("Accept-Encoding") == "identity", "OpenAI stream must disable compression")
+
+
+async def case_openai_cancel_after_complete_event():
+    reset(UpstreamPlan([sse_content("delivered") + b"\n\n", sse_content("unread") + b"\n\n"]))
+    await close_after_matching_event(new_stream("openai"), "delivered")
+    assert_single_finalize("delivered")
+
+
+async def case_openai_cancel_after_residual_tail():
+    reset(UpstreamPlan([sse_content("first") + b"\n\n", sse_content("tail")]))
+    await close_after_matching_event(new_stream("openai"), "tail")
+    assert_single_finalize("firsttail")
+
+
+async def case_anthropic_capture_before_yield_and_tail():
+    reset(UpstreamPlan([sse_content("anthropic") + b"\n\n", sse_content("-tail")]))
+    events = await collect_stream(new_stream("anthropic"))
+
+    assert_single_finalize("anthropic-tail")
+    check(events[-1] == "data: [DONE]\n\n", "Anthropic stream must finish with one [DONE]")
+    headers = ACTIVE_PLAN.requests[0]["headers"]
+    check(headers.get("Accept-Encoding") == "identity", "Anthropic identity header must remain")
+
+
+async def main():
+    patches = (
+        patch.object(gateway.httpx, "AsyncClient", FakeAsyncClient),
+        patch.object(gateway, "anthropic_stream_to_openai", fake_anthropic_adapter),
+        patch.object(gateway, "_finalize_stream_memories", fake_finalize),
+        patch.object(gateway, "_spawn_background_task", fake_spawn),
+        patch.object(gateway, "detect_dream_trigger", lambda _text: False),
+    )
+    failures = []
+    try:
+        for item in patches:
+            item.start()
+        cases = (
+            case_openai_normal_usage_tail,
+            case_openai_cancel_after_complete_event,
+            case_openai_cancel_after_residual_tail,
+            case_anthropic_capture_before_yield_and_tail,
+        )
+        for case in cases:
+            try:
+                await case()
+            except Exception as exc:
+                failures.append(f"{case.__name__}: {exc}")
+    finally:
+        for item in reversed(patches):
+            item.stop()
+
+    if failures:
+        raise AssertionError("stream capture guards failed:\n- " + "\n- ".join(failures))
+    print("PASS: stream capture-before-yield and single-finalize guards")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Scope

W1-02 from the approved Kiwi synchronization ledger. This PR fixes capture ordering in the OpenAI-compatible and Anthropic streaming paths and adds the missing OpenAI compression guard.

## Root cause

Complete SSE events were yielded before their assistant content was appended to the request-local capture buffer. If the downstream client closed immediately after receiving an event, generator cleanup ran with that delivered event still absent from `full_response`. Residual events without a trailing blank-line delimiter were forwarded without being captured at all. The OpenAI path also did not force `Accept-Encoding: identity`.

## Behavior contract

- Parse each complete SSE event and append assistant content to request-local memory before yielding it downstream.
- Apply the same parser to residual tail events.
- Keep usage-only events forwarded but out of assistant text.
- Keep database writes and extraction outside the delta loop; finalization is spawned at most once from `finally`.
- Preserve a single final `[DONE]` event.
- Force `Accept-Encoding: identity` on both provider formats while preserving other OpenAI headers.

## Red/green proof

- Tests-only commit `08a67b3` failed on the pre-fix tree with four independent violations: missing OpenAI identity, zero finalization after immediate OpenAI close, missing OpenAI residual text, and missing Anthropic residual text.
- Fixed commit `9d59f35` passes the new no-network stream guard, including normal multi-delta framing, usage tail, OpenAI and Anthropic cancellation, residual tails, header replacement, single finalization, and `[DONE]` deduplication.
- A temporary mutation that restored OpenAI yield-before-capture made only `case_openai_cancel_after_complete_event` fail; the mutation was removed and the final tree returned green.

## Validation

- Python compilation for changed files
- `scripts/test_drawer_stability.py`
- `scripts/test_gateway_tool_streaming.py` (real ASGI app with fake upstream)
- `scripts/test_stream_capture.py` (production async generator with fake upstream bytes and downstream cancellation)
- `scripts/test_calendar_summary_generation.py`
- `git diff --check`
- [GitHub CI Run 31462368289](https://github.com/LucieEveille/kiwi-mem/actions/runs/31462368289): success on final head `9d59f35`; Python 3.12 syntax job, open-source regression step, PostgreSQL 16 behavior job, and permanent S1-S6 database guard step all passed.

This workstation has no local PostgreSQL service or container runtime. PostgreSQL behavior was therefore verified by the disposable PostgreSQL 16 GitHub service. No real model, external provider API, production database, or real user data was called.

## Compatibility and rollback

No schema, endpoint, payload, token-budget, tool-loop, memory, Dream, or calendar semantics change. Revert the implementation commit to restore the prior behavior; no migration or backfill is required.