### PR TITLE
W2-02：G1.1 消息身份与原子导入

### DIFF
--- a/database.py
+++ b/database.py
@@ -296,6 +296,8 @@ async def init_tables():
                 attachments     JSONB,
                 usage           JSONB,
                 summary         TEXT,
+                dream_event     JSONB,
+                turn_key        TEXT,
                 sort_order      INTEGER DEFAULT 0
             );
         """)
@@ -527,6 +529,27 @@ async def init_tables():
             if not has_col:
                 await conn.execute(f"ALTER TABLE chat_messages ADD COLUMN {col_name} {col_def}")
                 print(f"✅ chat_messages 表已添加 {col_name} 列（完整消息同步）")
+
+        # W2-02：chat_messages 表扩展 — dream_event / turn_key
+        #   dream_event：消息气泡里用户可见的 Dream 过程/结果，跨设备与刷新后应保留。
+        #   turn_key：前端消息快照自带的轮次稳定标识，供重放与跨设备对齐使用。
+        #   两列一律可空、无默认、不建索引：旧 payload 缺字段时按兼容合同写 NULL，
+        #   存量行经 ADD COLUMN 自动为 NULL，前一版本代码不感知也不会写坏。
+        #   注意：本列只服务前端消息快照。若日后事件账本（W2-03）出现同名
+        #   conversations.turn_key，二者同名不同义，禁止联表推断轮次归属。
+        for col_name, col_def in [
+            ("dream_event", "JSONB"),
+            ("turn_key", "TEXT"),
+        ]:
+            has_col = await conn.fetchval("""
+                SELECT EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'chat_messages' AND column_name = $1
+                )
+            """, col_name)
+            if not has_col:
+                await conn.execute(f"ALTER TABLE chat_messages ADD COLUMN {col_name} {col_def}")
+                print(f"✅ chat_messages 表已添加 {col_name} 列（W2-02 消息身份）")
 
         # v5.3：时间有效期窗口（MemPalace 启发）
         for col_name, col_def in [
@@ -2617,11 +2640,13 @@ async def sync_get_conversation(conv_id: str):
         return result
 
 
-async def sync_upsert_conversation(conv: dict):
-    """创建或更新对话元数据（不含消息）"""
-    pool = await get_pool()
-    async with pool.acquire() as conn:
-        await conn.execute("""
+async def _upsert_conversation_tx(conn, conv: dict):
+    """在给定连接/事务内 upsert 对话元数据，不自开连接。
+
+    对应 Gateway G1.1 的 _import_upsert_conversation_tx。供 sync_import_all 把
+    「元数据 + 全量消息」合进同一事务，任一步失败整体回滚，绝不留下空壳对话。
+    """
+    await conn.execute("""
             INSERT INTO chat_conversations (id, title, model, provider_model_id, project_id, pinned, sort_order, created_at, updated_at)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             ON CONFLICT (id) DO UPDATE SET
@@ -2642,7 +2667,17 @@ async def sync_upsert_conversation(conv: dict):
             int(conv.get("sortOrder", conv.get("sort_order", 0)) or 0),
             _parse_time(conv.get("createdAt") or conv.get("created_at")),
             _parse_time(conv.get("updatedAt") or conv.get("updated_at")),
-        )
+    )
+
+
+async def sync_upsert_conversation(conv: dict):
+    """创建或更新对话元数据（不含消息）。
+
+    legacy 全量 PUT 仍走这里：单独取连接、单条语句自动提交，行为与 W2-01 冻结时一致。
+    """
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        await _upsert_conversation_tx(conn, conv)
     return True
 
 
@@ -2715,7 +2750,12 @@ async def sync_delete_conversation(conv_id: str):
 
 
 def _message_content_values(msg: dict) -> list:
-    """装配 chat_messages 中 role..summary 的 20 个内容字段。"""
+    """装配 chat_messages 中 role..turn_key 的 22 个内容字段。
+
+    全量 import、legacy 全量替换与 W2-01 单消息 upsert 三条通道共用本函数，
+    新增字段只在这里追加一次，避免通道之间出现字段分叉或默认值分叉。
+    完整快照语义：请求体缺字段即写空值，不保留该列的旧值。
+    """
     return [
         msg.get("role") or "user",
         msg.get("content") or "",
@@ -2737,6 +2777,9 @@ def _message_content_values(msg: dict) -> list:
         _to_json(msg.get("attachments")),
         _to_json(msg.get("usage")),
         msg.get("summary") if isinstance(msg.get("summary"), str) else None,
+        _to_json(msg.get("dreamEvent") or msg.get("dream_event")),
+        (msg.get("turnKey") if isinstance(msg.get("turnKey"), str)
+         else msg.get("turn_key") if isinstance(msg.get("turn_key"), str) else None),
     ]
 
 
@@ -2745,35 +2788,46 @@ _MESSAGE_INSERT_SQL = """
         id, conversation_id, role, content, time, model,
         streaming, error, token_info, thinking, status_events, tool_events,
         memory_result, memory_event, handoff_info, web_search_results, versions, version_index,
-        images, attachments, usage, summary, sort_order
+        images, attachments, usage, summary, dream_event, turn_key, sort_order
     ) VALUES (
         $1, $2, $3, $4, $5, $6,
         $7, $8, $9, $10, $11, $12,
         $13, $14, $15, $16, $17, $18,
-        $19, $20, $21, $22, $23
+        $19, $20, $21, $22, $23, $24, $25
     )
 """
 
 
+async def _replace_messages_tx(conn, conv_id: str, messages: list):
+    """在给定连接/事务内全量替换某对话的消息，不自开连接。
+
+    对应 Gateway G1.1 的 _import_replace_messages_tx。父对话必须已在同一事务内
+    upsert，否则外键约束失败并回滚整个事务。legacy 全量通道与 import 通道共用
+    本函数，SQL 与字段装配全仓只此一份。
+    """
+    await conn.execute("DELETE FROM chat_messages WHERE conversation_id = $1", conv_id)
+    rows = [
+        (
+            str(msg.get("id") or f"m-{conv_id}-{idx}"),
+            conv_id,
+            *_message_content_values(msg),
+            idx,  # sort_order 取数组下标，保持前端顺序
+        )
+        for idx, msg in enumerate(messages)
+    ]
+    if rows:
+        await conn.executemany(_MESSAGE_INSERT_SQL, rows)
+
+
 async def sync_upsert_messages(conv_id: str, messages: list):
-    """批量写入/更新消息（全量替换该对话的所有消息）"""
+    """批量写入/更新消息（全量替换该对话的所有消息）。
+
+    legacy 全量 PUT 仍走这里：单独取连接、单独事务，行为与 W2-01 冻结时一致。
+    """
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            await conn.execute(
-                "DELETE FROM chat_messages WHERE conversation_id = $1", conv_id
-            )
-            rows = [
-                (
-                    str(msg.get("id") or f"m-{conv_id}-{idx}"),
-                    conv_id,
-                    *_message_content_values(msg),
-                    idx,
-                )
-                for idx, msg in enumerate(messages)
-            ]
-            if rows:
-                await conn.executemany(_MESSAGE_INSERT_SQL, rows)
+            await _replace_messages_tx(conn, conv_id, messages)
     return True
 
 
@@ -2802,12 +2856,12 @@ async def sync_upsert_single_message(conv_id: str, msg_id: str, msg: dict):
                     id, conversation_id, role, content, time, model,
                     streaming, error, token_info, thinking, status_events, tool_events,
                     memory_result, memory_event, handoff_info, web_search_results, versions, version_index,
-                    images, attachments, usage, summary, sort_order
+                    images, attachments, usage, summary, dream_event, turn_key, sort_order
                 ) VALUES (
                     $1, $2, $3, $4, $5, $6,
                     $7, $8, $9, $10, $11, $12,
                     $13, $14, $15, $16, $17, $18,
-                    $19, $20, $21, $22, COALESCE($23, 0)
+                    $19, $20, $21, $22, $23, $24, COALESCE($25, 0)
                 )
                 ON CONFLICT (id) DO UPDATE SET
                     role = EXCLUDED.role,
@@ -2830,7 +2884,9 @@ async def sync_upsert_single_message(conv_id: str, msg_id: str, msg: dict):
                     attachments = EXCLUDED.attachments,
                     usage = EXCLUDED.usage,
                     summary = EXCLUDED.summary,
-                    sort_order = COALESCE($23, chat_messages.sort_order)
+                    dream_event = EXCLUDED.dream_event,
+                    turn_key = EXCLUDED.turn_key,
+                    sort_order = COALESCE($25, chat_messages.sort_order)
                 WHERE chat_messages.conversation_id = EXCLUDED.conversation_id
                 RETURNING id
             """, msg_id, conv_id, *content_values, sort_order)
@@ -2976,43 +3032,146 @@ async def sync_delete_project(proj_id: str):
 # 云端同步 — 批量导入（首次迁移用）（v4.1）
 # ============================================================
 
-async def sync_import_all(conversations: list, projects: list):
-    """一次性导入所有对话和项目（localStorage → 数据库）"""
-    imported_convs = 0
-    imported_msgs = 0
-    imported_projs = 0
-    errors = []
+# W2-02：import 的受控拒绝码与安全摘要。
+# 回执与日志只使用这里的固定文案，绝不回传数据库原始异常——异常文本常带列值片段。
+_IMPORT_REJECT_SUMMARIES = {
+    "invalid_item": "条目不是 JSON 对象",
+    "missing_id": "缺少非空 id",
+    "duplicate_id": "同批次内 id 重复",
+    "invalid_messages": "messages 不是数组",
+    "invalid_message_item": "messages 内含非对象元素",
+}
+_IMPORT_FAIL_CODE = "db_error"
+_IMPORT_FAIL_SUMMARY = "数据库写入失败"
 
-    # 导入项目
+
+def _import_entity_id(item: dict):
+    """取实体 ID：只接受非空字符串或整数，其余（None/bool/dict/list）一律视为缺失。"""
+    raw = item.get("id")
+    if isinstance(raw, bool) or not isinstance(raw, (str, int)):
+        return ""
+    return str(raw).strip()
+
+
+def _precheck_import_entity(item, seen_ids: set, *, with_messages: bool):
+    """返回 (entity_id, messages, reject_code)。
+
+    messages 为 None 表示 payload 没带 messages 键（只更新 metadata、保留旧消息）；
+    messages 为 [] 表示客户端明确要求清空。二者语义不同，不得合并。
+    reject_code 非空时该实体一律不写库。
+    """
+    if not isinstance(item, dict):
+        return "", None, "invalid_item"
+    entity_id = _import_entity_id(item)
+    if not entity_id:
+        return "", None, "missing_id"
+    if entity_id in seen_ids:
+        return entity_id, None, "duplicate_id"
+    messages = None
+    if with_messages and "messages" in item:
+        messages = item.get("messages")
+        if not isinstance(messages, list):
+            return entity_id, None, "invalid_messages"
+        if any(not isinstance(m, dict) for m in messages):
+            return entity_id, None, "invalid_message_item"
+    return entity_id, messages, None
+
+
+async def sync_import_all(conversations: list, projects: list):
+    """一次性导入所有对话和项目（localStorage → 数据库）。
+
+    W2-02：
+      · 每个对话的「元数据 upsert + 消息替换」合并进同一事务（复用同一连接），
+        任一步失败整体回滚，服务器绝不留下只有元数据的空壳对话；
+      · 项目维持逐项独立原子写，单条失败不阻断其他实体；
+      · 输入预检把畸形条目归入 rejected 并且完全不写库，与数据库执行失败
+        （failed）分开记账，不再静默接受缺 id 的条目；
+      · 计数与成功 ID 仅在实体事务提交后累加，回执可直接对账；
+      · 回执保留旧七个键，新增 counts 三态与 rejected_details。
+    对账不变式：conversations == counts.conversations.success == len(imported_conversation_ids)，
+                projects      == counts.projects.success      == len(imported_project_ids)。
+    """
+    counts = {
+        "conversations": {"success": 0, "rejected": 0, "failed": 0},
+        "projects": {"success": 0, "rejected": 0, "failed": 0},
+        "messages": {"success": 0},
+    }
+    errors = []
+    error_details = []
+    rejected_details = []
+    imported_conversation_ids = []
+    imported_project_ids = []
+
+    def record_reject(kind: str, entity_id: str, code: str) -> None:
+        counts[f"{kind}s"]["rejected"] += 1
+        rejected_details.append(
+            {"type": kind, "id": entity_id, "code": code, "error": _IMPORT_REJECT_SUMMARIES[code]}
+        )
+        # 观测事件只含实体种类与拒绝码，不含 payload 也不含实体 ID
+        print(f"event=sync_import_reject entity={kind} code={code} increment=1")
+
+    def record_failure(kind: str, entity_id: str) -> None:
+        counts[f"{kind}s"]["failed"] += 1
+        errors.append(f"{'对话' if kind == 'conversation' else '项目'} {entity_id}: {_IMPORT_FAIL_SUMMARY}")
+        error_details.append(
+            {"type": kind, "id": entity_id, "code": _IMPORT_FAIL_CODE, "error": _IMPORT_FAIL_SUMMARY}
+        )
+        print(f"event=sync_import_failure entity={kind} code={_IMPORT_FAIL_CODE} increment=1")
+
+    pool = await get_pool()
+
+    # 导入项目（单条 upsert 自身原子；逐项记账，失败不牵连其他实体）
+    seen_projects: set = set()
     for proj in projects:
+        pid, _, reject = _precheck_import_entity(proj, seen_projects, with_messages=False)
+        if reject:
+            record_reject("project", pid, reject)
+            continue
+        seen_projects.add(pid)
         try:
             await sync_upsert_project(proj)
-            imported_projs += 1
-        except Exception as e:
-            errors.append(f"项目 {proj.get('id', '?')}: {e}")
-            print(f"⚠️ 项目导入失败: {proj.get('id', '?')} — {e}")
+            counts["projects"]["success"] += 1
+            imported_project_ids.append(pid)
+        except Exception:
+            record_failure("project", pid)
 
-    # 导入对话 + 消息
+    # 导入对话 + 消息（每个对话一个事务：元数据与消息同生共死）
+    seen_conversations: set = set()
     for conv in conversations:
+        cid, messages, reject = _precheck_import_entity(conv, seen_conversations, with_messages=True)
+        if reject:
+            record_reject("conversation", cid, reject)
+            continue
+        seen_conversations.add(cid)
+        # 用字典推导而非 .pop()，避免修改调用方的原始数据
+        conv_meta = {k: v for k, v in conv.items() if k != "messages"}
+        conv_meta["id"] = cid
         try:
-            # 用 .get() 而非 .pop()，避免修改调用方的原始数据
-            messages = conv.get("messages", [])
-            # 传给 sync_upsert_conversation 时排除 messages 字段
-            conv_meta = {k: v for k, v in conv.items() if k != "messages"}
-            await sync_upsert_conversation(conv_meta)
-            if messages:
-                await sync_upsert_messages(conv_meta.get("id", conv.get("id", "")), messages)
-                imported_msgs += len(messages)
-            imported_convs += 1
-        except Exception as e:
-            errors.append(f"对话 {conv.get('id', '?')}: {e}")
-            print(f"⚠️ 对话导入失败: {conv.get('id', '?')} — {e}")
+            async with pool.acquire() as conn:
+                async with conn.transaction():
+                    await _upsert_conversation_tx(conn, conv_meta)
+                    # messages 缺失 → 只更新 metadata，保留既有消息；
+                    # 显式 [] → 清空；非空数组 → 完整替换并删除差集。
+                    if messages is not None:
+                        await _replace_messages_tx(conn, cid, messages)
+            # 事务已提交，方才计数并进入成功 ID 数组
+            counts["conversations"]["success"] += 1
+            if messages is not None:
+                counts["messages"]["success"] += len(messages)
+            imported_conversation_ids.append(cid)
+        except Exception:
+            record_failure("conversation", cid)
 
     return {
-        "conversations": imported_convs,
-        "messages": imported_msgs,
-        "projects": imported_projs,
+        "conversations": counts["conversations"]["success"],
+        "messages": counts["messages"]["success"],
+        "projects": counts["projects"]["success"],
         "errors": errors,
+        "imported_conversation_ids": imported_conversation_ids,
+        "imported_project_ids": imported_project_ids,
+        "error_details": error_details,
+        "counts": counts,
+        "rejected_details": rejected_details,
     }
 
 

--- a/database.py
+++ b/database.py
@@ -3040,8 +3040,9 @@ _IMPORT_REJECT_SUMMARIES = {
     "duplicate_id": "同批次内 id 重复",
     "invalid_messages": "messages 不是数组",
     "invalid_message_item": "messages 内含非对象元素",
+    "duplicate_message_id": "同一对话内消息 id 重复",
 }
-_IMPORT_FAIL_CODE = "db_error"
+_IMPORT_FAIL_CODE = "write_failed"
 _IMPORT_FAIL_SUMMARY = "数据库写入失败"
 
 
@@ -3053,28 +3054,70 @@ def _import_entity_id(item: dict):
     return str(raw).strip()
 
 
-def _precheck_import_entity(item, seen_ids: set, *, with_messages: bool):
-    """返回 (entity_id, messages, reject_code)。
+def _explicit_message_ids(messages: list) -> list:
+    """取消息数组里显式提供的非空 ID。缺 ID 的消息由写入期按下标合成，不参与重复判定。"""
+    ids = []
+    for msg in messages:
+        raw = msg.get("id")
+        if isinstance(raw, bool) or not isinstance(raw, (str, int)):
+            continue
+        text = str(raw).strip()
+        if text:
+            ids.append(text)
+    return ids
 
+
+def _precheck_import_batch(items: list, *, with_messages: bool) -> list:
+    """整批两遍预检，返回与 items 一一对应的 [(entity_id, messages, reject_code), ...]。
+
+    必须先扫完整批再定论：有效 ID 在同一数组出现多次时，**所有同 ID 副本一起拒绝**，
+    该 ID 零写库。只拒后来者会让先到的那份静默胜出，与冻结合同冲突。
+
+    冻结优先级：invalid_item → missing_id → duplicate_id → messages 检查。
     messages 为 None 表示 payload 没带 messages 键（只更新 metadata、保留旧消息）；
     messages 为 [] 表示客户端明确要求清空。二者语义不同，不得合并。
     reject_code 非空时该实体一律不写库。
     """
-    if not isinstance(item, dict):
-        return "", None, "invalid_item"
-    entity_id = _import_entity_id(item)
-    if not entity_id:
-        return "", None, "missing_id"
-    if entity_id in seen_ids:
-        return entity_id, None, "duplicate_id"
-    messages = None
-    if with_messages and "messages" in item:
-        messages = item.get("messages")
-        if not isinstance(messages, list):
-            return entity_id, None, "invalid_messages"
-        if any(not isinstance(m, dict) for m in messages):
-            return entity_id, None, "invalid_message_item"
-    return entity_id, messages, None
+    # 第一遍：只定结构与 ID，不下重复结论
+    staged = []
+    for item in items:
+        if not isinstance(item, dict):
+            staged.append(("", "invalid_item"))
+            continue
+        entity_id = _import_entity_id(item)
+        staged.append((entity_id, None if entity_id else "missing_id"))
+
+    frequency: dict = {}
+    for entity_id, code in staged:
+        if code is None:
+            frequency[entity_id] = frequency.get(entity_id, 0) + 1
+
+    # 第二遍：按频次统一裁决，再检查 messages
+    resolved = []
+    for item, (entity_id, code) in zip(items, staged):
+        if code is not None:
+            resolved.append((entity_id, None, code))
+            continue
+        if frequency.get(entity_id, 0) > 1:
+            resolved.append((entity_id, None, "duplicate_id"))
+            continue
+        messages = None
+        if with_messages and "messages" in item:
+            messages = item.get("messages")
+            if not isinstance(messages, list):
+                resolved.append((entity_id, None, "invalid_messages"))
+                continue
+            if any(not isinstance(m, dict) for m in messages):
+                resolved.append((entity_id, None, "invalid_message_item"))
+                continue
+            explicit_ids = _explicit_message_ids(messages)
+            if len(explicit_ids) != len(set(explicit_ids)):
+                # 同一对话内显式消息 ID 撞车属于输入不合规，在写库前拒绝整条对话，
+                # 不让它到主键约束处炸成服务器写入失败。
+                resolved.append((entity_id, None, "duplicate_message_id"))
+                continue
+        resolved.append((entity_id, messages, None))
+    return resolved
 
 
 async def sync_import_all(conversations: list, projects: list):
@@ -3085,9 +3128,10 @@ async def sync_import_all(conversations: list, projects: list):
         任一步失败整体回滚，服务器绝不留下只有元数据的空壳对话；
       · 项目维持逐项独立原子写，单条失败不阻断其他实体；
       · 输入预检把畸形条目归入 rejected 并且完全不写库，与数据库执行失败
-        （failed）分开记账，不再静默接受缺 id 的条目；
+        （failed）分开记账，不再静默接受缺 id 的条目；重复的实体 ID 与
+        对话内重复的显式消息 ID 都在写库前整体拒绝；
       · 计数与成功 ID 仅在实体事务提交后累加，回执可直接对账；
-      · 回执保留旧七个键，新增 counts 三态与 rejected_details。
+      · 回执保留既有兼容字段，并新增结构化三态回执（counts 与 rejected_details）。
     对账不变式：conversations == counts.conversations.success == len(imported_conversation_ids)，
                 projects      == counts.projects.success      == len(imported_project_ids)。
     """
@@ -3121,28 +3165,26 @@ async def sync_import_all(conversations: list, projects: list):
     pool = await get_pool()
 
     # 导入项目（单条 upsert 自身原子；逐项记账，失败不牵连其他实体）
-    seen_projects: set = set()
-    for proj in projects:
-        pid, _, reject = _precheck_import_entity(proj, seen_projects, with_messages=False)
+    for proj, (pid, _, reject) in zip(projects, _precheck_import_batch(projects, with_messages=False)):
         if reject:
             record_reject("project", pid, reject)
             continue
-        seen_projects.add(pid)
+        # 复制后覆盖权威 ID：预检已把首尾空白清理掉，写库必须用同一个值，
+        # 否则回执报清理后的 ID、主键却落成带空白的原值。
+        proj_meta = dict(proj)
+        proj_meta["id"] = pid
         try:
-            await sync_upsert_project(proj)
+            await sync_upsert_project(proj_meta)
             counts["projects"]["success"] += 1
             imported_project_ids.append(pid)
         except Exception:
             record_failure("project", pid)
 
     # 导入对话 + 消息（每个对话一个事务：元数据与消息同生共死）
-    seen_conversations: set = set()
-    for conv in conversations:
-        cid, messages, reject = _precheck_import_entity(conv, seen_conversations, with_messages=True)
+    for conv, (cid, messages, reject) in zip(conversations, _precheck_import_batch(conversations, with_messages=True)):
         if reject:
             record_reject("conversation", cid, reject)
             continue
-        seen_conversations.add(cid)
         # 用字典推导而非 .pop()，避免修改调用方的原始数据
         conv_meta = {k: v for k, v in conv.items() if k != "messages"}
         conv_meta["id"] = cid

--- a/main.py
+++ b/main.py
@@ -5467,17 +5467,32 @@ async def api_delete_file_chunks(proj_id: str, file_id: str):
 
 @app.post("/sync/import")
 async def api_sync_import(request: Request):
-    """一次性导入所有 localStorage 数据"""
+    """一次性导入所有 localStorage 数据。
+
+    顶层结构错误返回 400；单实体的畸形条目进 rejected、数据库失败进 failed，
+    两者都不影响同批次其他实体，整体仍返回 200 并由回执逐项交代。
+    """
     try:
-        data = await request.json()
+        data, err = await _read_json_object(request)
+        if err:
+            return err
         conversations = data.get("conversations", [])
         projects = data.get("projects", [])
+        if not isinstance(conversations, list) or not isinstance(projects, list):
+            return JSONResponse(
+                status_code=400, content={"error": "conversations 与 projects 必须是数组"}
+            )
         result = await sync_import_all(conversations, projects)
-        print(f"📦 云端同步导入完成：{result}")
+        # 只记计数，不打印回执正文：error_details 含实体 ID，日志侧不需要
+        counts = result["counts"]
+        print(
+            "event=sync_import_done "
+            f"conversations={counts['conversations']['success']}/{counts['conversations']['rejected']}/{counts['conversations']['failed']} "
+            f"projects={counts['projects']['success']}/{counts['projects']['rejected']}/{counts['projects']['failed']} "
+            f"messages={counts['messages']['success']} (success/rejected/failed)"
+        )
         return {"status": "ok", **result}
     except Exception as e:
-        import traceback
-        traceback.print_exc()
         return JSONResponse(status_code=500, content={"error": str(e)})
 
 

--- a/main.py
+++ b/main.py
@@ -5493,7 +5493,10 @@ async def api_sync_import(request: Request):
         )
         return {"status": "ok", **result}
     except Exception as e:
-        return JSONResponse(status_code=500, content={"error": str(e)})
+        # 整体崩溃路径：只暴露固定文案与异常类型名，绝不回传异常正文。
+        # 异常正文常带 payload 片段、消息内容或 DSN；逐实体失败路径同理（见 record_failure）。
+        print(f"event=sync_import_crash exception={type(e).__name__} code=import_failed increment=1")
+        return JSONResponse(status_code=500, content={"error": "导入失败"})
 
 
 # ──── 用户/助手配置同步（复用 config 表） ────

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -23,7 +23,7 @@ import re
 import sys
 import uuid
 import zipfile
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from datetime import date, datetime as StdDateTime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable
@@ -1741,6 +1741,8 @@ async def test_w2_02(client: httpx.AsyncClient) -> None:
             "metadata survived a failed message write: half-imported shell conversation",
         )
         require(body["counts"]["conversations"]["failed"] == 1, "failed conversation was not counted as failed")
+        require([d["code"] for d in body["error_details"]] == ["write_failed"],
+                f"message-write failure code must be write_failed: {[d.get('code') for d in body['error_details']]}")
         require(fail_conv not in body["imported_conversation_ids"], "failed conversation entered the success IDs")
         require(
             await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_messages WHERE conversation_id = $1)", ok_conv),
@@ -1798,6 +1800,8 @@ async def test_w2_02(client: httpx.AsyncClient) -> None:
                 "a failed project blocked conversation import")
         require(body["counts"]["projects"] == {"success": 1, "rejected": 0, "failed": 1},
                 f"project counts wrong: {body['counts']['projects']}")
+        require([d["code"] for d in body["error_details"]] == ["write_failed"],
+                f"project failure code must be write_failed: {[d.get('code') for d in body['error_details']]}")
         require(body["imported_project_ids"] == [good_proj], "project success IDs include a failed entity")
         passed("T-W2-02-10 project write failure is isolated to that project")
     finally:
@@ -1826,6 +1830,8 @@ async def test_w2_02(client: httpx.AsyncClient) -> None:
         require(await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_projects WHERE id = $1)", f"{prefix}metaok-p"),
                 "a failed conversation blocked project import")
         require(body["counts"]["conversations"]["failed"] == 1, "metadata failure was not counted")
+        require([d["code"] for d in body["error_details"]] == ["write_failed"],
+                f"metadata failure code must be write_failed: {[d.get('code') for d in body['error_details']]}")
         passed("T-W2-02-11 metadata write failure is isolated and leaves no messages")
     finally:
         await _drop_fail_trigger("chat_conversations", "w202_fail_meta")
@@ -1872,34 +1878,57 @@ async def test_w2_02(client: httpx.AsyncClient) -> None:
     passed("T-W2-02-13 malformed top-level import bodies return 400")
 
     await _truncate("chat_messages", "chat_conversations", "chat_projects")
-    dup = f"{prefix}dup-c"
+    dup_conv, dup_proj = f"{prefix}dup-c", f"{prefix}dup-p"
+    fine_conv, fine_proj = f"{prefix}fine-c", f"{prefix}fine-p"
     response = await client.post("/sync/import", json={
         "conversations": [
             "not-a-dict",
             {"title": "missing id"},
-            {"id": dup, "title": "first", "messages": []},
-            {"id": dup, "title": "second", "messages": []},
+            {"id": dup_conv, "title": "first", "messages": []},
+            {"id": dup_conv, "title": "second", "messages": []},
             {"id": f"{prefix}badmsgs", "title": "bad messages", "messages": "nope"},
             {"id": f"{prefix}badmsgitem", "title": "bad message item", "messages": ["x"]},
+            {"id": fine_conv, "title": "healthy", "messages": []},
         ],
-        "projects": ["not-a-dict", {"name": "missing id"}],
+        "projects": [
+            "not-a-dict",
+            {"name": "missing id"},
+            {"id": dup_proj, "name": "p-first"},
+            {"id": dup_proj, "name": "p-second"},
+            {"id": fine_proj, "name": "healthy"},
+        ],
     })
     require(response.status_code == 200, "per-entity rejects must not fail the whole batch")
     body = response.json()
     codes = [d["code"] for d in body["rejected_details"]]
     for expected in ("invalid_item", "missing_id", "duplicate_id", "invalid_messages", "invalid_message_item"):
         require(expected in codes, f"reject code {expected} missing from {codes}")
-    require(body["counts"]["conversations"]["rejected"] == 5,
+    # 重复实体 ID：每一份副本都必须自己进 rejected，先到者不得静默胜出
+    conv_dups = [d for d in body["rejected_details"]
+                 if d["type"] == "conversation" and d["code"] == "duplicate_id"]
+    proj_dups = [d for d in body["rejected_details"]
+                 if d["type"] == "project" and d["code"] == "duplicate_id"]
+    require(len(conv_dups) == 2, f"both duplicate conversation copies must be rejected, got {len(conv_dups)}")
+    require(len(proj_dups) == 2, f"both duplicate project copies must be rejected, got {len(proj_dups)}")
+    require(body["counts"]["conversations"]["rejected"] == 6,
             f"conversation rejected count wrong: {body['counts']['conversations']}")
-    require(body["counts"]["projects"]["rejected"] == 2,
+    require(body["counts"]["projects"]["rejected"] == 4,
             f"project rejected count wrong: {body['counts']['projects']}")
     require(body["counts"]["conversations"]["success"] == 1, "the one valid conversation did not import")
-    require(await _pool_fetchval("SELECT title FROM chat_conversations WHERE id = $1", dup) == "first",
-            "duplicate id overwrote the first accepted conversation")
+    require(body["counts"]["projects"]["success"] == 1, "the one valid project did not import")
+    require(body["imported_conversation_ids"] == [fine_conv],
+            f"conversation success IDs wrong: {body['imported_conversation_ids']}")
+    require(body["imported_project_ids"] == [fine_proj],
+            f"project success IDs wrong: {body['imported_project_ids']}")
+    require(not await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_conversations WHERE id = $1)", dup_conv),
+            "a duplicated conversation id reached the database")
+    require(not await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_projects WHERE id = $1)", dup_proj),
+            "a duplicated project id reached the database")
     require(not await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_conversations WHERE id = '')"),
             "an id-less conversation was silently written with an empty id")
-    require(body["counts"]["conversations"]["failed"] == 0, "rejects must not be counted as failures")
-    passed("T-W2-02-14 per-entity rejects are coded, counted, and never written")
+    require(body["counts"]["conversations"]["failed"] == 0 and body["counts"]["projects"]["failed"] == 0,
+            "rejects must not be counted as failures")
+    passed("T-W2-02-14 duplicate entity IDs reject every copy and never reach the database")
 
     # ---- message semantics: absent / empty / shorter array ------------------
     await _truncate("chat_messages", "chat_conversations", "chat_projects")
@@ -1989,6 +2018,134 @@ async def test_w2_02(client: httpx.AsyncClient) -> None:
         require("role" not in flat.lower(),
                 f"chat_messages delete branches on role: {flat}")
     passed("T-W2-02-17 chat_messages deletes stay deterministic, never role/order inferred")
+
+    # ---- per-column landing against an independent expectation table -------
+    # Channel-vs-channel comparison (T-W2-02-6) cannot catch a shift that both
+    # channels share, because they assemble through the same function.  These
+    # expectations are written by hand here and never derived from production code.
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    col_conv, col_msg = f"{prefix}col-c", f"{prefix}col-m"
+    await client.post("/sync/conversations", json={"id": col_conv, "title": "columns"})
+    response = await client.put(f"/sync/conversations/{col_conv}/messages/{col_msg}", json={
+        "role": "assistant", "content": "col-content", "time": "2026-03-04T05:06:07Z",
+        "model": "col-model", "error": True, "thinking": "col-thinking",
+        "summary": "col-summary", "versionIndex": 7, "sortOrder": 41,
+        "tokenInfo": {"col": "token_info"}, "statusEvents": [{"col": "status_events"}],
+        "toolEvents": [{"col": "tool_events"}], "memoryResult": {"col": "memory_result"},
+        "memoryEvent": {"col": "memory_event"}, "handoffInfo": {"col": "handoff_info"},
+        "webSearchResults": [{"col": "web_search_results"}], "versions": [{"col": "versions"}],
+        "images": [{"col": "images"}], "attachments": [{"col": "attachments"}],
+        "usage": {"col": "usage"}, "dreamEvent": {"col": "dream_event"}, "turnKey": "col-turn-key",
+    })
+    require(response.status_code == 200, f"per-column upsert failed: {response.status_code} {response.text}")
+    row = await _pool_fetchrow(
+        f"SELECT {', '.join(_MESSAGE_CONTENT_COLUMNS)}, sort_order FROM chat_messages WHERE id = $1",
+        col_msg,
+    )
+    for col, want in {
+        "role": "assistant", "content": "col-content", "model": "col-model",
+        "streaming": False, "error": True, "thinking": "col-thinking",
+        "version_index": 7, "summary": "col-summary", "turn_key": "col-turn-key",
+        "sort_order": 41,
+    }.items():
+        require(row[col] == want, f"column {col} landed as {row[col]!r}, expected {want!r}")
+    for col in ("token_info", "status_events", "tool_events", "memory_result", "memory_event",
+                "handoff_info", "web_search_results", "versions", "images", "attachments",
+                "usage", "dream_event"):
+        want = [{"col": col}] if col in {
+            "status_events", "tool_events", "web_search_results", "versions", "images", "attachments"
+        } else {"col": col}
+        require(json.loads(row[col]) == want, f"column {col} landed as {row[col]!r}, expected {want!r}")
+    require((row["time"].year, row["time"].month, row["time"].day) == (2026, 3, 4),
+            f"time column landed as {row['time']!r}")
+
+    # Update the two new fields while omitting sortOrder: they must change, it must survive.
+    response = await client.put(f"/sync/conversations/{col_conv}/messages/{col_msg}", json={
+        "role": "assistant", "content": "col-content-2",
+        "dreamEvent": {"col": "dream_event_2"}, "turnKey": "col-turn-key-2",
+    })
+    require(response.status_code == 200, "second per-column upsert failed")
+    row = await _pool_fetchrow(
+        "SELECT dream_event, turn_key, sort_order, content FROM chat_messages WHERE id = $1", col_msg
+    )
+    require(json.loads(row["dream_event"]) == {"col": "dream_event_2"}, "dream_event did not update")
+    require(row["turn_key"] == "col-turn-key-2", "turn_key did not update")
+    require(row["content"] == "col-content-2", "content did not update")
+    require(row["sort_order"] == 41,
+            f"sort_order must survive an update that omits sortOrder, got {row['sort_order']!r}")
+    passed("T-W2-02-18 every content column lands on its own independently expected value")
+
+    # ---- duplicate explicit message IDs are input errors, not write failures ----
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    dupmsg_conv, idless_conv = f"{prefix}dupmsg-c", f"{prefix}idless-c"
+    response = await client.post("/sync/import", json={
+        "conversations": [
+            {"id": dupmsg_conv, "title": "dup messages", "messages": [
+                {"id": f"{prefix}dm1", "role": "user", "content": "a"},
+                {"id": f"{prefix}dm1", "role": "assistant", "content": "b"},
+            ]},
+            {"id": idless_conv, "title": "id-less messages", "messages": [
+                {"role": "user", "content": "no explicit id"},
+                {"role": "assistant", "content": "also no explicit id"},
+            ]},
+        ],
+        "projects": [],
+    })
+    require(response.status_code == 200, "duplicate message id must not fail the whole batch")
+    body = response.json()
+    dup_msg_rejects = [d for d in body["rejected_details"] if d["code"] == "duplicate_message_id"]
+    require(len(dup_msg_rejects) == 1 and dup_msg_rejects[0]["id"] == dupmsg_conv,
+            f"duplicate_message_id reject missing: {body['rejected_details']}")
+    require(body["counts"]["conversations"]["rejected"] == 1, "duplicate message id was not counted as rejected")
+    require(body["counts"]["conversations"]["failed"] == 0,
+            "an input-level duplicate message id must not be counted as a write failure")
+    require(not await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_conversations WHERE id = $1)", dupmsg_conv),
+            "rejected conversation metadata reached the database")
+    require(not await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_messages WHERE conversation_id = $1)", dupmsg_conv),
+            "rejected conversation messages reached the database")
+    # Messages without an explicit id keep synthesizing distinct ids and must still commit.
+    require(await _pool_fetchval("SELECT COUNT(*) FROM chat_messages WHERE conversation_id = $1", idless_conv) == 2,
+            "id-less messages must not be treated as duplicates")
+    require(body["counts"]["conversations"]["success"] == 1, "healthy sibling conversation did not commit")
+    passed("T-W2-02-19 duplicate explicit message IDs reject the conversation before any write")
+
+    # ---- whole-request crash path leaks nothing --------------------------------
+    crash_sentinel = f"W2_02_CRASH_{uuid.uuid4().hex}"
+
+    async def _crashing_import(*args, **kwargs):
+        raise RuntimeError(crash_sentinel)
+
+    out_capture, err_capture = io.StringIO(), io.StringIO()
+    with patch.object(app_module, "sync_import_all", _crashing_import):
+        with redirect_stdout(out_capture), redirect_stderr(err_capture):
+            response = await client.post("/sync/import", json={"conversations": [], "projects": []})
+    require(response.status_code == 500, f"top-level crash must return 500, got {response.status_code}")
+    require(crash_sentinel not in response.text, "top-level exception text leaked into the HTTP response")
+    require(response.json() == {"error": "导入失败"},
+            f"top-level 500 must use the fixed safe message, got {response.text}")
+    require(crash_sentinel not in out_capture.getvalue(), "top-level exception text leaked into stdout")
+    require(crash_sentinel not in err_capture.getvalue(), "top-level exception text leaked into stderr")
+    passed("T-W2-02-20 whole-request crash returns a fixed safe message and leaks nothing")
+
+    # ---- cleaned ids must equal the actual primary keys ------------------------
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    padded_proj, padded_conv = f"{prefix}pad-p", f"{prefix}pad-c"
+    response = await client.post("/sync/import", json={
+        "conversations": [{"id": f"  {padded_conv}  ", "title": "padded", "messages": []}],
+        "projects": [{"id": f"  {padded_proj}  ", "name": "padded"}],
+    })
+    require(response.status_code == 200, "whitespace-padded ids failed to import")
+    body = response.json()
+    require(body["imported_project_ids"] == [padded_proj],
+            f"project receipt must report the cleaned id: {body['imported_project_ids']}")
+    require(body["imported_conversation_ids"] == [padded_conv],
+            f"conversation receipt must report the cleaned id: {body['imported_conversation_ids']}")
+    for table, cleaned in (("chat_projects", padded_proj), ("chat_conversations", padded_conv)):
+        require(await _pool_fetchval(f"SELECT EXISTS(SELECT 1 FROM {table} WHERE id = $1)", cleaned),
+                f"{table}: the cleaned id is not the actual primary key")
+        require(not await _pool_fetchval(f"SELECT EXISTS(SELECT 1 FROM {table} WHERE id = $1)", f"  {cleaned}  "),
+                f"{table}: the raw padded id reached the database as a separate primary key")
+    passed("T-W2-02-21 receipt ids and database primary keys agree after whitespace cleanup")
 
 
 async def run_suite(test_dsn: str) -> None:

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -2147,6 +2147,60 @@ async def test_w2_02(client: httpx.AsyncClient) -> None:
                 f"{table}: the raw padded id reached the database as a separate primary key")
     passed("T-W2-02-21 receipt ids and database primary keys agree after whitespace cleanup")
 
+    # ---- observability events carry codes, never entity IDs -------------------
+    # Scope: ordinary logs only.  The HTTP receipt deliberately keeps entity IDs so
+    # callers can reconcile (see T-W2-02-12), so nothing here asserts on the response.
+    # T-W2-02-16 guards database exception text and T-W2-02-20 guards whole-request
+    # crash text; this guard is about the IDs themselves and does not replace either.
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    reject_id = f"W2_02_REJECT_ID_{uuid.uuid4().hex}"
+    failure_id = f"W2_02_FAILURE_ID_{uuid.uuid4().hex}"
+    # The injected exception text is a fixed safe sentinel: never put the entity ID
+    # into the database error itself, or a leak could not be attributed to logging.
+    trigger_text = "W2_02_OBSERVABILITY_TRIGGER_FAILURE"
+
+    reject_out, reject_err = io.StringIO(), io.StringIO()
+    with redirect_stdout(reject_out), redirect_stderr(reject_err):
+        response = await client.post("/sync/import", json={
+            "conversations": [{"id": reject_id, "title": "rejected", "messages": "not-an-array"}],
+            "projects": [],
+        })
+    require(response.status_code == 200, "reject-path import must stay 200")
+    reject_logs = reject_out.getvalue() + reject_err.getvalue()
+
+    await _install_fail_trigger("chat_messages", "w202_obs", "conversation_id", failure_id, trigger_text)
+    try:
+        failure_out, failure_err = io.StringIO(), io.StringIO()
+        with redirect_stdout(failure_out), redirect_stderr(failure_err):
+            response = await client.post("/sync/import", json={
+                "conversations": [{"id": failure_id, "title": "doomed", "messages": [
+                    {"id": f"{prefix}obs-m", "role": "user", "content": "x"},
+                ]}],
+                "projects": [],
+            })
+        require(response.status_code == 200, "failure-path import must stay 200")
+        failure_logs = failure_out.getvalue() + failure_err.getvalue()
+    finally:
+        await _drop_fail_trigger("chat_messages", "w202_obs")
+
+    require(reject_id not in reject_logs, "reject observability leaked the entity ID into ordinary logs")
+    require(failure_id not in failure_logs, "failure observability leaked the entity ID into ordinary logs")
+    reject_events = [line.strip() for line in reject_logs.splitlines()
+                     if line.startswith("event=sync_import_reject ")]
+    failure_events = [line.strip() for line in failure_logs.splitlines()
+                      if line.startswith("event=sync_import_failure ")]
+    require(reject_events, f"no sync_import_reject event was emitted: {reject_logs!r}")
+    require(failure_events, f"no sync_import_failure event was emitted: {failure_logs!r}")
+    for event in reject_events + failure_events:
+        for field in ("entity=", "code=", "increment="):
+            require(field in event, f"observability event lost the controlled field {field}: {event!r}")
+    # The rejected entity must also stay out of the database entirely.
+    require(not await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_conversations WHERE id = $1)", reject_id),
+            "rejected conversation reached the database")
+    require(not await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_conversations WHERE id = $1)", failure_id),
+            "failed conversation left a half state")
+    passed("T-W2-02-22 reject and failure observability keep codes and drop entity IDs")
+
 
 async def run_suite(test_dsn: str) -> None:
     global database, config, app_module, memory_extractor

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -1507,6 +1507,490 @@ async def test_w2_01(client: httpx.AsyncClient) -> None:
     require(malformed.status_code == 400, "new JSON-object endpoint accepted an array body")
 
 
+# ---------------------------------------------------------------------------
+# W2-02 | G1.1 message identity fields and atomic import
+# ---------------------------------------------------------------------------
+
+_MESSAGE_CONTENT_COLUMNS = (
+    "role", "content", "time", "model", "streaming", "error",
+    "token_info", "thinking", "status_events", "tool_events",
+    "memory_result", "memory_event", "handoff_info", "web_search_results",
+    "versions", "version_index", "images", "attachments", "usage", "summary",
+    "dream_event", "turn_key",
+)
+
+
+async def _install_fail_trigger(table: str, name: str, column: str, match: str, message: str) -> None:
+    """Raise a server-side exception for one specific row, to prove transaction edges."""
+    await _pool_execute(
+        f"""
+        CREATE OR REPLACE FUNCTION {name}() RETURNS trigger AS $fn$
+        BEGIN
+            IF NEW.{column} = '{match}' THEN RAISE EXCEPTION '{message}'; END IF;
+            RETURN NEW;
+        END; $fn$ LANGUAGE plpgsql
+        """
+    )
+    await _pool_execute(f"DROP TRIGGER IF EXISTS {name}_trg ON {table}")
+    await _pool_execute(
+        f"CREATE TRIGGER {name}_trg BEFORE INSERT OR UPDATE ON {table} "
+        f"FOR EACH ROW EXECUTE FUNCTION {name}()"
+    )
+
+
+async def _drop_fail_trigger(table: str, name: str) -> None:
+    await _pool_execute(f"DROP TRIGGER IF EXISTS {name}_trg ON {table}")
+    await _pool_execute(f"DROP FUNCTION IF EXISTS {name}()")
+
+
+async def test_w2_02(client: httpx.AsyncClient) -> None:
+    """W2-02 G1.1 message identity fields, atomic import, and receipt guards."""
+    prefix = "w202-"
+
+    # ---- schema: additive, nullable, no default, no index -------------------
+    schema_rows = {
+        row["column_name"]: row
+        for row in await _pool_fetch(
+            """
+            SELECT column_name, data_type, is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_name = 'chat_messages' AND column_name = ANY($1::text[])
+            """,
+            ["dream_event", "turn_key"],
+        )
+    }
+    missing_cols = sorted({"dream_event", "turn_key"} - set(schema_rows))
+    require(not missing_cols, f"W2-02 chat_messages columns missing: {missing_cols}")
+    require(schema_rows["dream_event"]["data_type"] == "jsonb", "dream_event must be jsonb")
+    require(schema_rows["turn_key"]["data_type"] == "text", "turn_key must be text")
+    for col in ("dream_event", "turn_key"):
+        require(schema_rows[col]["is_nullable"] == "YES", f"{col} must be nullable")
+        require(schema_rows[col]["column_default"] is None, f"{col} must have no default")
+    indexed = await _pool_fetchval(
+        """
+        SELECT COUNT(*) FROM pg_indexes
+        WHERE tablename = 'chat_messages'
+          AND (indexdef LIKE '%dream_event%' OR indexdef LIKE '%turn_key%')
+        """
+    )
+    require(indexed == 0, "W2-02 columns must not be indexed in this ticket")
+    passed("T-W2-02-1 dream_event/turn_key are nullable, default-free, unindexed")
+
+    # init_tables() already ran twice in run_suite; re-running here proves the new
+    # migration block is still idempotent after the columns exist.
+    await database.init_tables()
+    recheck = await _pool_fetchval(
+        """
+        SELECT COUNT(*) FROM information_schema.columns
+        WHERE table_name = 'chat_messages' AND column_name = ANY($1::text[])
+        """,
+        ["dream_event", "turn_key"],
+    )
+    require(recheck == 2, "repeat init_tables() disturbed the W2-02 columns")
+    passed("T-W2-02-2 repeat init_tables() is idempotent for the new columns")
+
+    # ---- legacy database upgrade path --------------------------------------
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    legacy_conv, legacy_msg = f"{prefix}old-conv", f"{prefix}old-msg"
+    await _pool_execute("ALTER TABLE chat_messages DROP COLUMN IF EXISTS dream_event")
+    await _pool_execute("ALTER TABLE chat_messages DROP COLUMN IF EXISTS turn_key")
+    await _pool_execute(
+        "INSERT INTO chat_conversations (id, title) VALUES ($1, $2)", legacy_conv, "legacy"
+    )
+    await _pool_execute(
+        "INSERT INTO chat_messages (id, conversation_id, role, content) VALUES ($1, $2, $3, $4)",
+        legacy_msg, legacy_conv, "user", "legacy-body",
+    )
+    await database.init_tables()
+    upgraded = await _pool_fetchrow(
+        "SELECT content, dream_event, turn_key FROM chat_messages WHERE id = $1", legacy_msg
+    )
+    require(upgraded is not None, "legacy row vanished during migration")
+    require(upgraded["content"] == "legacy-body", "migration damaged existing message content")
+    require(upgraded["dream_event"] is None and upgraded["turn_key"] is None,
+            "existing rows must backfill to NULL, never to a synthesized value")
+    passed("T-W2-02-3 old databases upgrade in place with NULL backfill")
+
+    # ---- field assembly: both channels, both key styles ---------------------
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    imp_conv, imp_msg_camel, imp_msg_snake = f"{prefix}imp-c", f"{prefix}imp-m1", f"{prefix}imp-m2"
+    response = await client.post(
+        "/sync/import",
+        json={
+            "conversations": [{
+                "id": imp_conv, "title": "import",
+                "messages": [
+                    {"id": imp_msg_camel, "role": "user", "content": "a",
+                     "dreamEvent": {"stage": "camel"}, "turnKey": "tk-camel"},
+                    {"id": imp_msg_snake, "role": "assistant", "content": "b",
+                     "dream_event": {"stage": "snake"}, "turn_key": "tk-snake"},
+                ],
+            }],
+            "projects": [],
+        },
+    )
+    require(response.status_code == 200, f"import failed: {response.status_code} {response.text}")
+    camel_row = await _pool_fetchrow(
+        "SELECT dream_event, turn_key FROM chat_messages WHERE id = $1", imp_msg_camel
+    )
+    snake_row = await _pool_fetchrow(
+        "SELECT dream_event, turn_key FROM chat_messages WHERE id = $1", imp_msg_snake
+    )
+    require(json.loads(camel_row["dream_event"])["stage"] == "camel" and camel_row["turn_key"] == "tk-camel",
+            "import dropped camelCase dreamEvent/turnKey")
+    require(json.loads(snake_row["dream_event"])["stage"] == "snake" and snake_row["turn_key"] == "tk-snake",
+            "import dropped snake_case dream_event/turn_key")
+    passed("T-W2-02-4 import writes the new fields in both key styles")
+
+    gran_conv, gran_msg = f"{prefix}gran-c", f"{prefix}gran-m"
+    await client.post("/sync/conversations", json={"id": gran_conv, "title": "granular"})
+    response = await client.put(
+        f"/sync/conversations/{gran_conv}/messages/{gran_msg}",
+        json={"role": "user", "content": "a", "dreamEvent": {"stage": "camel"}, "turnKey": "tk-camel"},
+    )
+    require(response.status_code == 200, "granular upsert with new fields failed")
+    gran_row = await _pool_fetchrow(
+        "SELECT dream_event, turn_key FROM chat_messages WHERE id = $1", gran_msg
+    )
+    require(json.loads(gran_row["dream_event"])["stage"] == "camel" and gran_row["turn_key"] == "tk-camel",
+            "granular upsert dropped the new fields")
+    passed("T-W2-02-5 granular upsert writes the new fields")
+
+    # Same payload through both channels must land byte-identical on every content column.
+    both_conv, both_msg = f"{prefix}both-c", f"{prefix}both-m"
+    shared_payload = {
+        "role": "assistant", "content": "shared-body", "model": "m-1",
+        "thinking": "t", "summary": "s", "versionIndex": 3,
+        "tokenInfo": {"in": 1}, "statusEvents": [{"e": 1}], "toolEvents": [{"t": 1}],
+        "memoryResult": {"m": 1}, "memoryEvent": {"me": 1}, "handoffInfo": {"h": 1},
+        "webSearchResults": [{"w": 1}], "versions": [{"v": 1}], "images": [{"i": 1}],
+        "attachments": [{"a": 1}], "usage": {"u": 1},
+        "dreamEvent": {"d": 1}, "turnKey": "tk-shared", "error": True,
+        "time": "2026-05-05T05:05:05Z",
+    }
+    await client.post("/sync/import", json={
+        "conversations": [{"id": both_conv, "title": "both",
+                           "messages": [dict(shared_payload, id=both_msg)]}],
+        "projects": [],
+    })
+    import_cols = await _pool_fetchrow(
+        f"SELECT {', '.join(_MESSAGE_CONTENT_COLUMNS)} FROM chat_messages WHERE id = $1", both_msg
+    )
+    await _pool_execute("DELETE FROM chat_messages WHERE id = $1", both_msg)
+    response = await client.put(
+        f"/sync/conversations/{both_conv}/messages/{both_msg}", json=dict(shared_payload)
+    )
+    require(response.status_code == 200, "granular upsert of the shared payload failed")
+    granular_cols = await _pool_fetchrow(
+        f"SELECT {', '.join(_MESSAGE_CONTENT_COLUMNS)} FROM chat_messages WHERE id = $1", both_msg
+    )
+    divergent = [c for c in _MESSAGE_CONTENT_COLUMNS if import_cols[c] != granular_cols[c]]
+    require(not divergent, f"import and granular channels diverged on: {divergent}")
+    passed("T-W2-02-6 both write channels assemble all 22 content columns identically")
+
+    # ---- old-client compatibility: missing fields fall back to NULL ---------
+    await client.put(
+        f"/sync/conversations/{gran_conv}/messages/{gran_msg}",
+        json={"role": "user", "content": "refilled", "dreamEvent": {"x": 1}, "turnKey": "tk-x"},
+    )
+    response = await client.put(
+        f"/sync/conversations/{gran_conv}/messages/{gran_msg}",
+        json={"role": "user", "content": "old-client"},
+    )
+    require(response.status_code == 200, "old-client payload without the new fields was rejected")
+    stale = await _pool_fetchrow(
+        "SELECT dream_event, turn_key, content FROM chat_messages WHERE id = $1", gran_msg
+    )
+    require(stale["content"] == "old-client", "full-snapshot semantics broke for content")
+    require(stale["dream_event"] is None and stale["turn_key"] is None,
+            "old payload must clear the new fields, not retain stale values")
+    old_import_conv, old_import_msg = f"{prefix}oldimp-c", f"{prefix}oldimp-m"
+    await client.post("/sync/import", json={
+        "conversations": [{"id": old_import_conv, "title": "old",
+                           "messages": [{"id": old_import_msg, "role": "user", "content": "x"}]}],
+        "projects": [],
+    })
+    old_row = await _pool_fetchrow(
+        "SELECT dream_event, turn_key FROM chat_messages WHERE id = $1", old_import_msg
+    )
+    require(old_row["dream_event"] is None and old_row["turn_key"] is None,
+            "old import payload must write NULL for the new fields")
+    passed("T-W2-02-7 payloads lacking the new fields write NULL on both channels")
+
+    # ---- import atomicity: no shell conversations ---------------------------
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    fail_conv, ok_conv = f"{prefix}fail-c", f"{prefix}ok-c"
+    await _install_fail_trigger(
+        "chat_messages", "w202_fail_msg", "conversation_id", fail_conv,
+        "W2-02 injected message failure",
+    )
+    try:
+        response = await client.post("/sync/import", json={
+            "conversations": [
+                {"id": fail_conv, "title": "doomed",
+                 "messages": [{"id": f"{prefix}fail-m", "role": "user", "content": "x"}]},
+                {"id": ok_conv, "title": "healthy",
+                 "messages": [{"id": f"{prefix}ok-m", "role": "user", "content": "y"}]},
+            ],
+            "projects": [],
+        })
+        require(response.status_code == 200, "import must stay 200 for per-entity failures")
+        body = response.json()
+        require(
+            not await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_conversations WHERE id = $1)", fail_conv),
+            "metadata survived a failed message write: half-imported shell conversation",
+        )
+        require(body["counts"]["conversations"]["failed"] == 1, "failed conversation was not counted as failed")
+        require(fail_conv not in body["imported_conversation_ids"], "failed conversation entered the success IDs")
+        require(
+            await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_messages WHERE conversation_id = $1)", ok_conv),
+            "a sibling failure blocked a healthy conversation",
+        )
+        require(ok_conv in body["imported_conversation_ids"], "healthy conversation missing from success IDs")
+        passed("T-W2-02-8 message failure rolls back its conversation and spares siblings")
+    finally:
+        await _drop_fail_trigger("chat_messages", "w202_fail_msg")
+
+    # Update path: metadata must not be overwritten when the message write fails.
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    upd_conv, upd_msg = f"{prefix}upd-c", f"{prefix}upd-m"
+    await client.post("/sync/import", json={
+        "conversations": [{"id": upd_conv, "title": "original-title", "model": "original-model",
+                           "messages": [{"id": upd_msg, "role": "user", "content": "original-body"}]}],
+        "projects": [],
+    })
+    await _install_fail_trigger(
+        "chat_messages", "w202_fail_upd", "conversation_id", upd_conv,
+        "W2-02 injected update failure",
+    )
+    try:
+        await client.post("/sync/import", json={
+            "conversations": [{"id": upd_conv, "title": "NEW-title", "model": "NEW-model",
+                               "messages": [{"id": f"{prefix}upd-m2", "role": "user", "content": "NEW-body"}]}],
+            "projects": [],
+        })
+        meta = await _pool_fetchrow("SELECT title, model FROM chat_conversations WHERE id = $1", upd_conv)
+        require(meta["title"] == "original-title" and meta["model"] == "original-model",
+                "conversation metadata was overwritten while its messages rolled back")
+        body_row = await _pool_fetchrow("SELECT content FROM chat_messages WHERE id = $1", upd_msg)
+        require(body_row is not None and body_row["content"] == "original-body",
+                "original messages were lost to a failed update")
+        passed("T-W2-02-9 failed update leaves metadata and messages on the same old version")
+    finally:
+        await _drop_fail_trigger("chat_messages", "w202_fail_upd")
+
+    # ---- per-entity isolation: project / metadata / message failures --------
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    bad_proj, good_proj = f"{prefix}bad-p", f"{prefix}good-p"
+    await _install_fail_trigger("chat_projects", "w202_fail_proj", "id", bad_proj,
+                                "W2-02 injected project failure")
+    try:
+        response = await client.post("/sync/import", json={
+            "conversations": [{"id": f"{prefix}iso-c", "title": "iso", "messages": []}],
+            "projects": [{"id": bad_proj, "name": "doomed"}, {"id": good_proj, "name": "healthy"}],
+        })
+        body = response.json()
+        require(not await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_projects WHERE id = $1)", bad_proj),
+                "failed project left a half state")
+        require(await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_projects WHERE id = $1)", good_proj),
+                "a failed project blocked a healthy sibling project")
+        require(await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_conversations WHERE id = $1)", f"{prefix}iso-c"),
+                "a failed project blocked conversation import")
+        require(body["counts"]["projects"] == {"success": 1, "rejected": 0, "failed": 1},
+                f"project counts wrong: {body['counts']['projects']}")
+        require(body["imported_project_ids"] == [good_proj], "project success IDs include a failed entity")
+        passed("T-W2-02-10 project write failure is isolated to that project")
+    finally:
+        await _drop_fail_trigger("chat_projects", "w202_fail_proj")
+
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    meta_fail_conv = f"{prefix}metafail-c"
+    await _install_fail_trigger("chat_conversations", "w202_fail_meta", "id", meta_fail_conv,
+                                "W2-02 injected metadata failure")
+    try:
+        response = await client.post("/sync/import", json={
+            "conversations": [
+                {"id": meta_fail_conv, "title": "doomed",
+                 "messages": [{"id": f"{prefix}metafail-m", "role": "user", "content": "x"}]},
+                {"id": f"{prefix}metaok-c", "title": "healthy", "messages": []},
+            ],
+            "projects": [{"id": f"{prefix}metaok-p", "name": "healthy"}],
+        })
+        body = response.json()
+        require(not await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_conversations WHERE id = $1)", meta_fail_conv),
+                "failed metadata write left a conversation row")
+        require(not await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_messages WHERE conversation_id = $1)", meta_fail_conv),
+                "messages survived a failed metadata write")
+        require(await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_conversations WHERE id = $1)", f"{prefix}metaok-c"),
+                "a failed conversation blocked a healthy sibling")
+        require(await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_projects WHERE id = $1)", f"{prefix}metaok-p"),
+                "a failed conversation blocked project import")
+        require(body["counts"]["conversations"]["failed"] == 1, "metadata failure was not counted")
+        passed("T-W2-02-11 metadata write failure is isolated and leaves no messages")
+    finally:
+        await _drop_fail_trigger("chat_conversations", "w202_fail_meta")
+
+    # ---- structured receipt and reconciliation ------------------------------
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    response = await client.post("/sync/import", json={
+        "conversations": [
+            {"id": f"{prefix}r1", "title": "r1", "messages": [
+                {"id": f"{prefix}r1m1", "role": "user", "content": "a"},
+                {"id": f"{prefix}r1m2", "role": "assistant", "content": "b"},
+            ]},
+            {"id": f"{prefix}r2", "title": "r2", "messages": []},
+            {"title": "no id at all", "messages": []},
+        ],
+        "projects": [{"id": f"{prefix}rp1", "name": "p1"}],
+    })
+    require(response.status_code == 200, "receipt import failed")
+    body = response.json()
+    for legacy_key in ("conversations", "messages", "projects", "errors",
+                       "imported_conversation_ids", "imported_project_ids", "error_details"):
+        require(legacy_key in body, f"receipt dropped the legacy key {legacy_key}")
+    require(body["conversations"] == body["counts"]["conversations"]["success"],
+            "legacy conversation count != counts.conversations.success")
+    require(body["projects"] == body["counts"]["projects"]["success"],
+            "legacy project count != counts.projects.success")
+    require(body["messages"] == body["counts"]["messages"]["success"],
+            "legacy message count != counts.messages.success")
+    require(body["conversations"] == len(body["imported_conversation_ids"]),
+            "conversation success count != committed ID array length")
+    require(body["projects"] == len(body["imported_project_ids"]),
+            "project success count != committed ID array length")
+    require(body["counts"]["conversations"]["rejected"] == 1, "id-less conversation was not rejected")
+    require(len(body["rejected_details"]) == 1 and body["rejected_details"][0]["code"] == "missing_id",
+            f"rejected_details wrong: {body.get('rejected_details')}")
+    require(body["messages"] == 2, "message success count did not match committed rows")
+    passed("T-W2-02-12 receipt keeps legacy keys and reconciles against committed rows")
+
+    # ---- input precheck: top-level 400, per-entity rejected -----------------
+    for bad_body in ([1, 2, 3], {"conversations": "nope"}, {"projects": {"a": 1}}):
+        response = await client.post("/sync/import", json=bad_body)
+        require(response.status_code == 400,
+                f"malformed top-level import body was not 400: {bad_body!r} -> {response.status_code}")
+    passed("T-W2-02-13 malformed top-level import bodies return 400")
+
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    dup = f"{prefix}dup-c"
+    response = await client.post("/sync/import", json={
+        "conversations": [
+            "not-a-dict",
+            {"title": "missing id"},
+            {"id": dup, "title": "first", "messages": []},
+            {"id": dup, "title": "second", "messages": []},
+            {"id": f"{prefix}badmsgs", "title": "bad messages", "messages": "nope"},
+            {"id": f"{prefix}badmsgitem", "title": "bad message item", "messages": ["x"]},
+        ],
+        "projects": ["not-a-dict", {"name": "missing id"}],
+    })
+    require(response.status_code == 200, "per-entity rejects must not fail the whole batch")
+    body = response.json()
+    codes = [d["code"] for d in body["rejected_details"]]
+    for expected in ("invalid_item", "missing_id", "duplicate_id", "invalid_messages", "invalid_message_item"):
+        require(expected in codes, f"reject code {expected} missing from {codes}")
+    require(body["counts"]["conversations"]["rejected"] == 5,
+            f"conversation rejected count wrong: {body['counts']['conversations']}")
+    require(body["counts"]["projects"]["rejected"] == 2,
+            f"project rejected count wrong: {body['counts']['projects']}")
+    require(body["counts"]["conversations"]["success"] == 1, "the one valid conversation did not import")
+    require(await _pool_fetchval("SELECT title FROM chat_conversations WHERE id = $1", dup) == "first",
+            "duplicate id overwrote the first accepted conversation")
+    require(not await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM chat_conversations WHERE id = '')"),
+            "an id-less conversation was silently written with an empty id")
+    require(body["counts"]["conversations"]["failed"] == 0, "rejects must not be counted as failures")
+    passed("T-W2-02-14 per-entity rejects are coded, counted, and never written")
+
+    # ---- message semantics: absent / empty / shorter array ------------------
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    sem_conv = f"{prefix}sem-c"
+    await client.post("/sync/import", json={
+        "conversations": [{"id": sem_conv, "title": "v1", "messages": [
+            {"id": f"{prefix}sem-m1", "role": "user", "content": "1"},
+            {"id": f"{prefix}sem-m2", "role": "assistant", "content": "2"},
+            {"id": f"{prefix}sem-m3", "role": "user", "content": "3"},
+        ]}],
+        "projects": [],
+    })
+    require(await _pool_fetchval("SELECT COUNT(*) FROM chat_messages WHERE conversation_id = $1", sem_conv) == 3,
+            "seed import did not write three messages")
+
+    response = await client.post("/sync/import", json={
+        "conversations": [{"id": sem_conv, "title": "v2-metadata-only"}], "projects": [],
+    })
+    require(response.status_code == 200, "metadata-only import failed")
+    require(await _pool_fetchval("SELECT COUNT(*) FROM chat_messages WHERE conversation_id = $1", sem_conv) == 3,
+            "absent messages key must preserve existing messages")
+    require(await _pool_fetchval("SELECT title FROM chat_conversations WHERE id = $1", sem_conv) == "v2-metadata-only",
+            "metadata-only import did not update metadata")
+    require(response.json()["counts"]["messages"]["success"] == 0,
+            "metadata-only import must not claim message writes")
+
+    await client.post("/sync/import", json={
+        "conversations": [{"id": sem_conv, "title": "v3", "messages": [
+            {"id": f"{prefix}sem-m1", "role": "user", "content": "1-kept"},
+        ]}],
+        "projects": [],
+    })
+    remaining = await _pool_fetch(
+        "SELECT id FROM chat_messages WHERE conversation_id = $1 ORDER BY id", sem_conv
+    )
+    require([r["id"] for r in remaining] == [f"{prefix}sem-m1"],
+            "a shorter array must replace the set and delete the difference")
+
+    response = await client.post("/sync/import", json={
+        "conversations": [{"id": sem_conv, "title": "v4", "messages": []}], "projects": [],
+    })
+    require(response.status_code == 200, "explicit empty-array import failed")
+    require(await _pool_fetchval("SELECT COUNT(*) FROM chat_messages WHERE conversation_id = $1", sem_conv) == 0,
+            "explicit empty array must clear the conversation")
+    passed("T-W2-02-15 absent / empty / shorter message arrays have distinct semantics")
+
+    # ---- error safety: no sentinel leaks anywhere ---------------------------
+    await _truncate("chat_messages", "chat_conversations", "chat_projects")
+    sentinel = f"W2_02_SECRET_{uuid.uuid4().hex}"
+    leak_conv = f"{prefix}leak-c"
+    await _install_fail_trigger("chat_messages", "w202_leak", "conversation_id", leak_conv, sentinel)
+    try:
+        capture = io.StringIO()
+        with redirect_stdout(capture):
+            response = await client.post("/sync/import", json={
+                "conversations": [{"id": leak_conv, "title": "leaky",
+                                   "messages": [{"id": f"{prefix}leak-m", "role": "user", "content": "x"}]}],
+                "projects": [],
+            })
+        raw = response.text
+        body = response.json()
+        require(sentinel not in raw, "database error text leaked into the import HTTP response")
+        require(all(sentinel not in str(e) for e in body["errors"]), "sentinel leaked into errors[]")
+        require(all(sentinel not in str(d.get("error", "")) for d in body["error_details"]),
+                "sentinel leaked into error_details[].error")
+        require(sentinel not in capture.getvalue(), "sentinel leaked into structured logs")
+        require(body["error_details"] and body["error_details"][0].get("code"),
+                "error_details must carry a controlled code")
+        require(body["error_details"][0]["id"] == leak_conv,
+                "error_details must still name the entity for reconciliation")
+        passed("T-W2-02-16 database error text never reaches responses or logs")
+    finally:
+        await _drop_fail_trigger("chat_messages", "w202_leak")
+
+    # ---- frozen rule: no 'delete latest assistant message' inference --------
+    # Scope note: this guard covers the chat_messages sync channel only.  The
+    # conversations event-ledger helper delete_latest_assistant_message() is a
+    # known W2-07 debt and is deliberately out of this guard's reach.
+    source = (ROOT / "database.py").read_text(encoding="utf-8")
+    deletes = re.findall(r"DELETE FROM chat_messages[^\"']*", source)
+    require(deletes, "expected at least one chat_messages delete statement to audit")
+    for statement in deletes:
+        flat = " ".join(statement.split())
+        require("WHERE" in flat, f"unconditional chat_messages delete: {flat}")
+        require("ORDER BY" not in flat and "LIMIT" not in flat,
+                f"chat_messages delete infers rows by ordering: {flat}")
+        require("role" not in flat.lower(),
+                f"chat_messages delete branches on role: {flat}")
+    passed("T-W2-02-17 chat_messages deletes stay deterministic, never role/order inferred")
+
+
 async def run_suite(test_dsn: str) -> None:
     global database, config, app_module, memory_extractor
 
@@ -1547,6 +2031,7 @@ async def run_suite(test_dsn: str) -> None:
         await test_w1_08()
         await test_w1_01()
         await test_w2_01(client)
+        await test_w2_02(client)
 
 
 async def async_main() -> int:
@@ -1561,11 +2046,13 @@ async def async_main() -> int:
         w1_06_passed = [name for name in PASSED if name.startswith("T-W1-06-")]
         w1_08_passed = [name for name in PASSED if name.startswith("T-W1-08-")]
         w2_01_passed = [name for name in PASSED if name.startswith("T-W2-01-")]
+        w2_02_passed = [name for name in PASSED if name.startswith("T-W2-02-")]
         print(f"\nPASS: {len(legacy_passed)} permanent S1-S6 behavior guards")
         print(f"PASS: {len(w1_01_passed)} W1-01 isolation/permanent guards")
         print(f"PASS: {len(w1_06_passed)} W1-06 calendar-delete atomicity guards")
         print(f"PASS: {len(w1_08_passed)} W1-08 calendar-period guards")
         print(f"PASS: {len(w2_01_passed)} W2-01 granular-sync guards")
+        print(f"PASS: {len(w2_02_passed)} W2-02 message-identity/atomic-import guards")
         print(f"PASS: {len(PASSED)} total permanent behavior guards")
         print("Real database path: disposable PostgreSQL verified")
         print("Real model/API path: not called; embedding/model/HTTP boundaries were mocked")


### PR DESCRIPTION
## 范围

`chat_messages` 增加 `dream_event / turn_key`，`/sync/import` 改为每对话单事务并补齐结构化回执与输入预检。基线 `main@5d5da20`。

## 目标与实现

**schema** — 两列可空、无默认、不建索引；建表与启动期幂等迁移都覆盖，迁移沿用本表既有的 `information_schema` 风格。旧库就地补列，存量行经 `ADD COLUMN` 自动为 `NULL`（PG 11+ 不重写表），前一版本代码不感知也写不坏。注释写死同名不同义警告：本列只服务前端消息快照，日后若事件账本出现 `conversations.turn_key`，禁止联表推断轮次归属。

**字段装配** — `_message_content_values` 尾部追加两字段（camelCase 与 snake_case 双键名），三条通道继续共用它。两条 SQL 通道同步扩为 25 个占位符，`sort_order` 由 `$23` 移至 `$25`，两处 `COALESCE` 一并跟进。单消息 upsert 的 owner precheck、`ON CONFLICT ... WHERE` 归属防线与 `RETURNING` 判空原样保留，归属仍永不经 UPDATE 变更。

**共享事务原语（相对 Gateway 的有意改进）** — 抽出 `_upsert_conversation_tx` / `_replace_messages_tx` 两个事务内原语（不自开连接）。Gateway G1.1 为 import 通道另写了一份 SQL，与 legacy 通道各持一份；本 PR 让两条通道共用同一原语，**这段抽取超出 Gateway 参照实现**，目的是消除多份 SQL 与字段装配漂移——后续再加字段时只有一处要改。

**legacy 外部行为合同不变** — 路由不变、闸门不变、metadata 与 messages 仍是两段独立提交、旧客户端 payload 行为不变；改动只发生在内部实现。

**import 事务边界** — 每个 conversation 一个事务包住 metadata 与消息替换，任一步失败整体回滚，不再留下空壳对话，也不会出现新元数据配旧消息。项目维持逐项独立原子写。

**输入预检与回执** — 顶层非对象、`conversations`/`projects` 非数组一律 `400`。

预检为整批两遍：先定结构与 ID，再按频次统一裁决。冻结优先级 `invalid_item → missing_id → duplicate_id → messages 检查`。有效实体 ID 在同一数组出现多次时，**所有同 ID 副本一并拒绝**、该 ID 零写库、不进成功 ID 数组、不计 `failed`；同批其他合法实体照常成功。同一对话内**显式**消息 ID 重复归 `duplicate_message_id`，在写库前拒绝整条对话（metadata 与 messages 均零写入），缺 ID 的消息继续按下标合成而不计作重复。

数据库执行异常进 `failed`，码固定为 `write_failed`。消息语义三态：缺 `messages` 只更新 metadata 并保留旧消息；显式 `[]` 清空；非空数组完整替换并删除差集。回执保留既有兼容字段，新增 `counts` 三态与 `rejected_details`；旧三项成功计数分别等于 `counts.*.success`，成功 ID 数组只收已提交实体，且实体 ID 以清理后的值为准、与实际主键一致。

**错误安全与观测** — `error_details` 与 `rejected_details` 使用受控 `code` + 安全摘要；逐实体失败与整体崩溃两条路径都不回传数据库原始异常，顶层 500 固定为 `{"error": "导入失败"}`。观测事件只带 `entity / code / increment`，不带实体 ID；HTTP 回执则**按合同保留**实体 ID 供用户对账，两者要求不同。

## 已知边界（本轮不改生产代码）

- **消息 ID 判重会 trim**：`_explicit_message_ids` 对显式 ID 做 `.strip()` 后判重，因此 `"m1"` 与 `" m1 "` 会被保守地视为同一个 ID、拒绝整条对话。保守方向安全（宁可拒收也不写坏），但比写入期的实际主键判定更严。
- **整数 `id: 0` 在预检与写入期解释略有差异**：预检的 `_explicit_message_ids` 把 `0` 当作有效显式 ID 参与判重；写入期 `str(msg.get("id") or f"m-{conv_id}-{idx}")` 因 `0` 是 falsy 而走合成 ID 分支。实体级 ID 无此差异（`conv_meta["id"]` 已被预检结果覆盖）。
- **跨 conversation 的消息 ID 冲突不在预检范围**：仍由主键约束在写入期拦下，继续记为 `failed / write_failed`。预检只管同一对话内部。
- `dreamEvent: {}` 因 `or` 取值落成 `NULL` 属跨 Gateway/Kiwi 同型窄修，另票处理。

## 证据

| 项 | 值 |
|---|---|
| 基线 | `main@5d5da20e4c8ec1d1e4ff3fd3100c1da36db6f7a9` |
| tests-only 红证 head | `3739cddcf9e4d7790a000112fdabf3aa997feeac` |
| 首轮实现 head | `8d6ce01ab02bcbb77b3f5a5b8b41d62241b1b3ec` |
| 返工 head | `16ddd9a8f02486bbfffffca20697eef6bb5b116d` |
| 最终 head（守卫补位） | `06af20d7b5c97d4f201e58aba172588dd58c8db2` |
| 修复前 PG16 CI | Run [`31795703112`](https://github.com/LucieEveille/kiwi-mem/actions/runs/31795703112) — failure |
| 首轮 PG16 CI | Run [`31796168359`](https://github.com/LucieEveille/kiwi-mem/actions/runs/31796168359) — success |
| 返工 PG16 CI | Run [`31799062440`](https://github.com/LucieEveille/kiwi-mem/actions/runs/31799062440) — success |
| 最终 PG16 CI | Run [`31801298780`](https://github.com/LucieEveille/kiwi-mem/actions/runs/31801298780) |
| 守卫计数 | 既有 60 + W2-02 **22** = **82** 条永久真库守卫全绿 |

**修复前红证（`[PG16 真库]`）**：既有 60 条守卫全部 PASS 后，精确失败于
`AssertionError: W2-02 chat_messages columns missing: ['dream_event', 'turn_key']`。

**修复后**：`[PG16 真库]` CI 全绿；`[本地 PG16.13 真库]` 82 条守卫 + CI 清单 12 套既有回归全部通过；`[静态]` `compileall` 与 `git diff --check` 通过。`[真实供应商]` 未调用。`[生产部署]` 未核实。

## 守卫职责分工（不合并）

- `T-W2-02-16` — 逐实体失败路径的**数据库异常正文**不进响应与日志
- `T-W2-02-20` — 整体崩溃路径的**异常正文**不进响应、stdout、stderr，且返回固定安全文案
- `T-W2-02-22` — reject 与 failure 两类**观测事件不带实体 ID**，但仍保留 `entity / code / increment`；只约束普通日志，不约束 HTTP 回执

## 负向变异

三轮共十一把，均未提交，每把恢复后同套测试转绿。

**守卫补位轮**

| 刀 | 结果 |
|---|---|
| reject 事件附带 `id={entity_id}` | **精准红** `T-W2-02-22`：`reject observability leaked the entity ID into ordinary logs` |

**返工轮**

| 刀 | 结果 |
|---|---|
| 恢复「只拒绝后一个重复实体」 | **精准红** `T-W2-02-14`：`both duplicate conversation copies must be rejected, got 1` |
| 跳过重复消息 ID 预检 | **精准红** `T-W2-02-19`：`duplicate_message_id reject missing: []` |
| 恢复顶层 `str(e)` | **精准红** `T-W2-02-20`：`top-level exception text leaked into the HTTP response` |
| 恢复 `db_error` | **精准红** `T-W2-02-8`：`message-write failure code must be write_failed: ['db_error']` |
| 同类型字段错位（`model` ↔ `thinking`，均 TEXT） | **精准红** `T-W2-02-18`：`column model landed as 'col-thinking', expected 'col-model'`。同一轮里 `T-W2-02-6`（通道互比）**仍然全绿**——两条通道共用装配函数因而一起错位，互比发现不了，独立期望表才抓得住 |

**首轮**

| 刀 | 结果 |
|---|---|
| 去掉 conversation 外层事务 | **精准红** `T-W2-02-8`：`half-imported shell conversation` |
| `$25` 错写回 `$23` | **红，但归属既有防线** `T-W2-01-5`：JSONB 撞 INTEGER 列使单消息 upsert 直接失败，W2-01 归属守卫先撞上。该失效模式改由返工轮的同类型错位刀 + `T-W2-02-18` 覆盖 |
| 绕过缺 ID / 非法 messages 拒绝 | **精准红** `T-W2-02-12` |
| 恢复原始 `str(e)`（逐实体路径） | **精准红** `T-W2-02-16` |
| 细粒度通道 `ON CONFLICT` 丢掉两列 | **精准红** `T-W2-02-7` |

## 数据影响与回滚

加法式 schema：两列可空无默认，`ADD COLUMN` 不重写表，前一版本代码可容忍。回滚 revert 行为提交即可，新增列保留为惰性兼容，不需要也不应当删列。

## 非范围

W2-03 事件账本与暗写（`project_id / scope_known / usage / turn_id`）、W2-07 的 `delete_latest_assistant_message` 替换与 `turn_key` 归轮、memory extraction 消费者切换、日历/Dream/手动提取切源、思考强度与模型能力、管理面板、Eveille-Chat、ai-memory-gateway、CC Station、版本号与 Release 对齐、《kiwi 排查票据》其余 17 个根因。

**不碰 legacy PUT 的外部合同**：两条路由代码一字未改，闸门范围不变，`/sync/import` 继续不受闸门管辖（`T-W2-01-11` 防越界回归仍绿）。legacy 两段提交的半写问题登记为后续票据。

`T-W2-02-17` 的作用域明确限定在 `chat_messages` 同步通道；事件账本的 `delete_latest_assistant_message` 是已知 W2-07 债，刻意不在该守卫射程内。

推前已核 `main.py` 标题仍为 `Kiwi-Mem`（`main.py:299`）；全部实施为逐处打补丁，无整文件覆盖。

保持 Draft，未经露露授权不转 Ready、不合并。