### PR TITLE
fix: delete calendar page and comments atomically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
           python scripts/test_calendar_json_parser.py
           python scripts/test_mcp_recall.py
           python scripts/test_compression_reasoning.py
+          python scripts/test_calendar_delete_atomicity.py
 
       - name: 运行 S1-S6 永久真库行为守卫
         run: python scripts/test_kiwi_safety_sync.py

--- a/database.py
+++ b/database.py
@@ -3170,19 +3170,19 @@ async def delete_calendar_page(date_str: str, page_type: str = "day"):
     pool = await get_pool()
     d = date_cls.fromisoformat(date_str)
     async with pool.acquire() as conn:
-        # 先查出 page id，用于删评论
-        row = await conn.fetchrow(
-            "SELECT id FROM calendar_pages WHERE date = $1 AND type = $2", d, page_type
-        )
-        if row:
-            # 删除关联评论
-            await conn.execute(
-                "DELETE FROM comments WHERE target_type = 'calendar_page' AND target_id = $1", row['id']
+        async with conn.transaction():
+            # 页面与关联评论必须同成同败。评论自身的回复树继续由
+            # comments.parent_id ON DELETE CASCADE 清理。
+            row = await conn.fetchrow(
+                "SELECT id FROM calendar_pages WHERE date = $1 AND type = $2", d, page_type
             )
-        # 删除页面
-        result = await conn.execute(
-            "DELETE FROM calendar_pages WHERE date = $1 AND type = $2", d, page_type
-        )
+            if row:
+                await conn.execute(
+                    "DELETE FROM comments WHERE target_type = 'calendar_page' AND target_id = $1", row['id']
+                )
+            result = await conn.execute(
+                "DELETE FROM calendar_pages WHERE date = $1 AND type = $2", d, page_type
+            )
     return _rowcount_nonzero(result)
 
 

--- a/scripts/test_calendar_delete_atomicity.py
+++ b/scripts/test_calendar_delete_atomicity.py
@@ -1,0 +1,183 @@
+"""No-network transaction contract for calendar page deletion."""
+
+import asyncio
+import copy
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import database
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+class FakeStore:
+    def __init__(self):
+        self.pages = {
+            (date(2026, 7, 17), "day"): 1,
+            (date(2026, 7, 18), "day"): 2,
+        }
+        self.comments = {
+            10: {"target_type": "calendar_page", "target_id": 1, "parent_id": None},
+            11: {"target_type": "calendar_page", "target_id": 1, "parent_id": 10},
+            12: {"target_type": "calendar_page", "target_id": 2, "parent_id": None},
+            13: {"target_type": "memory", "target_id": 1, "parent_id": None},
+        }
+        self.fail_comments = False
+        self.fail_page = False
+        self.transaction_entries = 0
+        self.commits = 0
+        self.rollbacks = 0
+
+    def snapshot(self):
+        return copy.deepcopy((self.pages, self.comments))
+
+    def restore(self, snapshot):
+        self.pages, self.comments = copy.deepcopy(snapshot)
+
+
+class FakeTransaction:
+    def __init__(self, store):
+        self.store = store
+        self.before = None
+
+    async def __aenter__(self):
+        self.store.transaction_entries += 1
+        self.before = self.store.snapshot()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        if exc_type is None:
+            self.store.commits += 1
+        else:
+            self.store.restore(self.before)
+            self.store.rollbacks += 1
+        return False
+
+
+class FakeConnection:
+    def __init__(self, store):
+        self.store = store
+
+    def transaction(self):
+        return FakeTransaction(self.store)
+
+    async def fetchrow(self, sql, *args):
+        normalized = " ".join(sql.split()).upper()
+        key = (args[0], args[1])
+        if normalized.startswith("SELECT ID FROM CALENDAR_PAGES"):
+            page_id = self.store.pages.get(key)
+            return {"id": page_id} if page_id is not None else None
+        if normalized.startswith("DELETE FROM CALENDAR_PAGES") and "RETURNING ID" in normalized:
+            if self.store.fail_page:
+                raise RuntimeError("forced page delete failure")
+            page_id = self.store.pages.pop(key, None)
+            return {"id": page_id} if page_id is not None else None
+        raise AssertionError(f"unexpected fetchrow SQL: {normalized}")
+
+    async def execute(self, sql, *args):
+        normalized = " ".join(sql.split()).upper()
+        if normalized.startswith("DELETE FROM COMMENTS"):
+            if self.store.fail_comments:
+                raise RuntimeError("forced comment delete failure")
+            target_id = args[0]
+            doomed = {
+                comment_id
+                for comment_id, comment in self.store.comments.items()
+                if comment["target_type"] == "calendar_page" and comment["target_id"] == target_id
+            }
+            while True:
+                children = {
+                    comment_id
+                    for comment_id, comment in self.store.comments.items()
+                    if comment["parent_id"] in doomed
+                }
+                expanded = doomed | children
+                if expanded == doomed:
+                    break
+                doomed = expanded
+            for comment_id in doomed:
+                self.store.comments.pop(comment_id, None)
+            return f"DELETE {len(doomed)}"
+        if normalized.startswith("DELETE FROM CALENDAR_PAGES"):
+            if self.store.fail_page:
+                raise RuntimeError("forced page delete failure")
+            removed = self.store.pages.pop((args[0], args[1]), None)
+            return "DELETE 1" if removed is not None else "DELETE 0"
+        raise AssertionError(f"unexpected execute SQL: {normalized}")
+
+
+class FakeAcquire:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakePool:
+    def __init__(self, store):
+        self.conn = FakeConnection(store)
+
+    def acquire(self):
+        return FakeAcquire(self.conn)
+
+
+async def call_delete(store, date_str="2026-07-17"):
+    pool = FakePool(store)
+
+    async def fake_get_pool():
+        return pool
+
+    with patch.object(database, "get_pool", fake_get_pool):
+        return await database.delete_calendar_page(date_str, "day")
+
+
+async def check_success_and_idempotency():
+    store = FakeStore()
+    check(await call_delete(store), "existing calendar page must report deleted")
+    check((date(2026, 7, 17), "day") not in store.pages, "target page survived deletion")
+    check(10 not in store.comments and 11 not in store.comments, "target comments/replies survived deletion")
+    check(12 in store.comments, "another page's comment was deleted")
+    check(13 in store.comments, "another target type with the same id was deleted")
+    check(store.transaction_entries == 1 and store.commits == 1, "delete did not use one transaction")
+
+    check(not await call_delete(store), "repeated delete must report not_found")
+    check(12 in store.comments and 13 in store.comments, "idempotent delete touched unrelated comments")
+
+
+async def check_failure_rolls_back(failure_attr):
+    store = FakeStore()
+    before = store.snapshot()
+    setattr(store, failure_attr, True)
+    try:
+        await call_delete(store)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError(f"{failure_attr} did not interrupt deletion")
+    check(store.snapshot() == before, f"{failure_attr} left a partially deleted page/comment set")
+    check(store.transaction_entries == 1 and store.rollbacks == 1, "failure did not roll back one transaction")
+
+
+async def main():
+    await check_success_and_idempotency()
+    await check_failure_rolls_back("fail_page")
+    await check_failure_rolls_back("fail_comments")
+    print("PASS: calendar page and comments delete atomically")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -905,6 +905,119 @@ async def test_s6(client: httpx.AsyncClient) -> None:
     passed("T-S6-8 row-lock interleaving blocks late lifecycle writes; active control updates")
 
 
+async def test_w1_06() -> None:
+    print("\nW1-06 calendar page/comment delete atomicity")
+    await _truncate("calendar_pages", "comments")
+
+    target_id = await _pool_fetchval(
+        "INSERT INTO calendar_pages (date, type) VALUES ('2026-07-18', 'day') RETURNING id"
+    )
+    target_comment = await _pool_fetchval(
+        """
+        INSERT INTO comments (target_type, target_id, content)
+        VALUES ('calendar_page', $1, 'target') RETURNING id
+        """,
+        target_id,
+    )
+    await _pool_execute(
+        """
+        INSERT INTO comments (target_type, target_id, parent_id, content)
+        VALUES ('calendar_page', $1, $2, 'reply')
+        """,
+        target_id,
+        target_comment,
+    )
+
+    await _pool_execute(
+        """
+        CREATE OR REPLACE FUNCTION w1_06_fail_calendar_delete()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            RAISE EXCEPTION 'forced W1-06 page delete failure';
+        END;
+        $$
+        """
+    )
+    await _pool_execute(
+        """
+        CREATE TRIGGER w1_06_fail_calendar_delete_trigger
+        BEFORE DELETE ON calendar_pages
+        FOR EACH ROW WHEN (OLD.date = DATE '2026-07-18')
+        EXECUTE FUNCTION w1_06_fail_calendar_delete()
+        """
+    )
+    try:
+        try:
+            await database.delete_calendar_page("2026-07-18", "day")
+        except asyncpg.PostgresError:
+            pass
+        else:
+            raise AssertionError("forced page delete failure did not escape")
+        require(
+            await _pool_fetchval("SELECT COUNT(*) FROM calendar_pages WHERE id=$1", target_id) == 1,
+            "failed deletion removed the calendar page",
+        )
+        require(
+            await _pool_fetchval(
+                "SELECT COUNT(*) FROM comments WHERE target_type='calendar_page' AND target_id=$1",
+                target_id,
+            ) == 2,
+            "failed deletion did not restore calendar comments",
+        )
+    finally:
+        await _pool_execute("DROP TRIGGER IF EXISTS w1_06_fail_calendar_delete_trigger ON calendar_pages")
+        await _pool_execute("DROP FUNCTION IF EXISTS w1_06_fail_calendar_delete()")
+    passed("T-W1-06-1 injected second-step failure preserves page and comments")
+
+    keep_page_id = await _pool_fetchval(
+        "INSERT INTO calendar_pages (date, type) VALUES ('2026-07-19', 'day') RETURNING id"
+    )
+    keep_comment_id = await _pool_fetchval(
+        """
+        INSERT INTO comments (target_type, target_id, content)
+        VALUES ('calendar_page', $1, 'keep-page') RETURNING id
+        """,
+        keep_page_id,
+    )
+    other_target_id = await _pool_fetchval(
+        """
+        INSERT INTO comments (target_type, target_id, content)
+        VALUES ('memory', $1, 'keep-type') RETURNING id
+        """,
+        target_id,
+    )
+
+    require(await database.delete_calendar_page("2026-07-18", "day"), "existing page was not deleted")
+    require(
+        await _pool_fetchval("SELECT COUNT(*) FROM calendar_pages WHERE id=$1", target_id) == 0,
+        "target page survived successful delete",
+    )
+    require(
+        await _pool_fetchval(
+            "SELECT COUNT(*) FROM comments WHERE target_type='calendar_page' AND target_id=$1",
+            target_id,
+        ) == 0,
+        "target comments/replies survived successful delete",
+    )
+    passed("T-W1-06-2 successful delete removes page and its comment tree")
+
+    require(
+        await _pool_fetchval("SELECT COUNT(*) FROM comments WHERE id=$1", keep_comment_id) == 1,
+        "another page's comment was deleted",
+    )
+    require(
+        await _pool_fetchval("SELECT COUNT(*) FROM comments WHERE id=$1", other_target_id) == 1,
+        "another target type with the same numeric id was deleted",
+    )
+    passed("T-W1-06-3 unrelated comments remain untouched")
+
+    require(
+        not await database.delete_calendar_page("2026-07-18", "day"),
+        "repeated delete did not report not_found",
+    )
+    passed("T-W1-06-4 repeated delete is idempotent")
+
+
 async def test_w1_01() -> None:
     print("\nW1-01 project isolation and Dream permanent-memory protection")
     import importlib
@@ -1083,6 +1196,7 @@ async def run_suite(test_dsn: str) -> None:
         await test_s4(client)
         await test_s5(client)
         await test_s6(client)
+        await test_w1_06()
         await test_w1_01()
 
 
@@ -1095,8 +1209,10 @@ async def async_main() -> int:
         await run_suite(test_dsn)
         legacy_passed = [name for name in PASSED if name.startswith("T-S")]
         w1_01_passed = [name for name in PASSED if name.startswith("T-W1-01-")]
+        w1_06_passed = [name for name in PASSED if name.startswith("T-W1-06-")]
         print(f"\nPASS: {len(legacy_passed)} permanent S1-S6 behavior guards")
         print(f"PASS: {len(w1_01_passed)} W1-01 isolation/permanent guards")
+        print(f"PASS: {len(w1_06_passed)} W1-06 calendar-delete atomicity guards")
         print(f"PASS: {len(PASSED)} total permanent behavior guards")
         print("Real database path: disposable PostgreSQL verified")
         print("Real model/API path: not called; embedding/model/HTTP boundaries were mocked")


### PR DESCRIPTION
## 变更

- 将日历页面删除与其 `calendar_page` 评论清理包进同一个 asyncpg 事务。
- 保留现有 API、返回值、`_rowcount_nonzero` 与评论回复 `ON DELETE CASCADE` 行为。
- 新增无网络事务回滚合同和 PostgreSQL 16 真实失败注入守卫。

## 根因与影响

旧实现先删评论、再删页面，两条 SQL 共用连接但没有事务。若页面 DELETE 在第二步失败，评论已经永久消失，页面却仍保留。

现在任一步失败都会回滚整笔删除；成功时页面与评论树一起消失，重复删除继续返回 not_found，其他页面或其他 target_type 的评论不受影响。

## Tests-first

修复前新增无网络守卫精准红：`delete did not use one transaction`。生产修复仅改 `database.delete_calendar_page()` 的事务边界。

## 验证

- `git diff --check`
- 全仓 `compileall`
- 8 套既有/新增无网络与 ASGI 回归全绿
- 进程内负向变异移除事务后，回滚合同精准红：`fail_page left a partially deleted page/comment set`
- GitHub Actions PostgreSQL 16 会用一次性 trigger 强制第二步失败，验证真实数据库回滚；同时验证成功、评论回复级联、幂等与旁路隔离。

## 严格边界

本 PR 只建立页面与评论的单事务原语。没有创建 tombstone，没有增加生成封条，没有改变自动生成资格；W3-C2b 将来必须在这个事务内追加墓碑，不另开并列事务。
