### PR TITLE
[临时变异] W2-01 message ownership guard

### DIFF
--- a/database.py
+++ b/database.py
@@ -2792,11 +2792,6 @@ async def sync_upsert_single_message(conv_id: str, msg_id: str, msg: dict):
             )
             if not parent:
                 return ("对话不存在", 404)
-            owner = await conn.fetchrow(
-                "SELECT conversation_id FROM chat_messages WHERE id = $1", msg_id
-            )
-            if owner and owner["conversation_id"] != conv_id:
-                return ("消息属于其他对话", 409)
             row = await conn.fetchrow("""
                 INSERT INTO chat_messages (
                     id, conversation_id, role, content, time, model,

--- a/database.py
+++ b/database.py
@@ -2831,7 +2831,6 @@ async def sync_upsert_single_message(conv_id: str, msg_id: str, msg: dict):
                     usage = EXCLUDED.usage,
                     summary = EXCLUDED.summary,
                     sort_order = COALESCE($23, chat_messages.sort_order)
-                WHERE chat_messages.conversation_id = EXCLUDED.conversation_id
                 RETURNING id
             """, msg_id, conv_id, *content_values, sort_order)
             if row is None:


### PR DESCRIPTION
临时承重变异已完成。第一次仅移除 SQL WHERE 的 Run 31594508986 仍绿，证明前置 owner 检查在该调度下仍可兜底；补强为同时移除 owner 预检与 SQL WHERE 后，Run 31594660562 在 T-W2-01-6 跨项目/跨会话伪造 409 合同精准转红。此 PR 永不合并，现关闭。