### PR TITLE
fix: gate drawer fallback and MCP recall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           python scripts/test_stream_capture.py
           python scripts/test_calendar_summary_generation.py
           python scripts/test_calendar_json_parser.py
+          python scripts/test_mcp_recall.py
 
       - name: 运行 S1-S6 永久真库行为守卫
         run: python scripts/test_kiwi_safety_sync.py

--- a/main.py
+++ b/main.py
@@ -2038,6 +2038,8 @@ async def chat_completions(request: Request):
             await _drawer_init()
         except Exception as e:
             print(f"⚠️ 工具抽屉 lazy init 失败: {e}")
+        drawer_tools = []
+        drawer_map = {}
         try:
             from tool_drawer import route_tools as _drawer_route
             user_embedding = prompt_meta.get("user_embedding") if prompt_meta else None
@@ -2051,10 +2053,33 @@ async def chat_completions(request: Request):
                 mcp_mode=mcp_mode,
                 reminder_tools_enabled=reminder_tools_enabled,
             )
-            openai_tools.extend(drawer_tools)
-            tool_map.update(drawer_map)
         except Exception as e:
             print(f"❌ 工具抽屉路由失败: {e}")
+        if drawer_tools and drawer_map:
+            openai_tools.extend(drawer_tools)
+            tool_map.update(drawer_map)
+        else:
+            print("⚠️ 工具抽屉路由无可用结果，启用受门控的全量降级")
+            try:
+                from tool_drawer import build_full_fallback_tools, _get_pinned_external_categories
+                pinned_external = (
+                    await _get_pinned_external_categories()
+                    if mcp_mode == "manual"
+                    else set()
+                )
+                fallback_tools, fallback_map = build_full_fallback_tools(
+                    search_enabled=bool(do_search_auto),
+                    mem_enabled=mem_enabled,
+                    reminder_tools_enabled=reminder_tools_enabled,
+                    mcp_mode=mcp_mode,
+                    pinned_external=pinned_external,
+                    project_id=project_id,
+                )
+                openai_tools.extend(fallback_tools)
+                tool_map.update(fallback_map)
+                print(f"🗃️  全量降级：装载了 {len(fallback_tools)} 个受门控工具")
+            except Exception as fallback_e:
+                print(f"❌ 工具抽屉全量降级失败: {fallback_e}")
         # Request-body MCP servers are explicit third-party input and bypass mcp_mode by design.
         if mcp_servers:
             try:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -60,7 +60,7 @@ async def search_memory(query: str, limit: int = 10) -> str:
         async with httpx.AsyncClient(timeout=15, headers=GATEWAY_HEADERS) as client:
             resp = await client.get(
                 f"{GATEWAY_BASE}/debug/memories",
-                params={"q": query, "limit": limit},
+                params={"q": query, "limit": limit, "track_recall": "true"},
             )
             data = resp.json()
 

--- a/scripts/test_drawer_stability.py
+++ b/scripts/test_drawer_stability.py
@@ -14,11 +14,25 @@ sys.path.insert(0, ROOT)
 import tool_drawer as td
 
 RETURN_MESSAGE = "工具抽屉已是常驻模式：本会话展开的工具会一直保持可用，无需归还。"
+REMINDER_NAMES = {
+    "_gateway_create_reminder",
+    "_gateway_list_reminders",
+    "_gateway_complete_reminder",
+    "_gateway_delete_reminder",
+}
 
 
 def check(condition, message):
     if not condition:
         raise AssertionError(message)
+
+
+def tool_names(tools):
+    return [
+        item.get("function", {}).get("name")
+        for item in tools
+        if item.get("function", {}).get("name")
+    ]
 
 
 def ensure_categories():
@@ -193,6 +207,101 @@ async def check_reminder_route_gate():
         check("reminder" not in td._get_session(sid)["expanded"], "disabled route must keep reminder collapsed")
 
 
+async def check_fallback_builder_gates():
+    ext_id = "ext_fallback_contract"
+    ext_tool = "fallback_external_probe"
+    ext_schema = {
+        "type": "function",
+        "function": {
+            "name": ext_tool,
+            "description": "fallback external probe",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    td.TOOL_SCHEMAS[ext_tool] = ext_schema
+    td._tool_to_category[ext_tool] = ext_id
+    td.CATEGORIES[ext_id] = {
+        "label": "Fallback MCP",
+        "description": "fallback external probe",
+        "tool_names": [ext_tool],
+        "external": True,
+    }
+    td._external_categories[ext_id] = {
+        "label": "Fallback MCP",
+        "server_name": "Fallback MCP",
+        "tool_names": [ext_tool],
+        "tool_map": {
+            ext_tool: {
+                "type": "external_mcp",
+                "url": "https://invalid.test/mcp",
+                "transport": "streamable_http",
+                "server_name": "Fallback MCP",
+                "origin_name": ext_tool,
+            }
+        },
+    }
+    try:
+        blocked_tools, blocked_map = td.build_full_fallback_tools(
+            search_enabled=False,
+            mem_enabled=False,
+            reminder_tools_enabled=False,
+            mcp_mode="off",
+            project_id="project-hidden",
+        )
+        blocked_names = tool_names(blocked_tools)
+        meta_names = tool_names(td.META_TOOLS)
+        check(blocked_names[:len(meta_names)] == meta_names, "fallback must keep meta tools as the stable prefix")
+        check(len(blocked_names) == len(set(blocked_names)), "fallback must not duplicate tool schemas")
+        forbidden = {
+            name for name, category in td._tool_to_category.items()
+            if category in {"search", "memory", "conversation", "reminder"}
+        }
+        check(not (set(blocked_names) & forbidden), "fallback must filter every disabled internal category")
+        check(ext_tool not in blocked_names, "mcp_mode=off must hide fallback external tools")
+        check(
+            {"calendar", "dream", "profile"} & {
+                td._tool_to_category.get(name) for name in blocked_names
+            },
+            "fallback must retain allowed internal base tools",
+        )
+        meta_context = blocked_map["_drawer_request_tools"]
+        check(
+            set(meta_context["disabled_categories"]) == {"search", "memory", "conversation", "reminder"},
+            "fallback meta context must freeze every request-level disabled category",
+        )
+        check(meta_context["mcp_mode"] == "off", "fallback meta context must freeze MCP mode")
+
+        manual_tools, manual_map = td.build_full_fallback_tools(
+            search_enabled=False,
+            mem_enabled=True,
+            reminder_tools_enabled=False,
+            mcp_mode="manual",
+            pinned_external={ext_id},
+            project_id="project-42",
+        )
+        manual_names = tool_names(manual_tools)
+        check(ext_tool in manual_names, "manual fallback must include a pinned external category")
+        check("_gateway_web_search" not in manual_names, "manual fallback must keep disabled search hidden")
+        check(REMINDER_NAMES.isdisjoint(manual_names), "manual fallback must keep disabled reminders hidden")
+        check(
+            manual_map["_gateway_search_conversations"]["project_id"] == "project-42",
+            "fallback conversation search must retain the request project scope",
+        )
+
+        unpinned_tools, _ = td.build_full_fallback_tools(
+            mcp_mode="manual",
+            pinned_external=set(),
+        )
+        auto_tools, _ = td.build_full_fallback_tools(mcp_mode="auto")
+        check(ext_tool not in tool_names(unpinned_tools), "manual fallback must hide unpinned external tools")
+        check(ext_tool in tool_names(auto_tools), "auto fallback may expose registered external tools")
+    finally:
+        td.TOOL_SCHEMAS.pop(ext_tool, None)
+        td._tool_to_category.pop(ext_tool, None)
+        td.CATEGORIES.pop(ext_id, None)
+        td._external_categories.pop(ext_id, None)
+
+
 async def check_reserved_external_name():
     snapshots = {
         "schemas": dict(td.TOOL_SCHEMAS),
@@ -337,6 +446,7 @@ async def main():
     await check_request_context_gates()
     await check_mcp_mode_isolation()
     await check_reminder_route_gate()
+    await check_fallback_builder_gates()
     await check_reserved_external_name()
     check_source_guards()
 

--- a/scripts/test_drawer_stability.py
+++ b/scripts/test_drawer_stability.py
@@ -259,10 +259,10 @@ async def check_fallback_builder_gates():
         check(not (set(blocked_names) & forbidden), "fallback must filter every disabled internal category")
         check(ext_tool not in blocked_names, "mcp_mode=off must hide fallback external tools")
         check(
-            {"calendar", "dream", "profile"} & {
+            {"calendar", "dream", "profile"} <= {
                 td._tool_to_category.get(name) for name in blocked_names
             },
-            "fallback must retain allowed internal base tools",
+            "fallback must retain every allowed internal base category",
         )
         meta_context = blocked_map["_drawer_request_tools"]
         check(

--- a/scripts/test_gateway_tool_streaming.py
+++ b/scripts/test_gateway_tool_streaming.py
@@ -425,7 +425,11 @@ async def case_route_exception_with_request_mcp(client, controller):
         if category in {"calendar", "dream", "profile"}
     }
     check(all(not (set(names) & forbidden) for names in name_lists), "fallback must obey every disabled internal gate")
-    check(allowed_internal & set(name_lists[0]), "route exception must retain allowed internal base tools")
+    allowed_categories = {td._tool_to_category.get(name) for name in name_lists[0]}
+    check(
+        {"calendar", "dream", "profile"} <= allowed_categories,
+        "route exception must retain every allowed internal base category",
+    )
     check(all("request_mcp_probe" in names for names in name_lists), "request-body MCP must force entry into the tool loop")
     second_messages = json.dumps(controller.captured[key][1].get("messages", []), ensure_ascii=False)
     check("该类工具当前已被用户设置关闭，无法展开" in second_messages, "fallback meta expansion must obey memory gate")
@@ -460,7 +464,10 @@ async def case_empty_route_uses_gated_fallback(client, controller):
     check(name_lists[0] == name_lists[1], "full fallback schemas must stay a stable prefix without reshuffle")
     check("list_tool_categories" in name_lists[0], "empty route fallback must retain meta tools")
     first_categories = {td._tool_to_category.get(name) for name in name_lists[0]}
-    check(first_categories & {"calendar", "dream", "profile"}, "empty route fallback must retain allowed base categories")
+    check(
+        {"calendar", "dream", "profile"} <= first_categories,
+        "empty route fallback must retain every allowed base category",
+    )
     check(not (first_categories & {"search", "memory", "conversation", "reminder"}), "empty route fallback must keep disabled categories hidden")
     second_messages = json.dumps(controller.captured[key][1].get("messages", []), ensure_ascii=False)
     check('"id": "memory"' not in second_messages, "fallback category listing must hide disabled memory")
@@ -505,7 +512,10 @@ async def case_external_mcp_failure_keeps_internal_fallback(client, controller):
     check("list_tool_categories" in name_lists[0], "external outage must retain fallback meta tools")
     check("request_mcp_probe" not in name_lists[0], "unavailable request MCP schema must not be invented")
     first_categories = {td._tool_to_category.get(name) for name in name_lists[0]}
-    check(first_categories & {"calendar", "dream", "profile"}, "external outage must retain allowed internal tools")
+    check(
+        {"calendar", "dream", "profile"} <= first_categories,
+        "external outage must retain every allowed internal base category",
+    )
 
 
 async def case_concurrent_request_isolation(client, controller):

--- a/scripts/test_gateway_tool_streaming.py
+++ b/scripts/test_gateway_tool_streaming.py
@@ -391,7 +391,10 @@ async def case_route_exception_with_request_mcp(client, controller):
     MCP_BATCH_CALLS = 0
     controller.add_plan(
         key,
-        tool_response(tool_call("_drawer_return_tools", {}, "exception-return")),
+        tool_response(
+            tool_call("_drawer_request_tools", {"category": "memory"}, "exception-memory"),
+            tool_call("_drawer_return_tools", {}, "exception-return"),
+        ),
         final_response("exception final"),
     )
 
@@ -413,9 +416,96 @@ async def case_route_exception_with_request_mcp(client, controller):
 
     controller.assert_consumed(key)
     name_lists = assert_only_appends(controller.captured[key])
+    forbidden = {
+        name for name, category in td._tool_to_category.items()
+        if category in {"search", "memory", "conversation", "reminder"}
+    }
+    allowed_internal = {
+        name for name, category in td._tool_to_category.items()
+        if category in {"calendar", "dream", "profile"}
+    }
+    check(all(not (set(names) & forbidden) for names in name_lists), "fallback must obey every disabled internal gate")
+    check(allowed_internal & set(name_lists[0]), "route exception must retain allowed internal base tools")
     check(all("request_mcp_probe" in names for names in name_lists), "request-body MCP must force entry into the tool loop")
+    second_messages = json.dumps(controller.captured[key][1].get("messages", []), ensure_ascii=False)
+    check("该类工具当前已被用户设置关闭，无法展开" in second_messages, "fallback meta expansion must obey memory gate")
     check(RETURN_MESSAGE in response.text, "route-exception legacy call must still hit the meta tombstone")
     check(MCP_BATCH_CALLS == 0, "legacy return must not fall through to MCP batch execution")
+
+
+async def case_empty_route_uses_gated_fallback(client, controller):
+    key = "empty-route-fallback"
+    sid = "stream-empty-route"
+    td._sessions.pop(sid, None)
+    controller.add_plan(
+        key,
+        tool_response(tool_call("list_tool_categories", {}, "empty-list")),
+        final_response("empty route final"),
+    )
+
+    async def empty_route(*_args, **_kwargs):
+        return [], {}
+
+    with patch.object(td, "route_tools", empty_route):
+        response = await post_gateway(
+            client,
+            key,
+            sid,
+            {"drawer_enabled": True, "reminder_tools_enabled": False},
+        )
+
+    controller.assert_consumed(key)
+    name_lists = assert_only_appends(controller.captured[key])
+    check(streamed_text(response) == "empty route final", "empty route fallback must finish normally")
+    check(name_lists[0] == name_lists[1], "full fallback schemas must stay a stable prefix without reshuffle")
+    check("list_tool_categories" in name_lists[0], "empty route fallback must retain meta tools")
+    first_categories = {td._tool_to_category.get(name) for name in name_lists[0]}
+    check(first_categories & {"calendar", "dream", "profile"}, "empty route fallback must retain allowed base categories")
+    check(not (first_categories & {"search", "memory", "conversation", "reminder"}), "empty route fallback must keep disabled categories hidden")
+    second_messages = json.dumps(controller.captured[key][1].get("messages", []), ensure_ascii=False)
+    check('"id": "memory"' not in second_messages, "fallback category listing must hide disabled memory")
+    check('"id": "reminder"' not in second_messages, "fallback category listing must hide disabled reminders")
+
+
+async def case_external_mcp_failure_keeps_internal_fallback(client, controller):
+    key = "external-mcp-failure-fallback"
+    sid = "stream-external-failure"
+    td._sessions.pop(sid, None)
+    controller.add_plan(
+        key,
+        tool_response(tool_call("list_tool_categories", {}, "external-list")),
+        final_response("external failure final"),
+    )
+
+    async def empty_route(*_args, **_kwargs):
+        return [], {}
+
+    async def unavailable_mcp(*_args, **_kwargs):
+        raise RuntimeError("forced external MCP outage")
+
+    with (
+        patch.object(td, "route_tools", empty_route),
+        patch.object(gateway, "get_tools_for_servers", unavailable_mcp),
+    ):
+        response = await post_gateway(
+            client,
+            key,
+            sid,
+            {"drawer_enabled": True, "reminder_tools_enabled": False},
+            mcp_servers=[{
+                "name": "unavailable-mcp",
+                "url": "https://mcp.invalid/unavailable",
+                "transport": "streamable_http",
+            }],
+        )
+
+    controller.assert_consumed(key)
+    name_lists = assert_only_appends(controller.captured[key])
+    check(streamed_text(response) == "external failure final", "external MCP outage must not abort internal fallback")
+    check("list_tool_categories" in name_lists[0], "external outage must retain fallback meta tools")
+    check("request_mcp_probe" not in name_lists[0], "unavailable request MCP schema must not be invented")
+    first_categories = {td._tool_to_category.get(name) for name in name_lists[0]}
+    check(first_categories & {"calendar", "dream", "profile"}, "external outage must retain allowed internal tools")
 
 
 async def case_concurrent_request_isolation(client, controller):
@@ -544,6 +634,8 @@ async def main():
         await case_long_valid_loop_and_hard_stop(asgi_client, controller)
         await case_classic_legacy_return(asgi_client, controller)
         await case_route_exception_with_request_mcp(asgi_client, controller)
+        await case_empty_route_uses_gated_fallback(asgi_client, controller)
+        await case_external_mcp_failure_keeps_internal_fallback(asgi_client, controller)
         await case_concurrent_request_isolation(asgi_client, controller)
     finally:
         for item in reversed(patches):

--- a/scripts/test_mcp_recall.py
+++ b/scripts/test_mcp_recall.py
@@ -1,0 +1,135 @@
+"""No-network contracts for MCP memory recall accounting."""
+
+import asyncio
+import os
+import sys
+from unittest.mock import patch
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+import database
+import mcp_server
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def _fake_async_client(payload, captured):
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, *, params):
+            captured.append((url, dict(params)))
+            return _FakeResponse(payload)
+
+    return FakeAsyncClient
+
+
+async def check_mcp_explicit_recall_request():
+    for payload in (
+        {"memories": [], "total_memories": 0},
+        {
+            "memories": [{
+                "id": 7,
+                "title": "hit",
+                "content": "memory hit",
+                "importance": 5,
+                "created_at": "2026-08-11T00:00:00Z",
+                "memory_type": "fragment",
+            }],
+            "total_memories": 1,
+        },
+    ):
+        captured = []
+        with patch.object(mcp_server.httpx, "AsyncClient", _fake_async_client(payload, captured)):
+            await mcp_server.search_memory("recall contract", limit=3)
+
+        check(len(captured) == 1, "MCP search must make exactly one gateway request")
+        _url, params = captured[0]
+        check(params.get("q") == "recall contract", "MCP search must preserve the query")
+        check(params.get("limit") == 3, "MCP search must preserve the limit")
+        check(
+            params.get("track_recall") in (True, "true"),
+            "MCP search must explicitly request recall tracking",
+        )
+
+
+async def check_database_counts_only_real_hits():
+    recall_calls = []
+
+    async def no_embedding(_query):
+        return None
+
+    async def heat_params():
+        return {}
+
+    async def semantic_threshold(*_args, **_kwargs):
+        return 0.25
+
+    async def record_recall(memory_ids, query):
+        recall_calls.append((list(memory_ids), query))
+
+    async def no_hits(*_args, **_kwargs):
+        return []
+
+    hit = {
+        "id": 42,
+        "content": "real hit",
+        "score": 0.9,
+        "similarity": 0.0,
+        "heat": 0.5,
+    }
+
+    async def one_hit(*_args, **_kwargs):
+        return [dict(hit)]
+
+    common = (
+        patch.object(database, "get_embedding", no_embedding),
+        patch.object(database, "get_heat_params", heat_params),
+        patch.object(database, "track_memory_recall", record_recall),
+        patch("config.get_config_float", semantic_threshold),
+    )
+
+    for item in common:
+        item.start()
+    try:
+        with patch.object(database, "_keyword_search", no_hits):
+            result = await database.search_memories("empty", track_recall=True)
+        check(result == [], "empty search contract must return no memories")
+        check(recall_calls == [], "empty search must not increase recall heat")
+
+        with patch.object(database, "_keyword_search", one_hit):
+            result = await database.search_memories("found", track_recall=True)
+        check([item["id"] for item in result] == [42], "real search hit must be returned")
+        check(recall_calls == [([42], "found")], "one real search must count recall exactly once")
+    finally:
+        for item in reversed(common):
+            item.stop()
+
+
+async def main():
+    await check_mcp_explicit_recall_request()
+    await check_database_counts_only_real_hits()
+    print("PASS: MCP recall accounting")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tool_drawer.py
+++ b/tool_drawer.py
@@ -703,6 +703,33 @@ def _category_order_map(categories):
 def _sort_category_ids(cat_ids, order_map):
     return sorted(cat_ids, key=lambda cat_id: (order_map.get(cat_id, 10**9), cat_id))
 
+
+def _normalize_mcp_mode(value):
+    mode = str(value or "auto").strip().lower()
+    return mode if mode in ("off", "auto", "manual") else "auto"
+
+
+def _disabled_category_set(search_enabled=True, mem_enabled=True, reminder_tools_enabled=True):
+    disabled = set()
+    if not search_enabled:
+        disabled.add("search")
+    if not mem_enabled:
+        disabled.update({"memory", "conversation"})
+    if not reminder_tools_enabled:
+        disabled.add("reminder")
+    return disabled
+
+
+def _meta_tool_context(disabled_categories, mcp_mode, pinned_external):
+    """Freeze request-level routing state onto one meta entry."""
+    return {
+        "type": "meta",
+        "handler": "drawer_meta",
+        "disabled_categories": frozenset(disabled_categories or ()),
+        "mcp_mode": _normalize_mcp_mode(mcp_mode),
+        "pinned_external": frozenset(pinned_external or ()),
+    }
+
 def _get_session(session_id):
     now = time.time()
     if session_id not in _sessions:
@@ -769,9 +796,7 @@ async def route_tools(
         ext_threshold = 0.40
         ext_max_open = 3
 
-    mode = str(mcp_mode or "auto").strip().lower()
-    if mode not in ("off", "auto", "manual"):
-        mode = "auto"
+    mode = _normalize_mcp_mode(mcp_mode)
     external_auto = mode == "auto"
     # auto = 纯语义路由：切到 auto 后不保留手动钉选，外部工具完全交给语义/关键词决定。
     # 只有 manual 模式才尊重 mcp_manual_ids。这与 handle_meta_tool 的判定（mode=='manual'）
@@ -854,13 +879,11 @@ async def route_tools(
         matched_categories.discard("reminder")
         _remove_expanded(session, {"reminder"})
 
-    disabled = set()
-    if not search_enabled:
-        disabled.add("search")
-    if not mem_enabled:
-        disabled.update({"memory", "conversation"})
-    if not reminder_tools_enabled:
-        disabled.add("reminder")
+    disabled = _disabled_category_set(
+        search_enabled=search_enabled,
+        mem_enabled=mem_enabled,
+        reminder_tools_enabled=reminder_tools_enabled,
+    )
 
     _append_expanded_many(session, _sort_category_ids(matched_categories, category_order))
     active_categories = list(_get_expanded(session))
@@ -871,15 +894,10 @@ async def route_tools(
     # Assemble tool list. Meta-tools stay at the front so their cache breakpoint
     # is independent from later drawer expansion.
     openai_tools = list(meta_tools_snapshot)
-    tool_map = {}
-    for mt in meta_tools_snapshot:
-        tool_map[mt["function"]["name"]] = {
-            "type": "meta",
-            "handler": "drawer_meta",
-            "disabled_categories": set(disabled),
-            "mcp_mode": mode,
-            "pinned_external": set(pinned_external),
-        }
+    tool_map = {
+        mt["function"]["name"]: _meta_tool_context(disabled, mode, pinned_external)
+        for mt in meta_tools_snapshot
+    }
 
     for cat_id in active_categories:
         cat = categories_snapshot.get(cat_id)
@@ -960,6 +978,66 @@ def _infer_handler(tool_name):
     if "reminder" in tool_name: return "reminder"
     return tool_name
 
+
+def build_full_fallback_tools(
+    *,
+    search_enabled=False,
+    mem_enabled=True,
+    reminder_tools_enabled=True,
+    mcp_mode="auto",
+    pinned_external=None,
+    project_id=None,
+):
+    """Build a route-failure tool set without bypassing request-level gates."""
+    mode = _normalize_mcp_mode(mcp_mode)
+    pinned = set(pinned_external or ())
+    disabled = _disabled_category_set(
+        search_enabled=search_enabled,
+        mem_enabled=mem_enabled,
+        reminder_tools_enabled=reminder_tools_enabled,
+    )
+
+    meta_tools_snapshot = list(META_TOOLS)
+    tool_schemas_snapshot = dict(TOOL_SCHEMAS)
+    categories_snapshot = dict(CATEGORIES)
+    external_categories_snapshot = dict(_external_categories)
+
+    openai_tools = list(meta_tools_snapshot)
+    tool_map = {
+        mt["function"]["name"]: _meta_tool_context(disabled, mode, pinned)
+        for mt in meta_tools_snapshot
+    }
+    for tool_name, schema in tool_schemas_snapshot.items():
+        cat_id = _tool_to_category.get(tool_name)
+        if cat_id in disabled:
+            continue
+        cat = categories_snapshot.get(cat_id, {})
+        if cat.get("external"):
+            if mode == "off":
+                continue
+            if mode == "manual" and cat_id not in pinned:
+                continue
+
+        openai_tools.append(schema)
+        if cat.get("external"):
+            ext_map = external_categories_snapshot.get(cat_id, {}).get("tool_map", {})
+            tool_map[tool_name] = ext_map.get(tool_name, {
+                "type": "external_mcp",
+                "server_url": "",
+                "url": "",
+                "transport": "streamable_http",
+                "server_name": cat.get("label", cat_id or ""),
+                "origin_name": tool_name,
+            })
+        elif tool_name.startswith("_gateway_"):
+            route_info = {"type": "gateway_builtin", "handler": _infer_handler(tool_name)}
+            if tool_name == "_gateway_search_conversations":
+                route_info["project_id"] = project_id
+            tool_map[tool_name] = route_info
+        else:
+            tool_map[tool_name] = {"type": "drawer", "handler": tool_name}
+    return openai_tools, tool_map
+
 # ============================================================
 # 11. Meta-tool Execution
 # ============================================================
@@ -975,9 +1053,7 @@ async def handle_meta_tool(
 ):
     session = _get_session(session_id)
     disabled = set(disabled_categories or ())
-    mode = str(mcp_mode or "auto").strip().lower()
-    if mode not in ("off", "auto", "manual"):
-        mode = "auto"
+    mode = _normalize_mcp_mode(mcp_mode)
     pinned = set(pinned_external or ())
 
     def _category_visible(cat_id, cat):


### PR DESCRIPTION
## W1-04 scope

- add a full drawer fallback when routing raises or returns an unusable empty result
- keep memory, search, conversation, reminder, external MCP, and project gates frozen per request during fallback
- preserve meta tools as the stable prefix and append only permitted schemas
- keep explicit request-body MCP compatibility independent; an unavailable external server no longer removes internal fallback tools
- make MCP `search_memory` explicitly request recall tracking while preserving database-side empty-result suppression

## Tests-first evidence

Before production changes, the new guards failed at the intended contracts:

- `test_drawer_stability.py`: missing `build_full_fallback_tools`
- `test_gateway_tool_streaming.py`: route failure exposed no allowed internal fallback
- `test_mcp_recall.py`: MCP search omitted `track_recall`

Final local checks:

- `python -m compileall -q .`
- `python scripts/test_drawer_stability.py`
- `python scripts/test_gateway_tool_streaming.py`
- `python scripts/test_stream_capture.py`
- `python scripts/test_calendar_summary_generation.py`
- `python scripts/test_calendar_json_parser.py`
- `python scripts/test_mcp_recall.py`

All passed locally. PostgreSQL 16 safety guards are delegated to CI because this Windows checkout has no local PostgreSQL service.

## Mutation checks

- bypassing fallback disabled-category filtering was caught immediately
- removing the MCP recall query flag was caught immediately

## Compatibility boundary

- no schema or public API shape changes
- request-body MCP remains an explicit compatibility path that bypasses configured `mcp_mode`, matching existing Kiwi behavior
- only actual search hits increment recall heat; empty searches remain no-op