### PR TITLE
fix: enforce calendar period identities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
           python scripts/test_compression_reasoning.py
           python scripts/test_calendar_delete_atomicity.py
           python scripts/test_mcp_calendar_sections.py
+          python scripts/test_calendar_period_guards.py
+          node scripts/test_calendar_period_defaults.mjs
 
       - name: 运行 S1-S6 永久真库行为守卫
         run: python scripts/test_kiwi_safety_sync.py

--- a/admin-panel/js/calendar-periods.mjs
+++ b/admin-panel/js/calendar-periods.mjs
@@ -1,0 +1,39 @@
+function parseIsoDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) throw new Error(`invalid ISO date: ${value}`);
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error(`invalid ISO date: ${value}`);
+  }
+  return parsed;
+}
+
+function addDays(value, days) {
+  const copy = new Date(value.getTime());
+  copy.setUTCDate(copy.getUTCDate() + days);
+  return copy;
+}
+
+function isoDate(value) { return value.toISOString().slice(0, 10); }
+function isoMonth(value) { return value.toISOString().slice(0, 7); }
+
+export function previousCompletePeriods(todayValue) {
+  const today = parseIsoDate(todayValue);
+  const mondayIndex = (today.getUTCDay() + 6) % 7;
+  const weekEnd = addDays(today, -(mondayIndex + 1));
+  const weekStart = addDays(weekEnd, -6);
+
+  const monthStart = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+  const previousMonth = addDays(monthStart, -1);
+
+  const currentQuarter = Math.floor(today.getUTCMonth() / 3) + 1;
+  const previousQuarter = currentQuarter === 1 ? 4 : currentQuarter - 1;
+  const previousQuarterYear = currentQuarter === 1 ? today.getUTCFullYear() - 1 : today.getUTCFullYear();
+
+  return {
+    weekStart: isoDate(weekStart),
+    weekEnd: isoDate(weekEnd),
+    month: isoMonth(previousMonth),
+    quarter: `${previousQuarterYear}-Q${previousQuarter}`,
+    year: String(today.getUTCFullYear() - 1),
+  };
+}

--- a/admin-panel/js/pages/calendar.js
+++ b/admin-panel/js/pages/calendar.js
@@ -3,6 +3,7 @@ import { get, escAttr, todayStr } from '../api.js';
 import { loadingBlock, toast, delegate, setBusy, masterSwitch } from '../ui.js';
 import { loadConfig, renderConfigGroups, wireConfig, ensureModelDatalist } from '../config.js';
 import { CONFIG_META } from '../config-schema.js';
+import { previousCompletePeriods } from '../calendar-periods.mjs';
 
 export default {
   title: '日历与整理',
@@ -64,10 +65,7 @@ export default {
   renderGenerate() {
     const today = todayStr(0);
     const yest = todayStr(-1);
-    const monthStr = today.slice(0, 7);
-    const y = today.slice(0, 4);
-    const q = Math.floor(new Date(today).getMonth() / 3) + 1;
-    const monStart = todayStr(-6);
+    const completed = previousCompletePeriods(today);
     this.root.querySelector('#panel-generate').innerHTML = `
       <div class="banner banner-info"><span>⏳</span><div>下面每个都是后台长任务（调用模型，可能需要几十秒）。点击后按钮会转圈，完成后弹出结果状态。</div></div>
 
@@ -93,8 +91,8 @@ export default {
         <div class="card-title">🗓️ 周总结</div>
         <div class="card-desc">汇总一周的日页面成周总结。</div>
         <div class="toolbar mt8">
-          <label class="text-sm muted">起</label><input type="date" id="d-week-start" value="${escAttr(monStart)}">
-          <label class="text-sm muted">止</label><input type="date" id="d-week-end" value="${escAttr(today)}">
+          <label class="text-sm muted">起</label><input type="date" id="d-week-start" value="${escAttr(completed.weekStart)}">
+          <label class="text-sm muted">止</label><input type="date" id="d-week-end" value="${escAttr(completed.weekEnd)}">
           <button class="btn btn-primary" data-act="gen-week">生成周总结</button>
         </div>
       </div>
@@ -102,7 +100,7 @@ export default {
       <div class="card mt16">
         <div class="card-title">📆 月总结</div>
         <div class="toolbar mt8">
-          <input type="month" id="d-month" value="${escAttr(monthStr)}">
+          <input type="month" id="d-month" value="${escAttr(completed.month)}">
           <button class="btn btn-primary" data-act="gen-month">生成月总结</button>
         </div>
       </div>
@@ -111,14 +109,14 @@ export default {
         <div class="card">
           <div class="card-title">📊 季度总结</div>
           <div class="toolbar mt8">
-            <input type="text" id="d-quarter" value="${escAttr(y + '-Q' + q)}" placeholder="YYYY-QN" style="width:130px">
+            <input type="text" id="d-quarter" value="${escAttr(completed.quarter)}" placeholder="YYYY-QN" style="width:130px">
             <button class="btn btn-primary" data-act="gen-quarter">生成季度</button>
           </div>
         </div>
         <div class="card">
           <div class="card-title">🎍 年度总结</div>
           <div class="toolbar mt8">
-            <input type="number" id="d-year" value="${escAttr(y)}" step="1" style="width:130px">
+            <input type="number" id="d-year" value="${escAttr(completed.year)}" step="1" style="width:130px">
             <button class="btn btn-primary" data-act="gen-year">生成年度</button>
           </div>
         </div>

--- a/calendar_periods.py
+++ b/calendar_periods.py
@@ -34,6 +34,21 @@ def _coerce_date(value, field_name: str) -> date:
         ) from exc
 
 
+def _authored_date(value) -> date:
+    if isinstance(value, datetime):
+        authored = value
+    elif isinstance(value, date):
+        return value
+    else:
+        try:
+            authored = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except (TypeError, ValueError) as exc:
+            raise CalendarPeriodValidationError("created_at 不是合法时间") from exc
+    if authored.tzinfo is None:
+        authored = authored.replace(tzinfo=TZ_CST)
+    return authored.astimezone(TZ_CST).date()
+
+
 def _period_end(start: date, page_type: str) -> date:
     if page_type == "day":
         return start
@@ -65,6 +80,7 @@ def validate_calendar_period_identity(
     *,
     end_value=None,
     today: Optional[date] = None,
+    created_at=None,
 ) -> CalendarPeriod:
     """Validate one page key and, when supplied, its explicit range end.
 
@@ -89,19 +105,31 @@ def validate_calendar_period_identity(
         raise CalendarPeriodValidationError(
             f"{page_type} 只允许已经结束的完整周期（本周期结束于 {expected_end.isoformat()}）"
         )
+    if page_type != "day" and created_at is not None and _authored_date(created_at) <= expected_end:
+        raise CalendarPeriodValidationError(
+            f"{page_type} 页面在周期结束前成文，需按完整周期明确重新生成"
+        )
     return CalendarPeriod(page_type=page_type, start=start, end=expected_end)
 
 
-def calendar_period_invalid_reason(start_value, page_type: str, *, today: Optional[date] = None) -> Optional[str]:
+def calendar_period_invalid_reason(
+    start_value, page_type: str, *, today: Optional[date] = None, created_at=None
+) -> Optional[str]:
     try:
-        validate_calendar_period_identity(start_value, page_type, today=today)
+        validate_calendar_period_identity(
+            start_value, page_type, today=today, created_at=created_at
+        )
     except CalendarPeriodValidationError as exc:
         return str(exc)
     return None
 
 
-def is_calendar_period_identity_valid(start_value, page_type: str, *, today: Optional[date] = None) -> bool:
-    return calendar_period_invalid_reason(start_value, page_type, today=today) is None
+def is_calendar_period_identity_valid(
+    start_value, page_type: str, *, today: Optional[date] = None, created_at=None
+) -> bool:
+    return calendar_period_invalid_reason(
+        start_value, page_type, today=today, created_at=created_at
+    ) is None
 
 
 def filter_valid_calendar_period_pages(
@@ -111,5 +139,7 @@ def filter_valid_calendar_period_pages(
     return [
         page for page in pages
         if page.get("type", page_type) == page_type
-        and is_calendar_period_identity_valid(page.get("date"), page_type, today=today)
+        and is_calendar_period_identity_valid(
+            page.get("date"), page_type, today=today, created_at=page.get("created_at")
+        )
     ]

--- a/calendar_periods.py
+++ b/calendar_periods.py
@@ -71,7 +71,7 @@ def validate_calendar_period_identity(
     Summary pages are authoritative only after their entire canonical period has
     ended in Asia/Taipei. Day pages remain writable for any valid date.
     """
-    if page_type not in ALLOWED_CALENDAR_PAGE_TYPES:
+    if not isinstance(page_type, str) or page_type not in ALLOWED_CALENDAR_PAGE_TYPES:
         raise CalendarPeriodValidationError(
             "type 只允许 day/week/month/quarter/year"
         )

--- a/calendar_periods.py
+++ b/calendar_periods.py
@@ -1,0 +1,115 @@
+"""Canonical calendar-period identities shared by every write/selection boundary."""
+
+import calendar
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from typing import Iterable, Mapping, Optional
+
+
+TZ_CST = timezone(timedelta(hours=8))
+ALLOWED_CALENDAR_PAGE_TYPES = frozenset({"day", "week", "month", "quarter", "year"})
+
+
+class CalendarPeriodValidationError(ValueError):
+    """Raised when a calendar page does not identify a canonical completed period."""
+
+
+@dataclass(frozen=True)
+class CalendarPeriod:
+    page_type: str
+    start: date
+    end: date
+
+
+def _coerce_date(value, field_name: str) -> date:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    try:
+        return date.fromisoformat(str(value))
+    except (TypeError, ValueError) as exc:
+        raise CalendarPeriodValidationError(
+            f"{field_name} 必须是 YYYY-MM-DD 格式的合法日期"
+        ) from exc
+
+
+def _period_end(start: date, page_type: str) -> date:
+    if page_type == "day":
+        return start
+    if page_type == "week":
+        if start.weekday() != 0:
+            raise CalendarPeriodValidationError("week 的 date/start 必须是周一")
+        return start + timedelta(days=6)
+    if page_type == "month":
+        if start.day != 1:
+            raise CalendarPeriodValidationError("month 的 date/start 必须是每月 1 日")
+        return date(start.year, start.month, calendar.monthrange(start.year, start.month)[1])
+    if page_type == "quarter":
+        if start.day != 1 or start.month not in {1, 4, 7, 10}:
+            raise CalendarPeriodValidationError("quarter 的 date/start 必须是 1/4/7/10 月 1 日")
+        end_month = start.month + 2
+        return date(start.year, end_month, calendar.monthrange(start.year, end_month)[1])
+    if page_type == "year":
+        if start.month != 1 or start.day != 1:
+            raise CalendarPeriodValidationError("year 的 date/start 必须是 1 月 1 日")
+        return date(start.year, 12, 31)
+    raise CalendarPeriodValidationError(
+        "type 只允许 day/week/month/quarter/year"
+    )
+
+
+def validate_calendar_period_identity(
+    start_value,
+    page_type: str,
+    *,
+    end_value=None,
+    today: Optional[date] = None,
+) -> CalendarPeriod:
+    """Validate one page key and, when supplied, its explicit range end.
+
+    Summary pages are authoritative only after their entire canonical period has
+    ended in Asia/Taipei. Day pages remain writable for any valid date.
+    """
+    if page_type not in ALLOWED_CALENDAR_PAGE_TYPES:
+        raise CalendarPeriodValidationError(
+            "type 只允许 day/week/month/quarter/year"
+        )
+    start = _coerce_date(start_value, "date/start")
+    expected_end = _period_end(start, page_type)
+    if end_value is not None:
+        supplied_end = _coerce_date(end_value, "end")
+        if supplied_end != expected_end:
+            raise CalendarPeriodValidationError(
+                f"{page_type} 的 end 必须是 {expected_end.isoformat()}"
+            )
+
+    today = _coerce_date(today, "today") if today is not None else datetime.now(TZ_CST).date()
+    if page_type != "day" and expected_end >= today:
+        raise CalendarPeriodValidationError(
+            f"{page_type} 只允许已经结束的完整周期（本周期结束于 {expected_end.isoformat()}）"
+        )
+    return CalendarPeriod(page_type=page_type, start=start, end=expected_end)
+
+
+def calendar_period_invalid_reason(start_value, page_type: str, *, today: Optional[date] = None) -> Optional[str]:
+    try:
+        validate_calendar_period_identity(start_value, page_type, today=today)
+    except CalendarPeriodValidationError as exc:
+        return str(exc)
+    return None
+
+
+def is_calendar_period_identity_valid(start_value, page_type: str, *, today: Optional[date] = None) -> bool:
+    return calendar_period_invalid_reason(start_value, page_type, today=today) is None
+
+
+def filter_valid_calendar_period_pages(
+    pages: Iterable[Mapping], page_type: str, *, today: Optional[date] = None
+) -> list:
+    """Return only pages whose stored key is canonical and fully completed."""
+    return [
+        page for page in pages
+        if page.get("type", page_type) == page_type
+        and is_calendar_period_identity_valid(page.get("date"), page_type, today=today)
+    ]

--- a/daily_digest.py
+++ b/daily_digest.py
@@ -1650,8 +1650,11 @@ WEEK_SUMMARY_PROMPT = """你是用户的 AI 伴侣。请根据这一周的日页
 
 async def generate_week_summary(start: str, end: str, model_override: str = None):
     """从日页面生成周总结"""
+    from calendar_periods import validate_calendar_period_identity
     from database import get_calendar_range, save_calendar_page
     from config import get_config
+
+    validate_calendar_period_identity(start, "week", end_value=end)
 
     # 读取这一周的日页面
     day_pages = await get_calendar_range(start, end, "day")
@@ -1795,13 +1798,20 @@ async def generate_month_summary(start: str, end: str, month_str: str, model_ove
     missing（有素材但日页面缺失）。出现 missing 时延迟成文——月总结成文后
     扫描永久跳过，此时缺的日子会被固化为永久缺失，宁可等日页面补齐。
     """
+    from calendar_periods import filter_valid_calendar_period_pages, validate_calendar_period_identity
     from database import get_calendar_range, save_calendar_page, get_chat_messages_for_date
     from config import get_config
+
+    period = validate_calendar_period_identity(start, "month", end_value=end)
+    if month_str != period.start.strftime("%Y-%m"):
+        raise ValueError(f"month 必须与 start 对应：{period.start.strftime('%Y-%m')}")
 
     m_start = _coerce_date(start)
     m_end = _coerce_date(end)
 
-    week_pages = await get_calendar_range(start, end, "week")
+    week_pages = filter_valid_calendar_period_pages(
+        await get_calendar_range(start, end, "week"), "week"
+    )
     full_weeks = [
         p for p in week_pages
         if _coerce_date(p["date"]) + timedelta(days=6) <= m_end
@@ -1917,16 +1927,24 @@ PERIOD_SUMMARY_PROMPT = """你是用户的 AI 伴侣。请根据下面的{source
 async def generate_period_summary(start: str, end: str, period_type: str,
                                    label: str, source_type: str, model_override: str = None):
     """通用的季度/年度总结生成"""
+    from calendar_periods import filter_valid_calendar_period_pages, validate_calendar_period_identity
     from database import get_calendar_range, save_calendar_page
     from config import get_config
 
+    if period_type not in {"quarter", "year"}:
+        raise ValueError("generate_period_summary 只允许 quarter/year")
+    validate_calendar_period_identity(start, period_type, end_value=end)
+
     # 根据 source_type 决定读取什么
     if source_type == "月总结":
-        pages = await get_calendar_range(start, end, "month")
+        source_page_type = "month"
     elif source_type == "季度总结":
-        pages = await get_calendar_range(start, end, "quarter")
+        source_page_type = "quarter"
     else:
-        pages = await get_calendar_range(start, end, "week")
+        source_page_type = "week"
+    pages = filter_valid_calendar_period_pages(
+        await get_calendar_range(start, end, source_page_type), source_page_type
+    )
 
     if not pages:
         print(f"   📭 {label} 没有{source_type}数据，跳过")

--- a/database.py
+++ b/database.py
@@ -3062,6 +3062,7 @@ async def save_calendar_page(date_str: str, page_type: str, sections: list, diar
             INSERT INTO calendar_pages (date, type, sections, diary, keywords, model_used, summary, digest, title, updated_at)
             VALUES ($1, $2, $3::jsonb, $4, $5::jsonb, $6, $7, $8, $9, NOW())
             ON CONFLICT (date, type) DO UPDATE SET
+                created_at = NOW(),
                 sections = EXCLUDED.sections,
                 diary = EXCLUDED.diary,
                 keywords = EXCLUDED.keywords,
@@ -3205,7 +3206,7 @@ async def get_calendar_for_injection(lookback_days: int = 365):
 
     async with pool.acquire() as conn:
         rows = await conn.fetch("""
-            SELECT date, type, digest, summary, keywords
+            SELECT date, type, digest, summary, keywords, created_at
             FROM calendar_pages
             WHERE date >= $1
             ORDER BY date ASC
@@ -3218,7 +3219,10 @@ async def get_calendar_for_injection(lookback_days: int = 365):
     pages = [
         page for page in (_calendar_row_to_dict(r) for r in rows)
         if page.get("type") == "day"
-        or is_calendar_period_identity_valid(page.get("date"), page.get("type"), today=today)
+        or is_calendar_period_identity_valid(
+            page.get("date"), page.get("type"), today=today,
+            created_at=page.get("created_at"),
+        )
     ]
 
     # 按类型分组
@@ -3357,7 +3361,7 @@ async def get_invalid_calendar_period_pages():
     today = datetime.now(TZ_CST).date()
     async with pool.acquire() as conn:
         rows = await conn.fetch("""
-            SELECT id, date, type, title, updated_at
+            SELECT id, date, type, title, created_at, updated_at
             FROM calendar_pages
             WHERE type <> 'day'
             ORDER BY date ASC, type ASC
@@ -3366,10 +3370,15 @@ async def get_invalid_calendar_period_pages():
     invalid = []
     for row in rows:
         item = dict(row)
-        reason = calendar_period_invalid_reason(item.get("date"), item.get("type"), today=today)
+        reason = calendar_period_invalid_reason(
+            item.get("date"), item.get("type"), today=today,
+            created_at=item.get("created_at"),
+        )
         if not reason:
             continue
         item["date"] = str(item.get("date"))
+        if item.get("created_at"):
+            item["created_at"] = item["created_at"].isoformat()
         if item.get("updated_at"):
             item["updated_at"] = item["updated_at"].isoformat()
         item["reason"] = reason

--- a/database.py
+++ b/database.py
@@ -3051,6 +3051,8 @@ async def save_calendar_page(date_str: str, page_type: str, sections: list, diar
                               title: str = ""):
     """保存或更新日历页面（upsert），v5.4 summary / v5.5 digest / v6.0 title"""
     from datetime import date as date_cls
+    from calendar_periods import validate_calendar_period_identity
+    validate_calendar_period_identity(date_str, page_type)
     pool = await get_pool()
     d = date_cls.fromisoformat(date_str)
     kw = json.dumps(keywords or [], ensure_ascii=False)
@@ -3081,6 +3083,8 @@ async def update_calendar_page_user_edit(date_str: str, page_type: str, diary: s
     model_used 记为 user_edit。返回页面 id。
     """
     from datetime import date as date_cls
+    from calendar_periods import validate_calendar_period_identity
+    validate_calendar_period_identity(date_str, page_type)
     pool = await get_pool()
     d = date_cls.fromisoformat(date_str)
     empty_json = json.dumps([], ensure_ascii=False)
@@ -3210,7 +3214,12 @@ async def get_calendar_for_injection(lookback_days: int = 365):
     if not rows:
         return []
 
-    pages = [_calendar_row_to_dict(r) for r in rows]
+    from calendar_periods import is_calendar_period_identity_valid
+    pages = [
+        page for page in (_calendar_row_to_dict(r) for r in rows)
+        if page.get("type") == "day"
+        or is_calendar_period_identity_valid(page.get("date"), page.get("type"), today=today)
+    ]
 
     # 按类型分组
     by_type = {}
@@ -3338,6 +3347,34 @@ async def get_calendar_for_injection(lookback_days: int = 365):
     result.sort(key=lambda x: x["date"])
 
     return result
+
+
+async def get_invalid_calendar_period_pages():
+    """只读诊断存量非法总结页；不重锚、不改写、不删除。"""
+    from calendar_periods import calendar_period_invalid_reason
+
+    pool = await get_pool()
+    today = datetime.now(TZ_CST).date()
+    async with pool.acquire() as conn:
+        rows = await conn.fetch("""
+            SELECT id, date, type, title, updated_at
+            FROM calendar_pages
+            WHERE type <> 'day'
+            ORDER BY date ASC, type ASC
+        """)
+
+    invalid = []
+    for row in rows:
+        item = dict(row)
+        reason = calendar_period_invalid_reason(item.get("date"), item.get("type"), today=today)
+        if not reason:
+            continue
+        item["date"] = str(item.get("date"))
+        if item.get("updated_at"):
+            item["updated_at"] = item["updated_at"].isoformat()
+        item["reason"] = reason
+        invalid.append(item)
+    return invalid
 
 
 async def get_chat_messages_for_date(date_str: str):

--- a/main.py
+++ b/main.py
@@ -3706,10 +3706,13 @@ async def api_generate_day_page(date: str = None):
 
 @app.get("/admin/week-summary")
 async def api_generate_week_summary(start: str = None, end: str = None):
-    """手动触发周总结 ?start=2026-03-31&end=2026-04-06"""
+    """手动触发周总结 ?start=2026-03-30&end=2026-04-05"""
     try:
+        from calendar_periods import validate_calendar_period_identity
         from daily_digest import generate_week_summary
-        if not start or not end:
+        if (start is None) != (end is None):
+            return JSONResponse(status_code=400, content={"error": "start 与 end 必须同时提供或同时省略"})
+        if start is None and end is None:
             from datetime import timedelta as td, timezone as tz_mod, datetime as dt_cls
             TZ = tz_mod(td(hours=8))
             now = dt_cls.now(TZ)
@@ -3719,8 +3722,11 @@ async def api_generate_week_summary(start: str = None, end: str = None):
             last_sunday = last_monday + td(days=6)
             start = last_monday.strftime("%Y-%m-%d")
             end = last_sunday.strftime("%Y-%m-%d")
+        validate_calendar_period_identity(start, "week", end_value=end)
         result = await generate_week_summary(start, end)
         return {"status": "ok", **result}
+    except ValueError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
     except Exception as e:
         return {"error": str(e)}
 
@@ -3729,6 +3735,7 @@ async def api_generate_week_summary(start: str = None, end: str = None):
 async def api_generate_month_summary(month: str = None):
     """手动触发月总结 ?month=2026-03"""
     try:
+        from calendar_periods import validate_calendar_period_identity
         from daily_digest import generate_month_summary
         if not month:
             from datetime import timedelta as td, timezone as tz_mod, datetime as dt_cls
@@ -3742,8 +3749,11 @@ async def api_generate_month_summary(month: str = None):
         last_day = cal_mod.monthrange(int(year), int(mon))[1]
         start = f"{month}-01"
         end = f"{month}-{last_day:02d}"
+        validate_calendar_period_identity(start, "month", end_value=end)
         result = await generate_month_summary(start, end, month)
         return {"status": "ok", **result}
+    except ValueError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
     except Exception as e:
         return {"error": str(e)}
 
@@ -3752,6 +3762,7 @@ async def api_generate_month_summary(month: str = None):
 async def api_generate_quarter_summary(quarter: str = None):
     """手动触发季度总结 ?quarter=2026-Q1"""
     try:
+        from calendar_periods import validate_calendar_period_identity
         from daily_digest import generate_period_summary
         import calendar as cal_mod
         from datetime import timedelta as td, timezone as tz_mod, datetime as dt_cls
@@ -3781,8 +3792,11 @@ async def api_generate_quarter_summary(quarter: str = None):
         end = f"{year}-{q_end_month:02d}-{q_end_day:02d}"
         label = f"{year}Q{q}"
 
+        validate_calendar_period_identity(start, "quarter", end_value=end)
         result = await generate_period_summary(start, end, "quarter", label, "月总结")
         return {"status": "ok", **result}
+    except ValueError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
     except Exception as e:
         return {"error": str(e)}
 
@@ -3791,6 +3805,7 @@ async def api_generate_quarter_summary(quarter: str = None):
 async def api_generate_year_summary(year: str = None):
     """手动触发年度总结 ?year=2025"""
     try:
+        from calendar_periods import validate_calendar_period_identity
         from daily_digest import generate_period_summary
         from datetime import timedelta as td, timezone as tz_mod, datetime as dt_cls
 
@@ -3803,8 +3818,11 @@ async def api_generate_year_summary(year: str = None):
         start = f"{y}-01-01"
         end = f"{y}-12-31"
 
+        validate_calendar_period_identity(start, "year", end_value=end)
         result = await generate_period_summary(start, end, "year", str(y), "季度总结")
         return {"status": "ok", **result}
+    except ValueError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
     except Exception as e:
         return {"error": str(e)}
 
@@ -3908,15 +3926,28 @@ async def api_get_calendar_range(start: str = None, end: str = None, type: str =
         return {"error": str(e)}
 
 
+@app.get("/admin/calendar-period-audit")
+async def api_calendar_period_audit():
+    """只读列出存量非法周期页；隔离不等于迁移或删除。"""
+    try:
+        from database import get_invalid_calendar_period_pages
+        pages = await get_invalid_calendar_period_pages()
+        return {"status": "ok", "pages": pages, "count": len(pages)}
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
 @app.put("/admin/calendar/{date}")
 async def api_save_calendar_page(date: str, req: Request):
     """用户手动编辑/创建日历页面"""
     try:
+        from calendar_periods import validate_calendar_period_identity
         from database import update_calendar_page_user_edit
         body = await req.json()
         content = body.get("content", "")
         title = body.get("title", "")
         page_type = body.get("type", "day")
+        validate_calendar_period_identity(date, page_type)
         # 用户编辑只写 diary（content）与 title；页面已有的 AI 内容
         # （sections/keywords/summary/digest/model_used）一律保留，不再被空值覆盖。
         page_id = await update_calendar_page_user_edit(
@@ -3926,6 +3957,8 @@ async def api_save_calendar_page(date: str, req: Request):
             title=title,
         )
         return {"status": "ok", "id": page_id}
+    except ValueError as e:
+        return JSONResponse(status_code=400, content={"error": str(e)})
     except Exception as e:
         return {"error": str(e)}
 

--- a/scripts/test_calendar_json_parser.py
+++ b/scripts/test_calendar_json_parser.py
@@ -159,7 +159,7 @@ async def _run_week(text):
         patch.object(daily_digest.httpx, "AsyncClient", _fake_async_client(text)),
     ):
         result = await daily_digest.generate_week_summary(
-            "2026-07-01", "2026-07-07", model_override="test-model"
+            "2026-06-29", "2026-07-05", model_override="test-model"
         )
     return result, saves
 

--- a/scripts/test_calendar_period_defaults.mjs
+++ b/scripts/test_calendar_period_defaults.mjs
@@ -1,0 +1,25 @@
+import { previousCompletePeriods } from '../admin-panel/js/calendar-periods.js';
+
+function check(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+for (let day = 10; day <= 16; day += 1) {
+  const today = `2026-08-${String(day).padStart(2, '0')}`;
+  const value = previousCompletePeriods(today);
+  check(value.weekStart === '2026-08-03', `${today} weekStart=${value.weekStart}`);
+  check(value.weekEnd === '2026-08-09', `${today} weekEnd=${value.weekEnd}`);
+  check(value.month === '2026-07', `${today} month=${value.month}`);
+  check(value.quarter === '2026-Q2', `${today} quarter=${value.quarter}`);
+  check(value.year === '2025', `${today} year=${value.year}`);
+}
+
+const jan = previousCompletePeriods('2026-01-01');
+check(jan.month === '2025-12', `January rollover month=${jan.month}`);
+check(jan.quarter === '2025-Q4', `January rollover quarter=${jan.quarter}`);
+check(jan.year === '2025', `January rollover year=${jan.year}`);
+
+const april = previousCompletePeriods('2026-04-01');
+check(april.quarter === '2026-Q1', `April rollover quarter=${april.quarter}`);
+
+console.log('PASS: admin calendar defaults use previous complete periods');

--- a/scripts/test_calendar_period_defaults.mjs
+++ b/scripts/test_calendar_period_defaults.mjs
@@ -1,4 +1,4 @@
-import { previousCompletePeriods } from '../admin-panel/js/calendar-periods.js';
+import { previousCompletePeriods } from '../admin-panel/js/calendar-periods.mjs';
 
 function check(condition, message) {
   if (!condition) throw new Error(message);

--- a/scripts/test_calendar_period_guards.py
+++ b/scripts/test_calendar_period_guards.py
@@ -94,6 +94,7 @@ async def check_shared_period_contract():
 
     invalid = (
         ("unknown type", lambda: periods.validate_calendar_period_identity("2026-08-01", "fortnight", today=fixed_today)),
+        ("non-string type", lambda: periods.validate_calendar_period_identity("2026-08-01", ["week"], today=fixed_today)),
         ("week start", lambda: periods.validate_calendar_period_identity("2026-08-04", "week", end_value="2026-08-10", today=fixed_today)),
         ("week end", lambda: periods.validate_calendar_period_identity("2026-08-03", "week", end_value="2026-08-08", today=fixed_today)),
         ("reversed week", lambda: periods.validate_calendar_period_identity("2026-08-03", "week", end_value="2026-08-02", today=fixed_today)),
@@ -281,6 +282,10 @@ async def check_http_boundaries():
                 f"/admin/calendar/{today.isoformat()}", json={"type": "fortnight", "content": "bad"}
             )
             check(response.status_code == 400, "unknown manual page type must return 400")
+            response = await client.put(
+                f"/admin/calendar/{today.isoformat()}", json={"type": ["week"], "content": "bad"}
+            )
+            check(response.status_code == 400, "non-string manual page type must return 400")
             response = await client.put(
                 f"/admin/calendar/{(p['week'][0] + timedelta(days=1)).isoformat()}",
                 json={"type": "week", "content": "bad"},

--- a/scripts/test_calendar_period_guards.py
+++ b/scripts/test_calendar_period_guards.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import calendar
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 import importlib
 import os
 from pathlib import Path
@@ -88,6 +88,10 @@ async def check_shared_period_contract():
     periods.validate_calendar_period_identity(
         "2026-08-03", "week", end_value="2026-08-09", today=fixed_today
     )
+    periods.validate_calendar_period_identity(
+        "2026-08-03", "week", today=fixed_today,
+        created_at=datetime(2026, 8, 10, 0, 5, tzinfo=timezone(timedelta(hours=8))),
+    )
     periods.validate_calendar_period_identity("2026-07-01", "month", today=fixed_today)
     periods.validate_calendar_period_identity("2026-04-01", "quarter", today=fixed_today)
     periods.validate_calendar_period_identity("2025-01-01", "year", today=fixed_today)
@@ -99,6 +103,10 @@ async def check_shared_period_contract():
         ("week end", lambda: periods.validate_calendar_period_identity("2026-08-03", "week", end_value="2026-08-08", today=fixed_today)),
         ("reversed week", lambda: periods.validate_calendar_period_identity("2026-08-03", "week", end_value="2026-08-02", today=fixed_today)),
         ("incomplete week", lambda: periods.validate_calendar_period_identity("2026-08-10", "week", end_value="2026-08-16", today=fixed_today)),
+        ("premature authored week", lambda: periods.validate_calendar_period_identity(
+            "2026-08-03", "week", today=fixed_today,
+            created_at=datetime(2026, 8, 9, 12, 0, tzinfo=timezone(timedelta(hours=8))),
+        )),
         ("month anchor", lambda: periods.validate_calendar_period_identity("2026-07-02", "month", today=fixed_today)),
         ("incomplete month", lambda: periods.validate_calendar_period_identity("2026-08-01", "month", today=fixed_today)),
         ("quarter anchor", lambda: periods.validate_calendar_period_identity("2026-05-01", "quarter", today=fixed_today)),
@@ -389,12 +397,19 @@ async def check_material_and_injection_isolation():
 
     invalid_month_date = month_start + timedelta(days=1)
     invalid_week_date = invalid_week_start
+    canonical_week_start, canonical_week_end = p["week"]
+    premature_created_at = datetime(
+        canonical_week_end.year, canonical_week_end.month, canonical_week_end.day,
+        12, 0, tzinfo=database.TZ_CST,
+    )
     rows = [
         {"id": 1, "date": invalid_month_date, "type": "month", "digest": "BAD_MONTH", "summary": "", "keywords": []},
         {"id": 2, "date": invalid_week_date, "type": "week", "digest": "BAD_WEEK", "summary": "", "keywords": []},
         {"id": 3, "date": invalid_month_date, "type": "day", "digest": "GOOD_DAY_MONTH", "summary": "", "keywords": []},
         {"id": 4, "date": invalid_week_date, "type": "day", "digest": "GOOD_DAY_WEEK", "summary": "", "keywords": []},
         {"id": 5, "date": month_start, "type": "fortnight", "digest": "BAD_TYPE", "summary": "", "keywords": []},
+        {"id": 6, "date": canonical_week_start, "type": "week", "digest": "PREMATURE_WEEK", "summary": "", "keywords": [], "created_at": premature_created_at},
+        {"id": 7, "date": canonical_week_start, "type": "day", "digest": "GOOD_DAY_PREMATURE", "summary": "", "keywords": []},
     ]
     conn = _FakeConnection(rows)
 
@@ -407,10 +422,10 @@ async def check_material_and_injection_isolation():
     check(not any(x["type"] in {"week", "month", "fortnight"} for x in injected),
           "invalid historical summaries must not inject or claim coverage")
     bodies = {x.get("digest") for x in injected}
-    check({"GOOD_DAY_MONTH", "GOOD_DAY_WEEK"} <= bodies,
+    check({"GOOD_DAY_MONTH", "GOOD_DAY_WEEK", "GOOD_DAY_PREMATURE"} <= bodies,
           "day pages under invalid summaries must remain eligible")
     audited_ids = {x["id"] for x in audited}
-    check({1, 2, 5} <= audited_ids, "read-only audit must diagnose every invalid historical identity")
+    check({1, 2, 5, 6} <= audited_ids, "read-only audit must diagnose every invalid historical identity")
 
 
 async def main():

--- a/scripts/test_calendar_period_guards.py
+++ b/scripts/test_calendar_period_guards.py
@@ -1,0 +1,433 @@
+"""No-network contracts for calendar period identity and completed-period writes."""
+
+import asyncio
+import calendar
+from datetime import date, datetime, timedelta
+import importlib
+import os
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+import httpx
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import daily_digest
+import database
+import config
+import main as gateway
+
+
+SUMMARY_RESULT = {
+    "summary": "summary",
+    "digest": "digest",
+    "sections": {"emotion": "emotion", "life": "life", "growth": "growth"},
+    "highlights": ["highlight"],
+    "diary": "diary",
+}
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def _periods(today):
+    current_monday = today - timedelta(days=today.weekday())
+    week_end = current_monday - timedelta(days=1)
+    week_start = week_end - timedelta(days=6)
+
+    month_end = today.replace(day=1) - timedelta(days=1)
+    month_start = month_end.replace(day=1)
+
+    current_q_month = ((today.month - 1) // 3) * 3 + 1
+    current_q_start = date(today.year, current_q_month, 1)
+    quarter_end = current_q_start - timedelta(days=1)
+    quarter_start_month = ((quarter_end.month - 1) // 3) * 3 + 1
+    quarter_start = date(quarter_end.year, quarter_start_month, 1)
+
+    year_start = date(today.year - 1, 1, 1)
+    year_end = date(today.year - 1, 12, 31)
+    return {
+        "week": (week_start, week_end),
+        "month": (month_start, month_end),
+        "quarter": (quarter_start, quarter_end),
+        "year": (year_start, year_end),
+    }
+
+
+def _expect_value_error(fn, label):
+    try:
+        fn()
+    except ValueError:
+        return
+    raise AssertionError(f"{label} must be rejected")
+
+
+async def _expect_async_value_error(awaitable, label):
+    try:
+        await awaitable
+    except ValueError:
+        return
+    raise AssertionError(f"{label} must be rejected")
+
+
+async def check_shared_period_contract():
+    periods = importlib.import_module("calendar_periods")
+    fixed_today = date(2026, 8, 11)
+
+    check(
+        periods.validate_calendar_period_identity("2099-02-03", "day", today=fixed_today).start
+        == date(2099, 2, 3),
+        "day pages must accept any valid calendar date",
+    )
+    periods.validate_calendar_period_identity(
+        "2026-08-03", "week", end_value="2026-08-09", today=fixed_today
+    )
+    periods.validate_calendar_period_identity("2026-07-01", "month", today=fixed_today)
+    periods.validate_calendar_period_identity("2026-04-01", "quarter", today=fixed_today)
+    periods.validate_calendar_period_identity("2025-01-01", "year", today=fixed_today)
+
+    invalid = (
+        ("unknown type", lambda: periods.validate_calendar_period_identity("2026-08-01", "fortnight", today=fixed_today)),
+        ("week start", lambda: periods.validate_calendar_period_identity("2026-08-04", "week", end_value="2026-08-10", today=fixed_today)),
+        ("week end", lambda: periods.validate_calendar_period_identity("2026-08-03", "week", end_value="2026-08-08", today=fixed_today)),
+        ("reversed week", lambda: periods.validate_calendar_period_identity("2026-08-03", "week", end_value="2026-08-02", today=fixed_today)),
+        ("incomplete week", lambda: periods.validate_calendar_period_identity("2026-08-10", "week", end_value="2026-08-16", today=fixed_today)),
+        ("month anchor", lambda: periods.validate_calendar_period_identity("2026-07-02", "month", today=fixed_today)),
+        ("incomplete month", lambda: periods.validate_calendar_period_identity("2026-08-01", "month", today=fixed_today)),
+        ("quarter anchor", lambda: periods.validate_calendar_period_identity("2026-05-01", "quarter", today=fixed_today)),
+        ("incomplete quarter", lambda: periods.validate_calendar_period_identity("2026-07-01", "quarter", today=fixed_today)),
+        ("year anchor", lambda: periods.validate_calendar_period_identity("2025-02-01", "year", today=fixed_today)),
+        ("incomplete year", lambda: periods.validate_calendar_period_identity("2026-01-01", "year", today=fixed_today)),
+    )
+    for label, call in invalid:
+        _expect_value_error(call, label)
+
+
+class _FakeConnection:
+    def __init__(self, rows=None):
+        self.rows = list(rows or [])
+        self.fetchrow_calls = []
+
+    async def fetchrow(self, *args):
+        self.fetchrow_calls.append(args)
+        return {"id": len(self.fetchrow_calls)}
+
+    async def fetch(self, *args):
+        return self.rows
+
+
+class _FakeAcquire:
+    def __init__(self, conn):
+        self.conn = conn
+
+    async def __aenter__(self):
+        return self.conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def acquire(self):
+        return _FakeAcquire(self.conn)
+
+
+async def check_database_write_boundary():
+    today = datetime.now(database.TZ_CST).date()
+    p = _periods(today)
+    conn = _FakeConnection()
+
+    async def fake_pool():
+        return _FakePool(conn)
+
+    invalid_month = today.replace(day=1)
+    invalid_calls = (
+        (lambda: database.save_calendar_page(invalid_month.isoformat(), "month", []), "incomplete generated month"),
+        (lambda: database.save_calendar_page((p["month"][0] + timedelta(days=1)).isoformat(), "month", []), "misanchored generated month"),
+        (lambda: database.save_calendar_page(p["week"][0].isoformat(), "fortnight", []), "unknown generated type"),
+        (lambda: database.update_calendar_page_user_edit(invalid_month.isoformat(), "month", diary="manual"), "incomplete manual month"),
+        (lambda: database.update_calendar_page_user_edit((p["week"][0] + timedelta(days=1)).isoformat(), "week", diary="manual"), "misanchored manual week"),
+    )
+    with patch.object(database, "get_pool", fake_pool):
+        for make_awaitable, label in invalid_calls:
+            await _expect_async_value_error(make_awaitable(), label)
+        check(conn.fetchrow_calls == [], "invalid DB writes must fail before acquiring/writing")
+
+        await database.save_calendar_page(today.isoformat(), "day", [])
+        await database.save_calendar_page(p["week"][0].isoformat(), "week", [])
+        await database.update_calendar_page_user_edit(p["month"][0].isoformat(), "month", diary="manual")
+    check(len(conn.fetchrow_calls) == 3, "valid day/summary identities must still reach the DB boundary")
+
+
+async def check_generation_boundaries():
+    today = datetime.now(database.TZ_CST).date()
+    p = _periods(today)
+    io_calls = []
+
+    async def fake_range(*args, **kwargs):
+        io_calls.append(("range", args))
+        return []
+
+    async def fake_model(*args, **kwargs):
+        io_calls.append(("model", args))
+        return SUMMARY_RESULT
+
+    async def fake_save(*args, **kwargs):
+        io_calls.append(("save", args))
+        return 1
+
+    current_month_start = today.replace(day=1)
+    current_month_end = date(today.year, today.month, calendar.monthrange(today.year, today.month)[1])
+    current_q_month = ((today.month - 1) // 3) * 3 + 1
+    current_q_start = date(today.year, current_q_month, 1)
+    current_q_end_month = current_q_month + 2
+    current_q_end = date(today.year, current_q_end_month, calendar.monthrange(today.year, current_q_end_month)[1])
+
+    with (
+        patch.object(database, "get_calendar_range", fake_range),
+        patch.object(database, "save_calendar_page", fake_save),
+        patch.object(daily_digest, "_call_model_for_json", fake_model),
+    ):
+        await _expect_async_value_error(
+            daily_digest.generate_week_summary(
+                (p["week"][0] + timedelta(days=1)).isoformat(),
+                (p["week"][1] + timedelta(days=1)).isoformat(),
+            ),
+            "direct invalid week generator",
+        )
+        await _expect_async_value_error(
+            daily_digest.generate_month_summary(
+                current_month_start.isoformat(), current_month_end.isoformat(),
+                current_month_start.strftime("%Y-%m"),
+            ),
+            "direct incomplete month generator",
+        )
+        await _expect_async_value_error(
+            daily_digest.generate_period_summary(
+                current_q_start.isoformat(), current_q_end.isoformat(),
+                "quarter", f"{today.year}Q{((today.month - 1) // 3) + 1}", "月总结",
+            ),
+            "direct incomplete quarter generator",
+        )
+    check(io_calls == [], "invalid direct generators must fail before material/model/DB I/O")
+
+
+async def check_http_boundaries():
+    today = datetime.now(database.TZ_CST).date()
+    p = _periods(today)
+    calls = []
+
+    async def fake_week(*args, **kwargs):
+        calls.append(("week", args))
+        return {"status": "success", "week": f"{args[0]}~{args[1]}"}
+
+    async def fake_month(*args, **kwargs):
+        calls.append(("month", args))
+        return {"status": "success", "month": args[2]}
+
+    async def fake_period(*args, **kwargs):
+        calls.append((args[2], args))
+        return {"status": "success", "label": args[3]}
+
+    async def fake_update(*args, **kwargs):
+        calls.append(("put", kwargs))
+        return 9
+
+    transport = httpx.ASGITransport(app=gateway.app)
+    with (
+        patch.object(daily_digest, "generate_week_summary", fake_week),
+        patch.object(daily_digest, "generate_month_summary", fake_month),
+        patch.object(daily_digest, "generate_period_summary", fake_period),
+        patch.object(database, "update_calendar_page_user_edit", fake_update),
+    ):
+        async with httpx.AsyncClient(transport=transport, base_url="http://kiwi.test") as client:
+            response = await client.get(f"/admin/week-summary?start={p['week'][0].isoformat()}")
+            check(response.status_code == 400, "week start/end partial input must return HTTP 400")
+            check(calls == [], "partial week input must not reach the generator")
+
+            response = await client.get("/admin/week-summary")
+            check(response.status_code == 200, "omitted week range must default successfully")
+            check(calls.pop(0) == ("week", (p["week"][0].isoformat(), p["week"][1].isoformat())),
+                  "omitted week range must choose the previous complete natural week")
+
+            bad_week_start = p["week"][0] + timedelta(days=1)
+            bad_week_end = bad_week_start + timedelta(days=6)
+            response = await client.get(
+                f"/admin/week-summary?start={bad_week_start.isoformat()}&end={bad_week_end.isoformat()}"
+            )
+            check(response.status_code == 400, "misanchored week HTTP input must return 400")
+            check(calls == [], "misanchored week HTTP input must not reach the generator")
+
+            response = await client.get(f"/admin/month-summary?month={today.strftime('%Y-%m')}")
+            check(response.status_code == 400, "incomplete month HTTP input must return 400")
+            response = await client.get(
+                f"/admin/quarter-summary?quarter={today.year}-Q{((today.month - 1) // 3) + 1}"
+            )
+            check(response.status_code == 400, "incomplete quarter HTTP input must return 400")
+            response = await client.get(f"/admin/year-summary?year={today.year}")
+            check(response.status_code == 400, "incomplete year HTTP input must return 400")
+            check(calls == [], "incomplete summary HTTP inputs must not reach generators")
+
+            response = await client.put(
+                f"/admin/calendar/{today.isoformat()}", json={"type": "fortnight", "content": "bad"}
+            )
+            check(response.status_code == 400, "unknown manual page type must return 400")
+            response = await client.put(
+                f"/admin/calendar/{(p['week'][0] + timedelta(days=1)).isoformat()}",
+                json={"type": "week", "content": "bad"},
+            )
+            check(response.status_code == 400, "misanchored manual week must return 400")
+            response = await client.put(
+                f"/admin/calendar/{today.replace(day=1).isoformat()}",
+                json={"type": "month", "content": "bad"},
+            )
+            check(response.status_code == 400, "incomplete manual month must return 400")
+            check(calls == [], "invalid manual pages must fail before the DB function")
+
+            response = await client.put(
+                f"/admin/calendar/{today.isoformat()}", json={"type": "day", "content": "valid"}
+            )
+            check(response.status_code == 200, "valid day manual page must remain writable")
+            check(len(calls) == 1 and calls[0][0] == "put", "valid day must reach the DB function once")
+
+
+def _day_page(d):
+    return {
+        "type": "day", "date": d, "sections": [], "keywords": [],
+        "summary": f"DAY_{d.isoformat()}", "digest": "", "diary": "",
+    }
+
+
+async def check_material_and_injection_isolation():
+    today = datetime.now(database.TZ_CST).date()
+    p = _periods(today)
+    month_start, month_end = p["month"]
+    invalid_week_start = next(
+        d for d in (month_start + timedelta(days=i) for i in range(0, 7))
+        if d.weekday() != 0 and d + timedelta(days=6) <= month_end
+    )
+    days = [_day_page(month_start + timedelta(days=i)) for i in range((month_end - month_start).days + 1)]
+    invalid_week = {
+        "type": "week", "date": invalid_week_start,
+        "sections": [{"emotion": "INVALID_WEEK_MATERIAL"}], "keywords": [], "diary": "",
+    }
+    prompts = []
+
+    async def calendar_range(start, end, page_type):
+        if page_type == "week":
+            return [invalid_week]
+        if page_type == "day":
+            return days
+        return []
+
+    async def no_messages(*args, **kwargs):
+        return []
+
+    async def fake_model(prompt, *args, **kwargs):
+        prompts.append(prompt)
+        return SUMMARY_RESULT
+
+    async def fake_save(*args, **kwargs):
+        return 77
+
+    async def empty_config(*args, **kwargs):
+        return ""
+
+    with (
+        patch.object(database, "get_calendar_range", calendar_range),
+        patch.object(database, "get_chat_messages_for_date", no_messages),
+        patch.object(database, "save_calendar_page", fake_save),
+        patch.object(config, "get_config", empty_config),
+        patch.object(daily_digest, "_call_model_for_json", fake_model),
+    ):
+        result = await daily_digest.generate_month_summary(
+            month_start.isoformat(), month_end.isoformat(), month_start.strftime("%Y-%m")
+        )
+    check(result["status"] == "success", "month generation must recover with day-page material")
+    check("INVALID_WEEK_MATERIAL" not in prompts[0], "invalid historical week must not feed month material")
+    check(f"DAY_{invalid_week_start.isoformat()}" in prompts[0], "invalid week span must fall back to day material")
+
+    q_start, q_end = p["quarter"]
+    invalid_month = {
+        "type": "month", "date": q_start + timedelta(days=1),
+        "sections": [{"emotion": "INVALID_MONTH_MATERIAL"}], "diary": "",
+    }
+    model_calls = []
+
+    async def invalid_month_range(*args, **kwargs):
+        return [invalid_month]
+
+    async def forbidden_model(*args, **kwargs):
+        model_calls.append(args)
+        return SUMMARY_RESULT
+
+    with (
+        patch.object(database, "get_calendar_range", invalid_month_range),
+        patch.object(config, "get_config", empty_config),
+        patch.object(daily_digest, "_call_model_for_json", forbidden_model),
+    ):
+        result = await daily_digest.generate_period_summary(
+            q_start.isoformat(), q_end.isoformat(), "quarter",
+            f"{q_start.year}Q{((q_start.month - 1) // 3) + 1}", "月总结",
+        )
+    check(result["status"] == "skipped", "period generator must skip when only invalid source pages exist")
+    check(model_calls == [], "invalid source pages must never reach the period model")
+
+    invalid_month_date = month_start + timedelta(days=1)
+    invalid_week_date = invalid_week_start
+    rows = [
+        {"id": 1, "date": invalid_month_date, "type": "month", "digest": "BAD_MONTH", "summary": "", "keywords": []},
+        {"id": 2, "date": invalid_week_date, "type": "week", "digest": "BAD_WEEK", "summary": "", "keywords": []},
+        {"id": 3, "date": invalid_month_date, "type": "day", "digest": "GOOD_DAY_MONTH", "summary": "", "keywords": []},
+        {"id": 4, "date": invalid_week_date, "type": "day", "digest": "GOOD_DAY_WEEK", "summary": "", "keywords": []},
+        {"id": 5, "date": month_start, "type": "fortnight", "digest": "BAD_TYPE", "summary": "", "keywords": []},
+    ]
+    conn = _FakeConnection(rows)
+
+    async def fake_pool():
+        return _FakePool(conn)
+
+    with patch.object(database, "get_pool", fake_pool):
+        injected = await database.get_calendar_for_injection(lookback_days=400)
+        audited = await database.get_invalid_calendar_period_pages()
+    check(not any(x["type"] in {"week", "month", "fortnight"} for x in injected),
+          "invalid historical summaries must not inject or claim coverage")
+    bodies = {x.get("digest") for x in injected}
+    check({"GOOD_DAY_MONTH", "GOOD_DAY_WEEK"} <= bodies,
+          "day pages under invalid summaries must remain eligible")
+    audited_ids = {x["id"] for x in audited}
+    check({1, 2, 5} <= audited_ids, "read-only audit must diagnose every invalid historical identity")
+
+
+async def main():
+    failures = []
+    cases = (
+        ("shared validator", check_shared_period_contract),
+        ("DB write boundary", check_database_write_boundary),
+        ("generation boundary", check_generation_boundaries),
+        ("HTTP boundary", check_http_boundaries),
+        ("material/injection isolation", check_material_and_injection_isolation),
+    )
+    for name, case in cases:
+        try:
+            await case()
+        except Exception as exc:
+            failure = f"{name}: {type(exc).__name__}: {exc}"
+            failures.append(failure)
+            print(f"FAIL {failure}")
+    if failures:
+        raise AssertionError("; ".join(failures))
+    print("PASS: calendar period identity and completed-period boundaries")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/test_calendar_summary_generation.py
+++ b/scripts/test_calendar_summary_generation.py
@@ -111,7 +111,7 @@ async def _calendar_range(start, end, page_type):
         }],
         "quarter": [{
             "type": "quarter",
-            "date": "2026-01-01",
+            "date": "2025-01-01",
             "sections": [{"emotion": "quarter source"}],
             "diary": "",
         }],
@@ -170,7 +170,7 @@ async def run_budget_contract():
         patch.object(daily_digest, "_call_model_for_json", fake_model),
     ):
         await daily_digest.generate_week_summary(
-            "2026-07-01", "2026-07-07", model_override="test-model"
+            "2026-06-29", "2026-07-05", model_override="test-model"
         )
         await daily_digest.generate_month_summary(
             "2026-07-01", "2026-07-31", "2026-07", model_override="test-model"
@@ -180,7 +180,7 @@ async def run_budget_contract():
             model_override="test-model",
         )
         await daily_digest.generate_period_summary(
-            "2026-01-01", "2026-12-31", "year", "2026", "季度总结",
+            "2025-01-01", "2025-12-31", "year", "2025", "季度总结",
             model_override="test-model",
         )
 
@@ -214,7 +214,7 @@ async def run_length_contract():
         redirect_stdout(output),
     ):
         result = await daily_digest.generate_week_summary(
-            "2026-07-01", "2026-07-07", model_override="test-model"
+            "2026-06-29", "2026-07-05", model_override="test-model"
         )
 
     log = output.getvalue()

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -1076,7 +1076,19 @@ async def test_w1_08() -> None:
         "INSERT INTO calendar_pages (date, type, digest) VALUES ($1, 'fortnight', 'BAD_TYPE') RETURNING id",
         previous_month_start,
     )
-    source_dates = {bad_week_date, bad_month_date}
+    premature_created_at = StdDateTime(
+        previous_week_end.year, previous_week_end.month, previous_week_end.day,
+        12, 0, tzinfo=database.TZ_CST,
+    )
+    premature_week_id = await _pool_fetchval(
+        """
+        INSERT INTO calendar_pages (date, type, digest, created_at, updated_at)
+        VALUES ($1, 'week', 'PREMATURE_WEEK', $2, $2) RETURNING id
+        """,
+        previous_week_start,
+        premature_created_at,
+    )
+    source_dates = {bad_week_date, bad_month_date, previous_week_start}
     for index, source_date in enumerate(sorted(source_dates), start=1):
         await _pool_execute(
             """
@@ -1094,7 +1106,7 @@ async def test_w1_08() -> None:
     require(count_before == count_after, "legacy period audit mutated stored pages")
     audited_ids = {row["id"] for row in audited}
     require(
-        {bad_week_id, bad_month_id, bad_type_id} <= audited_ids,
+        {bad_week_id, bad_month_id, bad_type_id, premature_week_id} <= audited_ids,
         f"legacy audit missed invalid identities: {audited_ids}",
     )
     passed("T-W1-08-3 read-only audit diagnoses legacy invalid pages without mutation")
@@ -1120,6 +1132,24 @@ async def test_w1_08() -> None:
             "legacy isolation moved or deleted a source day",
         )
     passed("T-W1-08-5 legacy isolation preserves original rows for explicit rebuild")
+
+    await database.save_calendar_page(
+        previous_week_start.isoformat(), "week", [], digest="REBUILT_WEEK"
+    )
+    rebuilt = await _pool_fetchrow(
+        "SELECT created_at, digest FROM calendar_pages WHERE id=$1", premature_week_id
+    )
+    require(
+        rebuilt["created_at"].astimezone(database.TZ_CST).date() > previous_week_end
+        and rebuilt["digest"] == "REBUILT_WEEK",
+        "explicit regeneration did not refresh the quarantined authorship epoch",
+    )
+    audited_after_rebuild = await database.get_invalid_calendar_period_pages()
+    require(
+        premature_week_id not in {row["id"] for row in audited_after_rebuild},
+        "explicit canonical rebuild did not restore period eligibility",
+    )
+    passed("T-W1-08-6 explicit regeneration releases premature-page quarantine")
 
 
 async def test_w1_01() -> None:

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -1018,6 +1018,110 @@ async def test_w1_06() -> None:
     passed("T-W1-06-4 repeated delete is idempotent")
 
 
+async def test_w1_08() -> None:
+    print("\nW1-08 calendar period identity and legacy isolation")
+    import importlib
+
+    periods = importlib.import_module("calendar_periods")
+    today = StdDateTime.now(database.TZ_CST).date()
+    current_monday = today - timedelta(days=today.weekday())
+    previous_week_end = current_monday - timedelta(days=1)
+    previous_week_start = previous_week_end - timedelta(days=6)
+    previous_month_end = today.replace(day=1) - timedelta(days=1)
+    previous_month_start = previous_month_end.replace(day=1)
+
+    await _truncate("calendar_pages", "comments")
+    invalid_factories = (
+        lambda: database.save_calendar_page(today.replace(day=1).isoformat(), "month", []),
+        lambda: database.save_calendar_page((previous_week_start + timedelta(days=1)).isoformat(), "week", []),
+        lambda: database.save_calendar_page(previous_week_start.isoformat(), "fortnight", []),
+        lambda: database.update_calendar_page_user_edit(today.replace(day=1).isoformat(), "month", diary="bad"),
+    )
+    for make_awaitable in invalid_factories:
+        try:
+            await make_awaitable()
+        except periods.CalendarPeriodValidationError:
+            pass
+        else:
+            raise AssertionError("invalid/incomplete calendar identity crossed the DB write boundary")
+    require(
+        await _pool_fetchval("SELECT COUNT(*) FROM calendar_pages") == 0,
+        "rejected calendar identities left rows behind",
+    )
+    passed("T-W1-08-1 DB writes reject unknown, misanchored, and incomplete periods")
+
+    await database.save_calendar_page(today.isoformat(), "day", [])
+    await database.save_calendar_page(previous_week_start.isoformat(), "week", [])
+    await database.update_calendar_page_user_edit(
+        previous_month_start.isoformat(), "month", diary="valid manual summary"
+    )
+    require(
+        await _pool_fetchval("SELECT COUNT(*) FROM calendar_pages") == 3,
+        "valid day/completed summaries did not remain writable",
+    )
+    passed("T-W1-08-2 valid day and completed canonical periods remain writable")
+
+    await _truncate("calendar_pages", "comments")
+    bad_week_date = previous_week_start - timedelta(days=13)  # Tuesday, safely older than seven days.
+    bad_month_date = previous_month_start + timedelta(days=1)
+    bad_week_id = await _pool_fetchval(
+        "INSERT INTO calendar_pages (date, type, digest) VALUES ($1, 'week', 'BAD_WEEK') RETURNING id",
+        bad_week_date,
+    )
+    bad_month_id = await _pool_fetchval(
+        "INSERT INTO calendar_pages (date, type, digest) VALUES ($1, 'month', 'BAD_MONTH') RETURNING id",
+        bad_month_date,
+    )
+    bad_type_id = await _pool_fetchval(
+        "INSERT INTO calendar_pages (date, type, digest) VALUES ($1, 'fortnight', 'BAD_TYPE') RETURNING id",
+        previous_month_start,
+    )
+    source_dates = {bad_week_date, bad_month_date}
+    for index, source_date in enumerate(sorted(source_dates), start=1):
+        await _pool_execute(
+            """
+            INSERT INTO calendar_pages (date, type, digest)
+            VALUES ($1, 'day', $2)
+            ON CONFLICT (date, type) DO UPDATE SET digest=EXCLUDED.digest
+            """,
+            source_date,
+            f"GOOD_DAY_{index}",
+        )
+
+    count_before = await _pool_fetchval("SELECT COUNT(*) FROM calendar_pages")
+    audited = await database.get_invalid_calendar_period_pages()
+    count_after = await _pool_fetchval("SELECT COUNT(*) FROM calendar_pages")
+    require(count_before == count_after, "legacy period audit mutated stored pages")
+    audited_ids = {row["id"] for row in audited}
+    require(
+        {bad_week_id, bad_month_id, bad_type_id} <= audited_ids,
+        f"legacy audit missed invalid identities: {audited_ids}",
+    )
+    passed("T-W1-08-3 read-only audit diagnoses legacy invalid pages without mutation")
+
+    injected = await database.get_calendar_for_injection(lookback_days=400)
+    require(
+        not any(row["type"] in {"week", "month", "fortnight"} for row in injected),
+        "invalid legacy summaries entered injection or claimed coverage",
+    )
+    injected_digests = {row.get("digest") for row in injected}
+    expected_day_digests = {f"GOOD_DAY_{i}" for i in range(1, len(source_dates) + 1)}
+    require(
+        expected_day_digests <= injected_digests,
+        f"invalid summaries hid their source days: {injected_digests}",
+    )
+    passed("T-W1-08-4 invalid legacy summaries cannot inject or claim day coverage")
+
+    for source_date in source_dates:
+        require(
+            await _pool_fetchval(
+                "SELECT COUNT(*) FROM calendar_pages WHERE date=$1 AND type='day'", source_date
+            ) == 1,
+            "legacy isolation moved or deleted a source day",
+        )
+    passed("T-W1-08-5 legacy isolation preserves original rows for explicit rebuild")
+
+
 async def test_w1_01() -> None:
     print("\nW1-01 project isolation and Dream permanent-memory protection")
     import importlib
@@ -1197,6 +1301,7 @@ async def run_suite(test_dsn: str) -> None:
         await test_s5(client)
         await test_s6(client)
         await test_w1_06()
+        await test_w1_08()
         await test_w1_01()
 
 
@@ -1210,9 +1315,11 @@ async def async_main() -> int:
         legacy_passed = [name for name in PASSED if name.startswith("T-S")]
         w1_01_passed = [name for name in PASSED if name.startswith("T-W1-01-")]
         w1_06_passed = [name for name in PASSED if name.startswith("T-W1-06-")]
+        w1_08_passed = [name for name in PASSED if name.startswith("T-W1-08-")]
         print(f"\nPASS: {len(legacy_passed)} permanent S1-S6 behavior guards")
         print(f"PASS: {len(w1_01_passed)} W1-01 isolation/permanent guards")
         print(f"PASS: {len(w1_06_passed)} W1-06 calendar-delete atomicity guards")
+        print(f"PASS: {len(w1_08_passed)} W1-08 calendar-period guards")
         print(f"PASS: {len(PASSED)} total permanent behavior guards")
         print("Real database path: disposable PostgreSQL verified")
         print("Real model/API path: not called; embedding/model/HTTP boundaries were mocked")

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -476,16 +476,17 @@ async def test_s3() -> None:
     await _pool_execute(
         """
         INSERT INTO calendar_pages (date, type, digest, summary)
-        VALUES ('2026-01-01', 'year', 'year', 'year'),
+        VALUES ('2025-01-01', 'year', 'year', 'year'),
+               ('2025-07-16', 'day', 'year-source', 'year-source'),
                ('2026-07-01', 'quarter', 'quarter', 'quarter'),
                ('2026-07-01', 'month', 'month', 'month')
         """
     )
     tz_calls.clear()
     with patch.object(database, "datetime", FixedDateTime):
-        hierarchical = await database.get_calendar_for_injection(lookback_days=365)
+        hierarchical = await database.get_calendar_for_injection(lookback_days=800)
     require(tz_calls == [database.TZ_CST], f"hierarchy path did not request TZ_CST: {tz_calls}")
-    require(any(item.get("label") == "2026年总结" for item in hierarchical), "date_cls hierarchy path broke")
+    require(any(item.get("label") == "2025年总结" for item in hierarchical), "date_cls hierarchy path broke")
     source = inspect.getsource(database.get_calendar_for_injection)
     require("datetime.now(TZ_CST).date()" in source, "CST anchor missing")
     require("date_cls.today()" not in source, "local container date anchor remains")


### PR DESCRIPTION
## 变更

- 新增共享 `calendar_periods.py`，统一校验 day/week/month/quarter/year 的规范锚点、完整周期与成文时点。
- HTTP 手动端点、周/月/季/年生成函数、`save_calendar_page` 与 `update_calendar_page_user_edit` 分别接入校验，任一层都不能绕过。
- `/admin/week-summary` 的 start/end 缺一返回 400；全部省略时默认上一完整自然周。
- 管理面板默认生成范围统一改为上一完整周/月/季/年。
- 存量非法或过早成文的总结页原样保留，通过只读 `/admin/calendar-period-audit` 诊断；它们不进入上级素材或日历注入，也不占日页面覆盖。
- 显式重新生成会刷新 `created_at` 并解除“过早成文”隔离；普通正文编辑不会误清隔离。
- 既有 #54 自然周跨月素材、missing/empty 与部分重叠三态保持不变。

## 周期合同

- week：周一至周日，end 必须等于 start + 6 天。
- month：每月 1 日；quarter：1/4/7/10 月 1 日；year：1 月 1 日。
- 周/月/季/年只有在整个周期已于 Asia/Taipei 的今天之前结束后才可新写入。
- 存量总结若在周期结束日或更早成文，保持隔离，直到用户显式重新生成。
- day 仍允许任意合法日期；type 只允许 day/week/month/quarter/year，非字符串 type 也按合同拒绝。

## Tests-first

修复前守卫同时复现：

1. 共享验证器不存在。
2. DB 保存边界接受进行中的月总结。
3. 内部生成函数可以绕过 HTTP。
4. week 参数缺一仍返回 200。
5. 非法旧周会混入月总结素材并遮蔽日页面。
6. 管理面板上一完整周期纯函数不存在。
7. list 等非字符串 type 触发 TypeError/HTTP 200。
8. 规范锚点但过早成文的存量周页仍会进入注入并认领覆盖。

两处旧“星期三开周”夹具与一条尚未结束的 2026 年总结夹具校准为合法完整周期；冻结守卫 ID、测试意图和 #54 回归均保留。

## 行为矩阵

| 场景 | HTTP | 生成函数 | DB | 素材/注入 |
|---|---|---|---|---|
| 合法且已结束周期 | 通过 | 通过 | 写入 | 正常参与 |
| start/end 缺一 | 400 | — | 无写入 | — |
| 非周一/错误 end | 400 | 拒绝 | 拒绝 | 存量隔离 |
| 错误月/季/年锚点 | 400 | 拒绝 | 拒绝 | 存量隔离 |
| 进行中周期 | 400 | 拒绝 | 拒绝 | 存量隔离 |
| 过早成文存量页 | — | 显式重建可恢复 | 原行保留 | 隔离且不认领覆盖 |
| 未知或非字符串 type | 400 | 拒绝 | 拒绝 | 只读诊断 |
| day 合法日期 | 通过 | 保持原样 | 写入 | 保持原样 |

## 验证

- 本地：全仓 Python 编译、十套 Python 行为脚本、管理面板 Node 周期默认合同、`git diff --check` 全绿。
- #54 月素材、missing/empty、diary-only、注入部分重叠回归保持全绿。
- CI Run [31480908823](https://github.com/LucieEveille/kiwi-mem/actions/runs/31480908823)：Python 3.12 语法与 disposable PostgreSQL 16 双作业全绿。
- 永久真库守卫：34 个 S1-S6 + 4 个 W1-01 + 4 个 W1-06 + 6 个 W1-08 = **48/48 PASS**；旧 ID 只增不减。
- 六把负向变异分别拆过早成文、DB、生成函数、HTTP、存量隔离、JS 默认，均精准转红并恢复绿。

## CI 校准记录

第一次 PostgreSQL CI 在旧 T-S3 夹具转红：它为层级日期构造测试插入了尚未结束的 2026 年总结，新隔离规则正确将其挡掉。最终提交只把该夹具换成已结束的 2025 年并补同年来源日页，冻结 ID 与 CST/层级断言未变；最终 CI 全绿。

## 数据与回滚

无 schema 或破坏性迁移。存量非法页不会自动重锚、改写或删除；审计只读。回滚可直接 revert 本 PR，原始数据始终保留。

## 证据边界

本机没有 PostgreSQL 服务或 Docker；本地证据覆盖纯函数、ASGI、确定性假 DB/模型边界。真实 SQL/asyncpg 路径由本 PR 的 disposable PostgreSQL 16 CI 证明。真实模型、生产 API 与生产数据均未调用。