### PR TITLE
fix: harden calendar model JSON parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           python scripts/test_gateway_tool_streaming.py
           python scripts/test_stream_capture.py
           python scripts/test_calendar_summary_generation.py
+          python scripts/test_calendar_json_parser.py
 
       - name: 运行 S1-S6 永久真库行为守卫
         run: python scripts/test_kiwi_safety_sync.py

--- a/daily_digest.py
+++ b/daily_digest.py
@@ -1020,6 +1020,234 @@ DAY_PAGE_PROMPT = """你是用户的 AI 伴侣。请根据今天的完整聊天�
 {conversations}"""
 
 
+def _strip_json_wrapping(text: str) -> str:
+    """Remove the common Markdown fence around a model JSON response."""
+    value = (text or "").strip()
+    if value.startswith("```json"):
+        value = value[7:]
+    elif value.startswith("```"):
+        value = value[3:]
+    if value.endswith("```"):
+        value = value[:-3]
+    return value.strip()
+
+
+def _iter_json_object_candidates(text: str):
+    """Yield balanced JSON-object slices without a greedy cross-object match."""
+    start = None
+    depth = 0
+    in_string = False
+    escaped = False
+    for index, char in enumerate(text):
+        if start is None:
+            if char == "{":
+                start = index
+                depth = 1
+                in_string = False
+                escaped = False
+            continue
+
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                yield text[start:index + 1]
+                start = None
+
+
+def _next_nonspace_index(text: str, start: int) -> int:
+    index = start
+    while index < len(text) and text[index].isspace():
+        index += 1
+    return index
+
+
+def _quote_is_structural(
+    text: str,
+    quote_index: int,
+    container: str = None,
+    string_is_key: bool = False,
+) -> bool:
+    """Return whether a quote looks like a JSON key/value closing quote."""
+    index = _next_nonspace_index(text, quote_index + 1)
+    if string_is_key:
+        return index < len(text) and text[index] == ":"
+    if index >= len(text):
+        return container is None
+    if container == "{":
+        if text[index] == "}":
+            return True
+        if text[index] != ",":
+            return False
+        index = _next_nonspace_index(text, index + 1)
+        return index < len(text) and text[index] == '"'
+    if container == "[":
+        if text[index] == "]":
+            return True
+        if text[index] != ",":
+            return False
+        index = _next_nonspace_index(text, index + 1)
+        if index >= len(text):
+            return False
+        return (
+            text[index] in '"{['
+            or text[index].isdigit()
+            or text[index] == "-"
+            or text.startswith("true", index)
+            or text.startswith("false", index)
+            or text.startswith("null", index)
+        )
+    return False
+
+
+def _escape_unescaped_json_content_quotes(text: str) -> str:
+    """Conservatively escape bare quotes inside JSON string content."""
+    output = []
+    containers = []
+    last_significant = None
+    in_string = False
+    escaped = False
+    string_container = None
+    string_is_key = False
+    for index, char in enumerate(text):
+        if not in_string:
+            if char == '"':
+                string_container = containers[-1] if containers else None
+                string_is_key = string_container == "{" and last_significant in ("{", ",")
+                in_string = True
+            elif char in "{[":
+                containers.append(char)
+            elif char == "}" and containers and containers[-1] == "{":
+                containers.pop()
+            elif char == "]" and containers and containers[-1] == "[":
+                containers.pop()
+            output.append(char)
+            if not char.isspace():
+                last_significant = char
+            continue
+
+        if escaped:
+            output.append(char)
+            escaped = False
+        elif char == "\\":
+            output.append(char)
+            escaped = True
+        elif char != '"':
+            output.append(char)
+        elif _quote_is_structural(text, index, string_container, string_is_key):
+            in_string = False
+            output.append(char)
+            last_significant = char
+        else:
+            output.append('\\"')
+    return "".join(output)
+
+
+def _has_safe_json_keys(value, *, root: bool = True) -> bool:
+    """Reject malformed keys that may have been invented by quote repair."""
+    if isinstance(value, dict):
+        if root and not value:
+            return False
+        for key, child in value.items():
+            if (
+                not isinstance(key, str)
+                or not key
+                or len(key) > 64
+                or not all(char.isascii() and (char.isalnum() or char in "_-") for char in key)
+            ):
+                return False
+            if not _has_safe_json_keys(child, root=False):
+                return False
+    elif isinstance(value, list):
+        return all(_has_safe_json_keys(item, root=False) for item in value)
+    return True
+
+
+def _is_string_list(value) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _is_valid_calendar_payload(value, payload_type: str) -> bool:
+    """Validate the complete persisted shape for day or summary pages."""
+    if not isinstance(value, dict) or not _has_safe_json_keys(value):
+        return False
+
+    if payload_type == "day":
+        required = {"summary", "digest", "sections", "diary", "all_keywords"}
+        if not required.issubset(value):
+            return False
+        if not all(isinstance(value[key], str) for key in ("summary", "digest", "diary")):
+            return False
+        if not _is_string_list(value["all_keywords"]):
+            return False
+        if not isinstance(value["sections"], list):
+            return False
+        section_keys = {"period", "title", "content", "keywords"}
+        for section in value["sections"]:
+            if not isinstance(section, dict) or not section_keys.issubset(section):
+                return False
+            if not all(isinstance(section[key], str) for key in ("period", "title", "content")):
+                return False
+            if not _is_string_list(section["keywords"]):
+                return False
+        return True
+
+    if payload_type == "summary":
+        required = {"summary", "digest", "sections", "highlights", "diary"}
+        if not required.issubset(value):
+            return False
+        if not all(isinstance(value[key], str) for key in ("summary", "digest", "diary")):
+            return False
+        if not _is_string_list(value["highlights"]):
+            return False
+        sections = value["sections"]
+        section_keys = {"emotion", "life", "growth"}
+        return (
+            isinstance(sections, dict)
+            and section_keys.issubset(sections)
+            and all(isinstance(sections[key], str) for key in section_keys)
+        )
+
+    return False
+
+
+def _parse_calendar_model_json(text: str, payload_type: str):
+    """Parse a complete calendar model object from common imperfect output."""
+    cleaned = _strip_json_wrapping(text)
+    if not cleaned:
+        return None
+
+    candidates = [cleaned]
+    candidates.extend(_iter_json_object_candidates(cleaned))
+    seen = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        for attempt in (candidate, _escape_unescaped_json_content_quotes(candidate)):
+            try:
+                result = json.loads(attempt, strict=False)
+            except json.JSONDecodeError:
+                continue
+            if _is_valid_calendar_payload(result, payload_type):
+                if attempt != candidate:
+                    print("   🔧 JSON 内容引号兜底解析成功")
+                return result
+    return None
+
+
 async def generate_day_page(target_date: str = None, model_override: str = None):
     # Bug #7：防止同一日期并发生成日页面。与 run_daily_digest 共用 _digest_running，
     # 故用 daypage: 前缀的 key 区分，避免与每日整理互相误判为“正在进行”。
@@ -1164,33 +1392,21 @@ async def _generate_day_page_impl(target_date: str = None, model_override: str =
                 return {"date": date_str, "status": "error", "error": f"HTTP {response.status_code}"}
 
             data = parse_background_response(response.json(), use_api_format)
-            text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+            choices = data.get("choices") or [{}]
+            choice = choices[0] if isinstance(choices[0], dict) else {}
+            message = choice.get("message") or {}
+            text = message.get("content") or ""
+            if choice.get("finish_reason") == "length":
+                usage = data.get("usage") or {}
+                print(
+                    "   ⚠️ 日页面模型输出达到 token 上限："
+                    f"finish_reason=length completion_tokens={usage.get('completion_tokens')} "
+                    f"text_chars={len(text)} max_tokens=6000"
+                )
+                return {"date": date_str, "status": "error", "error": "invalid format"}
 
-            # 清理 markdown 包裹
-            text = text.strip()
-            if text.startswith("```json"):
-                text = text[7:]
-            if text.startswith("```"):
-                text = text[3:]
-            if text.endswith("```"):
-                text = text[:-3]
-            text = text.strip()
-
-            # 解析 JSON
-            result = None
-            try:
-                result = json.loads(text)
-            except json.JSONDecodeError:
-                import re
-                match = re.search(r'\{.*\}', text, re.DOTALL)
-                if match:
-                    try:
-                        result = json.loads(match.group())
-                        print(f"   🔧 JSON 正则兜底解析成功")
-                    except json.JSONDecodeError:
-                        pass
-
-            if not result or not isinstance(result, dict):
+            result = _parse_calendar_model_json(text, "day")
+            if result is None:
                 print(f"   ⚠️ 日页面模型返回格式错误：{text[:200]}")
                 return {"date": date_str, "status": "error", "error": "invalid format"}
 
@@ -1811,27 +2027,11 @@ async def _call_model_for_json(prompt: str, user_msg: str, model: str, max_token
                     f"text_chars={len(text)} max_tokens={max_tokens}"
                 )
                 return None
-            text = text.strip()
-            if text.startswith("```json"):
-                text = text[7:]
-            if text.startswith("```"):
-                text = text[3:]
-            if text.endswith("```"):
-                text = text[:-3]
-            text = text.strip()
-
-            try:
-                return json.loads(text)
-            except json.JSONDecodeError:
-                import re
-                match = re.search(r'\{.*\}', text, re.DOTALL)
-                if match:
-                    try:
-                        return json.loads(match.group())
-                    except json.JSONDecodeError:
-                        pass
-                print(f"   ⚠️ JSON 解析失败：{text[:200]}")
-                return None
+            result = _parse_calendar_model_json(text, "summary")
+            if result is not None:
+                return result
+            print(f"   ⚠️ JSON 解析失败：{text[:200]}")
+            return None
     except Exception as e:
         print(f"   ⚠️ 模型调用出错: {e}")
         return None

--- a/scripts/test_calendar_json_parser.py
+++ b/scripts/test_calendar_json_parser.py
@@ -40,20 +40,21 @@ SUMMARY_RESULT = {
 class _FakeResponse:
     status_code = 200
 
-    def __init__(self, text):
+    def __init__(self, text, finish_reason="stop"):
         self._text = text
+        self._finish_reason = finish_reason
 
     def json(self):
         return {
             "choices": [{
                 "message": {"content": self._text},
-                "finish_reason": "stop",
+                "finish_reason": self._finish_reason,
             }],
             "usage": {"completion_tokens": 100},
         }
 
 
-def _fake_async_client(text):
+def _fake_async_client(text, finish_reason="stop"):
     class FakeAsyncClient:
         def __init__(self, *args, **kwargs):
             pass
@@ -65,7 +66,7 @@ def _fake_async_client(text):
             return False
 
         async def post(self, *args, **kwargs):
-            return _FakeResponse(text)
+            return _FakeResponse(text, finish_reason)
 
     return FakeAsyncClient
 
@@ -116,7 +117,7 @@ async def _calendar_range(start, end, page_type):
     }]
 
 
-async def _run_day(text, save_hook=None):
+async def _run_day(text, save_hook=None, finish_reason="stop"):
     saves = []
 
     async def fake_save(*args, **kwargs):
@@ -131,7 +132,11 @@ async def _run_day(text, save_hook=None):
         patch.object(database, "resolve_model_endpoint", _model_endpoint),
         patch.object(database, "save_calendar_page", fake_save),
         patch.object(config, "get_config", _empty_config),
-        patch.object(daily_digest.httpx, "AsyncClient", _fake_async_client(text)),
+        patch.object(
+            daily_digest.httpx,
+            "AsyncClient",
+            _fake_async_client(text, finish_reason),
+        ),
     ):
         result = await daily_digest.generate_day_page(
             "2026-07-01", model_override="test-model"
@@ -195,6 +200,12 @@ async def case_truncated_json_rejected():
     assert result["status"] == "error" and saves == []
 
 
+async def case_length_finish_rejected_even_when_parseable():
+    text = json.dumps(DAY_RESULT, ensure_ascii=False)
+    result, saves = await _run_day(text, finish_reason="length")
+    assert result["status"] == "error" and saves == []
+
+
 async def case_empty_response_rejected():
     result, saves = await _run_day("   ")
     assert result["status"] == "error" and saves == []
@@ -245,6 +256,7 @@ async def main():
         case_explanatory_text_with_braces,
         case_raw_content_quotes,
         case_truncated_json_rejected,
+        case_length_finish_rejected_even_when_parseable,
         case_empty_response_rejected,
         case_day_field_types_rejected,
         case_summary_field_types_rejected,

--- a/scripts/test_calendar_json_parser.py
+++ b/scripts/test_calendar_json_parser.py
@@ -1,0 +1,267 @@
+"""No-network contracts for calendar model JSON parsing and safe persistence."""
+
+import asyncio
+from copy import deepcopy
+import json
+import os
+import sys
+from unittest.mock import patch
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+import config
+import daily_digest
+import database
+
+
+DAY_RESULT = {
+    "summary": "day summary",
+    "digest": "day digest",
+    "sections": [{
+        "period": "上午",
+        "title": "记录",
+        "content": "正文",
+        "keywords": ["日常"],
+    }],
+    "diary": "day diary",
+    "all_keywords": ["day"],
+}
+
+SUMMARY_RESULT = {
+    "summary": "summary",
+    "digest": "digest",
+    "sections": {"emotion": "e", "life": "l", "growth": "g"},
+    "highlights": ["highlight"],
+    "diary": "diary",
+}
+
+
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self, text):
+        self._text = text
+
+    def json(self):
+        return {
+            "choices": [{
+                "message": {"content": self._text},
+                "finish_reason": "stop",
+            }],
+            "usage": {"completion_tokens": 100},
+        }
+
+
+def _fake_async_client(text):
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, *args, **kwargs):
+            return _FakeResponse(text)
+
+    return FakeAsyncClient
+
+
+class _FakeConnection:
+    async def fetch(self, *args, **kwargs):
+        return []
+
+
+class _FakeAcquire:
+    async def __aenter__(self):
+        return _FakeConnection()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakePool:
+    def acquire(self):
+        return _FakeAcquire()
+
+
+async def _empty_config(*args, **kwargs):
+    return ""
+
+
+async def _model_endpoint(*args, **kwargs):
+    return "https://model.test/v1/chat/completions", "test-key", "openai"
+
+
+async def _messages(*args, **kwargs):
+    return [{"role": "user", "content": "hello"}]
+
+
+async def _pool(*args, **kwargs):
+    return _FakePool()
+
+
+async def _calendar_range(start, end, page_type):
+    if page_type != "day":
+        return []
+    return [{
+        "type": "day",
+        "date": start,
+        "sections": [{"period": "上午", "title": "记录", "content": "source"}],
+        "keywords": [],
+        "diary": "",
+    }]
+
+
+async def _run_day(text, save_hook=None):
+    saves = []
+
+    async def fake_save(*args, **kwargs):
+        saves.append(kwargs)
+        if save_hook:
+            save_hook(kwargs)
+        return 101
+
+    with (
+        patch.object(database, "get_chat_messages_for_date", _messages),
+        patch.object(database, "get_pool", _pool),
+        patch.object(database, "resolve_model_endpoint", _model_endpoint),
+        patch.object(database, "save_calendar_page", fake_save),
+        patch.object(config, "get_config", _empty_config),
+        patch.object(daily_digest.httpx, "AsyncClient", _fake_async_client(text)),
+    ):
+        result = await daily_digest.generate_day_page(
+            "2026-07-01", model_override="test-model"
+        )
+    return result, saves
+
+
+async def _run_week(text):
+    saves = []
+
+    async def fake_save(*args, **kwargs):
+        saves.append(kwargs)
+        return 202
+
+    with (
+        patch.object(database, "get_calendar_range", _calendar_range),
+        patch.object(database, "resolve_model_endpoint", _model_endpoint),
+        patch.object(database, "save_calendar_page", fake_save),
+        patch.object(config, "get_config", _empty_config),
+        patch.object(daily_digest.httpx, "AsyncClient", _fake_async_client(text)),
+    ):
+        result = await daily_digest.generate_week_summary(
+            "2026-07-01", "2026-07-07", model_override="test-model"
+        )
+    return result, saves
+
+
+async def case_normal_json():
+    result, saves = await _run_day(json.dumps(DAY_RESULT, ensure_ascii=False))
+    assert result["status"] == "success" and len(saves) == 1
+
+
+async def case_fenced_json():
+    text = "```json\n" + json.dumps(DAY_RESULT, ensure_ascii=False) + "\n```"
+    result, saves = await _run_day(text)
+    assert result["status"] == "success" and len(saves) == 1
+
+
+async def case_explanatory_text_with_braces():
+    text = (
+        "说明：{这段只是自然语言，不是 JSON}\n"
+        + json.dumps(DAY_RESULT, ensure_ascii=False)
+        + "\n以上是整理结果。"
+    )
+    result, saves = await _run_day(text)
+    assert result["status"] == "success" and len(saves) == 1
+
+
+async def case_raw_content_quotes():
+    payload = deepcopy(DAY_RESULT)
+    payload["summary"] = '她说"你好"，然后笑了'
+    text = json.dumps(payload, ensure_ascii=False).replace('\\"你好\\"', '"你好"')
+    result, saves = await _run_day(text)
+    assert result["status"] == "success" and len(saves) == 1
+    assert saves[0]["summary"] == payload["summary"]
+
+
+async def case_truncated_json_rejected():
+    text = json.dumps(DAY_RESULT, ensure_ascii=False)[:-1]
+    result, saves = await _run_day(text)
+    assert result["status"] == "error" and saves == []
+
+
+async def case_empty_response_rejected():
+    result, saves = await _run_day("   ")
+    assert result["status"] == "error" and saves == []
+
+
+async def case_day_field_types_rejected():
+    payload = deepcopy(DAY_RESULT)
+    payload["sections"] = {"content": "wrong container"}
+    result, saves = await _run_day(json.dumps(payload, ensure_ascii=False))
+    assert result["status"] == "error" and saves == []
+
+
+async def case_summary_field_types_rejected():
+    payload = deepcopy(SUMMARY_RESULT)
+    payload["sections"] = ["wrong container"]
+    payload["highlights"] = "wrong list"
+    result, saves = await _run_week(json.dumps(payload, ensure_ascii=False))
+    assert result["status"] == "error" and saves == []
+
+
+async def case_authored_page_survives_failure():
+    authored = {"model_used": "user_edit", "diary": "用户原文", "summary": "用户概要"}
+    before = deepcopy(authored)
+
+    def overwrite_if_saved(kwargs):
+        authored.update({"diary": kwargs["diary"], "summary": kwargs["summary"]})
+
+    payload = deepcopy(DAY_RESULT)
+    payload["all_keywords"] = {"wrong": "container"}
+    result, saves = await _run_day(
+        json.dumps(payload, ensure_ascii=False), save_hook=overwrite_if_saved
+    )
+    assert result["status"] == "error" and saves == []
+    assert authored == before
+
+
+async def case_failure_can_retry():
+    failed, failed_saves = await _run_day(json.dumps(DAY_RESULT, ensure_ascii=False)[:-1])
+    retried, retry_saves = await _run_day(json.dumps(DAY_RESULT, ensure_ascii=False))
+    assert failed["status"] == "error" and failed_saves == []
+    assert retried["status"] == "success" and len(retry_saves) == 1
+
+
+async def main():
+    cases = [
+        case_normal_json,
+        case_fenced_json,
+        case_explanatory_text_with_braces,
+        case_raw_content_quotes,
+        case_truncated_json_rejected,
+        case_empty_response_rejected,
+        case_day_field_types_rejected,
+        case_summary_field_types_rejected,
+        case_authored_page_survives_failure,
+        case_failure_can_retry,
+    ]
+    failures = []
+    for case in cases:
+        try:
+            await case()
+            print(f"PASS {case.__name__}")
+        except Exception as exc:
+            failures.append(f"FAIL {case.__name__}: {type(exc).__name__}: {exc}")
+    if failures:
+        raise AssertionError("\n".join(failures))
+    print("test_calendar_json_parser: all tests passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Scope

- Replace greedy calendar JSON regex fallback with balanced object extraction.
- Conservatively repair bare quotes inside JSON string content.
- Validate complete day-page and summary payload shapes before persistence.
- Reject finish_reason=length for day pages as well as summaries.

## Safety contracts

- Normal, fenced, explanatory, and bare-quote responses are covered.
- Truncated, empty, and wrong-typed payloads never call save_calendar_page.
- Existing authored content remains unchanged on parse failure.
- A failed scheduled attempt can retry successfully.

## Evidence

- Tests-first commits: 07a9af7 and 305d689.
- Local: calendar JSON parser, calendar hierarchy, drawer, tool-loop, and stream-capture suites pass.
- Negative mutation: bypassing payload validation makes the wrong-field guard fail precisely.
- Real model/API not called; PostgreSQL 16 safety guards are delegated to CI because this change has no schema or data migration.