### PR TITLE
fix: validate reasoning and render compression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           python scripts/test_calendar_summary_generation.py
           python scripts/test_calendar_json_parser.py
           python scripts/test_mcp_recall.py
+          python scripts/test_compression_reasoning.py
 
       - name: 运行 S1-S6 永久真库行为守卫
         run: python scripts/test_kiwi_safety_sync.py

--- a/admin-panel/js/config-schema.js
+++ b/admin-panel/js/config-schema.js
@@ -118,7 +118,7 @@ export const CONFIG_META = {
   // —— 网关 / 对话行为 ——
   default_title_model:    { label:'标题生成模型', type:'text', def:'', input:'model', desc:'自动生成对话标题用的模型。建议小模型。' },
   prompt_title_summary:   { label:'标题生成提示词', type:'text', def:'', input:'prompt', hasDefault:false, desc:'指导如何生成对话标题。留空用内置默认。' },
-  reasoning_effort:       { label:'思考强度', type:'text', def:'off', input:'select', options:['off','low','medium','high'], desc:'转发时附带的推理强度，仅对支持 reasoning 的模型生效。off=不传。（v1.6.1 新登记：此前面板上改不了）' },
+  reasoning_effort:       { label:'思考强度', type:'text', def:'off', input:'select', options:['off','auto','low','medium','high'], desc:'转发时附带的推理强度，仅对支持 reasoning 的模型生效。off=不传，auto=由供应商自动决定。（v1.6.1 新登记：此前面板上改不了）' },
 
   // —— 网关 / 性能 ——
   prompt_cache_enabled:   { label:'Prompt 缓存', type:'bool', def:'true', input:'bool', desc:'Claude 模型的显式缓存：重复的 system prompt 前缀只收 1/10 费用。非 Claude 自动跳过。' },

--- a/config.py
+++ b/config.py
@@ -205,7 +205,12 @@ async def get_all_config() -> dict:
 # 写入配置
 # ============================================================
 
-_ENUM_VALUES = {"mcp_mode": {"off", "auto", "manual"}}
+REASONING_EFFORT_VALUES = ("off", "auto", "low", "medium", "high")
+
+_ENUM_VALUES = {
+    "mcp_mode": {"off", "auto", "manual"},
+    "reasoning_effort": set(REASONING_EFFORT_VALUES),
+}
 
 
 def _mask_secret(value: str) -> str:

--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ from database import (
     create_reminder, get_reminders, update_reminder, delete_reminder, get_due_reminders, fire_reminder,
 )
 from config import (
+    REASONING_EFFORT_VALUES,
     SYNC_SETTING_KEYS,
     get_all_config, set_config, get_config, get_config_int, get_config_bool, get_config_float,
 )
@@ -1607,6 +1608,26 @@ async def extract_file_content(file: UploadFile = File(...)):
         )
 
 
+def _normalize_reasoning_effort(value):
+    """Normalize the public five-value request contract or reject it explicitly."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(
+            "reasoning_effort 必须是 "
+            + "/".join(REASONING_EFFORT_VALUES)
+            + " 之一"
+        )
+    normalized = value.strip().lower()
+    if normalized not in REASONING_EFFORT_VALUES:
+        raise ValueError(
+            "reasoning_effort 必须是 "
+            + "/".join(REASONING_EFFORT_VALUES)
+            + f" 之一，收到 {value[:40]!r}"
+        )
+    return normalized
+
+
 def _apply_reasoning(body: dict, is_openrouter: bool, is_anthropic_fmt: bool, reasoning_effort, skip_prompt: bool = False):
     """统一决定一个出站请求体的思考链参数。转发路径与工具循环共用，保证两条路对所有供应商一致。
 
@@ -1615,8 +1636,9 @@ def _apply_reasoning(body: dict, is_openrouter: bool, is_anthropic_fmt: bool, re
       - OpenRouter / Anthropic 直连 → 写 reasoning={"enabled":True[, "effort"]}
           None（旧前端 / 非推理模型未发）视为默认开（向后兼容）；'auto' 开但不带 effort；
           'low'/'medium'/'high' 带 effort。
-      - 其它 OpenAI 兼容供应商 → 只透传合法 effort(low/medium/high)；off/auto/未知值剥掉，
+      - 其它 OpenAI 兼容供应商 → 只透传合法 effort(low/medium/high)；off/auto 剥掉，
           避免严格供应商（如直连 OpenAI o 系列）对非法 reasoning_effort 报 400。
+    未知值在 /v1 入口由 _normalize_reasoning_effort 明确拒绝，不会静默进入本函数。
     """
     # 先清干净，避免 fresh body 残留或重复调用叠加
     body.pop("reasoning", None)
@@ -1677,6 +1699,20 @@ async def chat_completions(request: Request):
     # API_KEY 检查移到供应商路由的 else 分支：只有「既没匹配到供应商、又没有环境变量
     # API_KEY」时才报 500。否则面板里配了供应商、但 env API_KEY 留空的用户会被误拦。
     body = await request.json()
+    try:
+        reasoning_effort = _normalize_reasoning_effort(body.pop("reasoning_effort", None))
+    except ValueError as e:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": {
+                    "message": str(e),
+                    "type": "invalid_request_error",
+                    "param": "reasoning_effort",
+                    "code": "invalid_value",
+                }
+            },
+        )
     messages = body.get("messages", [])
     
     # ---------- 提取用户最新消息 ----------
@@ -1990,7 +2026,6 @@ async def chat_completions(request: Request):
     
     # 思考链参数：统一交给 _apply_reasoning 处理（转发路径与工具循环同一套规则，对各类供应商分流）。
     # 由 to_anthropic_request 把 reasoning.enabled 转成 Anthropic extended thinking。
-    reasoning_effort = body.pop("reasoning_effort", None)
     _apply_reasoning(body, is_openrouter, is_anthropic_fmt, reasoning_effort, skip_prompt)
     
     # ---------- Prompt 缓存（v5.5 → v5.7 修正）----------
@@ -4181,6 +4216,30 @@ async def api_set_config(key: str, request: Request):
 # 无缝换窗 v2：源对话概要压缩（同步调用）
 # ============================================================
 
+async def _render_compress_prompt(template: str) -> str:
+    """Replace public compression placeholders with configured or safe values."""
+    ratio = 0.35
+    output_max = 4000
+    try:
+        configured_ratio = await get_config_float("compress_ratio", fallback=ratio)
+        if math.isfinite(configured_ratio) and configured_ratio > 0:
+            ratio = configured_ratio
+    except Exception:
+        pass
+    try:
+        configured_output_max = await get_config_int("compress_output_max", fallback=output_max)
+        if configured_output_max > 0:
+            output_max = configured_output_max
+    except Exception:
+        pass
+
+    return (
+        str(template or "")
+        .replace("{compress_ratio}", f"{round(ratio * 100)}%")
+        .replace("{compress_output_max}", f"{output_max} token")
+    )
+
+
 async def _compress_for_handoff(existing_summary: str, messages: list):
     """把源对话的（已有概要 + 待压消息）同步压成一段概要，失败返回 None。
 
@@ -4211,6 +4270,7 @@ async def _compress_for_handoff(existing_summary: str, messages: list):
         "请将以下对话内容压缩为简洁的摘要，保留关键信息、话题走向和情感基调。"
         "不要截断正在进行中的话题。"
     )
+    compress_prompt = await _render_compress_prompt(compress_prompt)
 
     try:
         from database import resolve_model_endpoint

--- a/scripts/test_compression_reasoning.py
+++ b/scripts/test_compression_reasoning.py
@@ -1,0 +1,248 @@
+"""No-network contracts for compression placeholders and reasoning effort."""
+
+import asyncio
+import copy
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import config
+import database
+import main as gateway
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+class _FakeConnection:
+    def __init__(self):
+        self.writes = []
+
+    async def execute(self, *args):
+        self.writes.append(args)
+        return "INSERT 0 1"
+
+
+class _FakeAcquire:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def acquire(self):
+        return _FakeAcquire(self.conn)
+
+
+async def check_reasoning_config_contract():
+    conn = _FakeConnection()
+
+    async def fake_pool():
+        return _FakePool(conn)
+
+    allowed = ("off", "auto", "low", "medium", "high")
+    rejected = ("", "xhigh", "max", "ultra", "HIGH")
+    with patch.object(config, "get_pool", fake_pool):
+        for value in allowed:
+            check(await config.set_config("reasoning_effort", value), f"config must accept {value}")
+        accepted_writes = len(conn.writes)
+        for value in rejected:
+            check(
+                not await config.set_config("reasoning_effort", value),
+                f"config must reject unsupported reasoning effort {value!r}",
+            )
+        check(len(conn.writes) == accepted_writes, "rejected config values must never reach the database")
+
+        transport = httpx.ASGITransport(app=gateway.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://kiwi.test") as client:
+            admin_response = await client.put(
+                "/admin/config/reasoning_effort",
+                json={"value": "xhigh"},
+            )
+            check("error" in admin_response.json(), "admin config must return an explicit invalid-value error")
+
+            sync_response = await client.put(
+                "/sync/settings",
+                json={"reasoning_effort": "max"},
+            )
+            check(
+                sync_response.json().get("rejected") == ["reasoning_effort"],
+                "sync settings must report an invalid reasoning value as rejected",
+            )
+
+    panel_source = (ROOT / "admin-panel" / "js" / "config-schema.js").read_text(encoding="utf-8")
+    check(
+        "options:['off','auto','low','medium','high']" in panel_source,
+        "admin panel must expose exactly the public five-value reasoning contract",
+    )
+
+
+async def check_request_reasoning_contract():
+    for value in ("off", "auto", "low", "medium", "high"):
+        check(gateway._normalize_reasoning_effort(value) == value, f"request must accept {value}")
+    check(gateway._normalize_reasoning_effort(None) is None, "omitted effort must preserve legacy behavior")
+    check(gateway._normalize_reasoning_effort(" HIGH ") == "high", "request effort may normalize case/space")
+
+    for value in ("", "xhigh", "max", "ultra", 7):
+        try:
+            gateway._normalize_reasoning_effort(value)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"request must reject unsupported reasoning effort {value!r}")
+
+    provider_calls = []
+
+    async def forbidden_provider_call(*args, **kwargs):
+        provider_calls.append((args, kwargs))
+        raise AssertionError("invalid reasoning must fail before provider routing")
+
+    transport = httpx.ASGITransport(app=gateway.app)
+    with patch.object(gateway, "resolve_provider_for_model", forbidden_provider_call):
+        async with httpx.AsyncClient(transport=transport, base_url="http://kiwi.test") as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "test/model",
+                    "messages": [{"role": "user", "content": "reasoning contract"}],
+                    "reasoning_effort": "xhigh",
+                },
+            )
+
+    check(response.status_code == 400, "unsupported request effort must return HTTP 400")
+    payload = response.json()
+    error = payload.get("error", {})
+    check(error.get("param") == "reasoning_effort", "400 response must identify reasoning_effort")
+    check("off/auto/low/medium/high" in error.get("message", ""), "400 response must list allowed values")
+    check(provider_calls == [], "invalid request must not touch provider routing or upstream I/O")
+
+    body = {"reasoning": {"enabled": False}, "reasoning_effort": "stale"}
+    gateway._apply_reasoning(body, True, False, "auto")
+    check(body == {"reasoning": {"enabled": True}}, "auto must enable OpenRouter reasoning without effort")
+    body = {}
+    gateway._apply_reasoning(body, False, False, "high")
+    check(body == {"reasoning_effort": "high"}, "direct OpenAI-compatible high must remain supported")
+    body = {"reasoning": {"enabled": True}, "reasoning_effort": "high"}
+    gateway._apply_reasoning(body, True, False, "off")
+    check(body == {}, "off must remove every outbound reasoning field")
+
+
+class _FakeCompressionResponse:
+    status_code = 200
+
+    def json(self):
+        return {
+            "choices": [{
+                "message": {"content": "compressed summary"},
+                "finish_reason": "stop",
+            }]
+        }
+
+
+def _compression_client(captured):
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, *, headers, json):
+            captured.append({"url": url, "headers": copy.deepcopy(headers), "body": copy.deepcopy(json)})
+            return _FakeCompressionResponse()
+
+    return FakeAsyncClient
+
+
+async def _run_compression_case(get_float, get_int):
+    captured = []
+
+    async def fake_get_config(key):
+        values = {
+            "handoff_summary_model": "test/model",
+            "prompt_compress": "比例={compress_ratio}；上限={compress_output_max}",
+        }
+        return values.get(key, "")
+
+    async def fake_resolve(_model):
+        return "https://upstream.invalid/v1/chat/completions", "test-key", "openai"
+
+    with (
+        patch.object(gateway, "get_config", fake_get_config),
+        patch.object(gateway, "get_config_float", get_float),
+        patch.object(gateway, "get_config_int", get_int),
+        patch.object(database, "resolve_model_endpoint", fake_resolve),
+        patch.object(gateway.httpx, "AsyncClient", _compression_client(captured)),
+    ):
+        result = await gateway._compress_for_handoff(
+            "old summary",
+            [{"role": "user", "content": "new material"}],
+        )
+
+    check(result == "compressed summary", "compression response must remain compatible")
+    check(len(captured) == 1, "compression must make one background request")
+    body = captured[0]["body"]
+    system_prompt = body["messages"][0]["content"]
+    check("{" not in system_prompt and "}" not in system_prompt, "compression placeholders must not reach the model")
+    check(body["max_tokens"] == 2000, "placeholder output max must not rewrite provider token policy")
+    return system_prompt
+
+
+async def check_compression_placeholders():
+    async def ratio(*_args, **_kwargs):
+        return 0.42
+
+    async def output_max(*_args, **_kwargs):
+        return 7777
+
+    configured = await _run_compression_case(ratio, output_max)
+    check("比例=42%" in configured, "configured compression ratio must be rendered as a percentage")
+    check("上限=7777 token" in configured, "configured compression output max must be rendered")
+
+    async def unavailable(*_args, **_kwargs):
+        raise RuntimeError("forced config outage")
+
+    fallback = await _run_compression_case(unavailable, unavailable)
+    check("比例=35%" in fallback, "compression ratio must use the safe default on config failure")
+    check("上限=4000 token" in fallback, "compression output max must use the safe default on config failure")
+
+
+async def main():
+    failures = []
+    for name, case in (
+        ("reasoning config", check_reasoning_config_contract),
+        ("request reasoning", check_request_reasoning_contract),
+        ("compression placeholders", check_compression_placeholders),
+    ):
+        try:
+            await case()
+        except Exception as exc:
+            failures.append(f"{name}: {type(exc).__name__}: {exc}")
+            print(f"FAIL {failures[-1]}")
+    if failures:
+        raise AssertionError("; ".join(failures))
+    print("PASS: compression placeholders and reasoning effort contracts")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## 变更

- 渲染压缩提示词中的 `{compress_ratio}` 与 `{compress_output_max}`，配置不可用时使用 35% / 4000 token 安全默认值。
- 给已保存配置增加公版五值校验：`off / auto / low / medium / high`；面板补上 `auto`。
- `/v1/chat/completions` 对未知 `reasoning_effort` 返回 OpenAI 形状 HTTP 400，不再静默吞掉。
- 保持压缩后台请求 `max_tokens=2000`，未引入 `xhigh/max`，未扩大公版容量策略。

## Tests-first 红灯

修复前新增守卫精准红三类：保存配置接受非法值、请求入口缺少显式验证、压缩占位符原样抵达模型。

## 验证

- `git diff --check`
- `python -m compileall -q .`
- `scripts/test_drawer_stability.py`
- `scripts/test_gateway_tool_streaming.py`
- `scripts/test_stream_capture.py`
- `scripts/test_calendar_summary_generation.py`
- `scripts/test_calendar_json_parser.py`
- `scripts/test_mcp_recall.py`
- `scripts/test_compression_reasoning.py`
- 两把进程内变异刀：放行 `xhigh`、恢复字面占位符，均使对应新守卫精准变红；恢复后回绿。

本机没有 PostgreSQL 服务；38 条真库守卫由 GitHub Actions 的 PostgreSQL 16 job 承担。

## 边界

这是 Kiwi-Mem 公版 bug 修复。没有同步私有 gateway 的六档思考，没有启用 `xhigh/max`，没有统一上调后台 `max_tokens`。