### PR TITLE
W2-03：M1 schema、权威 scope 与暗写

### DIFF
--- a/admin-panel/js/config-schema.js
+++ b/admin-panel/js/config-schema.js
@@ -106,6 +106,10 @@ export const CONFIG_META = {
   ext_drawer_max_open:    { label:'外部抽屉同开上限', type:'int', def:'3', input:'int', desc:'单次对话最多同时展开几个外部工具抽屉。' },
   reminder_tools_enabled: { label:'提醒工具', type:'bool', def:'true', input:'bool', desc:'控制提醒系统的 4 个工具，关闭后传统模式与工具抽屉中均不可见。' },
 
+  // —— 兼容与回退（W2-03）——
+  memory_event_ledger_write_enabled: { label:'事件账本原子写入', type:'bool', def:'true', input:'bool', desc:'开启后一轮对话作为单个事务写入事件账本，带上项目、轮次与用量身份，任一步失败整体回滚。关闭则退回旧的两次独立写入（新字段留空）。出问题时关掉即可回退，不需要发版。' },
+  session_identity_v2_enabled: { label:'会话身份 v2', type:'bool', def:'false', input:'bool', desc:'前端没传对话 ID 时如何生成会话身份。关闭＝沿用「首条消息内容哈希」，同样的开场白会被并成同一段会话。开启＝改用随机 ID 并回传给前端，会话不再串线；但尚未采纳回传 ID 的第三方客户端会每轮换会话，工具抽屉状态与 OpenRouter 黏性路由会断。前端适配完成前保持关闭。' },
+
   // —— 联网搜索 ——
   search_engine:          { label:'搜索引擎', type:'text', def:'', input:'engine', desc:'联网搜索使用的引擎。' },
   search_api_key:         { label:'搜索 API Key', type:'text', def:'', input:'pass', desc:'所选搜索引擎的 API Key（local 类型引擎无需）。' },
@@ -205,6 +209,7 @@ export const CONFIG_PAGES = {
     groups: [
       { title:'对话行为', desc:'网关转发对话时的行为：标题生成与思考强度。', keys:['default_title_model','prompt_title_summary','reasoning_effort'] },
       { title:'性能', keys:['prompt_cache_enabled','prompt_cache_ttl'] },
+      { title:'兼容与回退', desc:'出问题时可以立刻关掉的新行为开关，改完即时生效、无需发版。', keys:['memory_event_ledger_write_enabled','session_identity_v2_enabled'] },
     ],
   },
 };

--- a/config.py
+++ b/config.py
@@ -119,6 +119,13 @@ CONFIG_SCHEMA = {
     #       外部 mcp_servers 仍走原路径并合并，对模型表现为一组完整工具
     "tool_drawer_enabled":   ("",                        "false","工具抽屉开关",      "bool"),
     "reminder_tools_enabled":("",                        "true", "提醒工具",          "bool"),
+    # W2-03：事件账本暗写闸门。默认开——开=一轮进单事务原子落账（带项目/轮次/用量身份），
+    #        关=退回旧的两次独立写入且新列全默认。两者互斥，绝不双写。
+    "memory_event_ledger_write_enabled": ("",            "true", "事件账本原子写入",  "bool"),
+    # W2-03：会话身份 v2。默认关——开=无 conversation_id 时用 auto-r- + 完整 uuid4，
+    #        并把身份回传给客户端；关=沿用旧的首条文本 md5 短 hash。
+    #        开启后未采纳回传的第三方客户端会每轮换 session，断 OpenRouter 黏性与抽屉状态。
+    "session_identity_v2_enabled": ("",                  "false","会话身份 v2",       "bool"),
 }
 
 

--- a/database.py
+++ b/database.py
@@ -1083,12 +1083,29 @@ def normalize_usage_for_storage(usage):
         return None
     if set(usage) == _NORMALIZED_USAGE_KEYS:
         return dict(usage)
+
+    cache_creation = usage.get("cache_creation_input_tokens") or 0
+    cache_read = usage.get("cache_read_input_tokens") or 0
+
+    prompt_tokens = usage.get("prompt_tokens")
+    if prompt_tokens is None:
+        # Anthropic 口径：input_tokens **不含**缓存部分，真实总输入还要把
+        # cache_creation_input_tokens 与 cache_read_input_tokens 加回来。
+        # 工具循环在 from_anthropic_response() 之前就归一化原始 usage，拿到的
+        # 正是这种形状；漏加会让开了 prompt cache 的多轮工具聊天持续少记。
+        prompt = (usage.get("input_tokens") or 0) + cache_creation + cache_read
+    else:
+        # OpenAI 口径：prompt_tokens 已经把 cached_tokens 算在内，不得重复累加。
+        prompt = prompt_tokens
+
     details = usage.get("prompt_tokens_details")
     cached = details.get("cached_tokens") if isinstance(details, dict) else None
     if cached is None:
-        cached = usage.get("cached_tokens") or usage.get("cache_read_input_tokens") or 0
+        # cached 只记「读命中」，不含 cache creation——后者是首次写入的成本。
+        cached = usage.get("cached_tokens") or cache_read or 0
+
     return {
-        "prompt": usage.get("prompt_tokens") or usage.get("input_tokens") or 0,
+        "prompt": prompt,
         "completion": usage.get("completion_tokens") or usage.get("output_tokens") or 0,
         "cached": cached or 0,
     }
@@ -1109,8 +1126,11 @@ async def _regen_turn_tx(conn, session_id, assistant_content, model,
     混合期（闸门开→关→开）关闸行与新轮并存时，OR 混选会让带合法 turn_id 的新轮
     误删后写入的 NULL 行。
     """
+    # 连身份一起取回：替换进来的 assistant 必须继承目标 user 的轮次与归属，
+    # 而不是用「本次请求」重新判定的那份——否则同一轮会被撕成两半。
     latest_user = await conn.fetchrow(
-        "SELECT id, turn_id FROM conversations WHERE session_id = $1 AND role = 'user' "
+        "SELECT id, turn_id, turn_key, scope_known, project_id FROM conversations "
+        "WHERE session_id = $1 AND role = 'user' "
         "ORDER BY created_at DESC, id DESC LIMIT 1",
         session_id,
     )
@@ -1163,9 +1183,16 @@ async def _regen_turn_tx(conn, session_id, assistant_content, model,
             session_id, user_id,
         )
 
+    # 身份四件套一律继承目标 user，不用本次请求重新判定的值：
+    #   · 旧客户端重生成不带 turn_key 时，用请求值会把 user 的 k1 配上 assistant 的 NULL；
+    #   · 会话在原轮之后被移进/移出项目，或 metadata 此时才同步完成，用当前判定会让
+    #     同一轮出现「问题在全局、回答在项目」，W2-06 按 scope 消费时这一轮会被撕开，
+    #     项目侧的回答甚至可能单边进入全局池。
+    # 当前 scope 判定只在没有目标 user 可继承的 orphan 分支里兜底。
     await conn.execute(
         _LEDGER_INSERT_SQL, session_id, "assistant", assistant_content, model,
-        project_id, scope_known, _to_json(normalize_usage_for_storage(usage)), latest_turn, turn_key,
+        latest_user["project_id"], latest_user["scope_known"],
+        _to_json(normalize_usage_for_storage(usage)), latest_turn, latest_user["turn_key"],
     )
     return {"ok": True, "path": "regen", "turn_id": latest_turn}
 

--- a/database.py
+++ b/database.py
@@ -551,6 +551,35 @@ async def init_tables():
                 await conn.execute(f"ALTER TABLE chat_messages ADD COLUMN {col_name} {col_def}")
                 print(f"✅ chat_messages 表已添加 {col_name} 列（W2-02 消息身份）")
 
+        # W2-03：事件账本 conversations 扩展 — 项目、轮次、用量三重身份。
+        # 三态语义（scope_known 取代空串哨兵，与 memories.project_id IS NULL=全局 对齐）：
+        #   scope_known=TRUE  + project_id NULL → 明确全局
+        #   scope_known=TRUE  + project_id 非空 → 项目对话（含项目已删的历史归属行；
+        #                        归属是历史事实，TRUE+非空永不进全局，安全等价且信息保留）
+        #   scope_known=FALSE + project_id NULL → 归属未知（存量 + 关闸期 + 不可证），
+        #                        不参与任何新循环，永不自动宣称全局
+        # 存量行由 DEFAULT FALSE 永久留白，无需也不得回填。
+        # turn_id = 该轮 user 事件自身 id，同轮 user 与 assistant 共享。
+        # turn_key 是客户端稳定轮次键：它与 chat_messages.turn_key **同名不同义**——
+        # 后者只服务前端消息快照，本列服务不可变事件账本，禁止跨表 JOIN 或互推。
+        await conn.execute("ALTER TABLE conversations ADD COLUMN IF NOT EXISTS project_id TEXT DEFAULT NULL")
+        await conn.execute("ALTER TABLE conversations ADD COLUMN IF NOT EXISTS scope_known BOOLEAN NOT NULL DEFAULT FALSE")
+        await conn.execute("ALTER TABLE conversations ADD COLUMN IF NOT EXISTS usage JSONB DEFAULT NULL")
+        await conn.execute("ALTER TABLE conversations ADD COLUMN IF NOT EXISTS turn_id BIGINT DEFAULT NULL")
+        await conn.execute("ALTER TABLE conversations ADD COLUMN IF NOT EXISTS turn_key TEXT DEFAULT NULL")
+
+        # W2-03：每会话提取游标 + 原子认领的载体。本票只建表、零读写，
+        # 接线留给 W2-07（游标、租约、失败重试与历史重生成）。
+        await conn.execute("""
+            CREATE TABLE IF NOT EXISTS memory_extraction_state (
+                session_id                TEXT PRIMARY KEY,
+                last_extracted_message_id BIGINT NOT NULL DEFAULT 0,
+                claimed_until             TIMESTAMPTZ DEFAULT NULL,
+                updated_at                TIMESTAMPTZ DEFAULT NOW()
+            );
+        """)
+        await conn.execute("ALTER TABLE memory_extraction_state ADD COLUMN IF NOT EXISTS claim_token TEXT")
+
         # v5.3：时间有效期窗口（MemPalace 启发）
         for col_name, col_def in [
             ("valid_from", "TIMESTAMPTZ DEFAULT NOW()"),
@@ -935,6 +964,12 @@ def calculate_heat(row, params: dict = None) -> float:
 # 对话记录操作
 # ============================================================
 
+# W2-03：全局事件的唯一判定式。TRUE+非空（项目对话，含项目已删的历史归属行）与
+# FALSE+NULL（归属未知）都不满足它，因此都进不了全局循环。消费者一律引用本常量，
+# 不得就地手写条件，避免各处漂移。
+CONVERSATIONS_GLOBAL_SCOPE = "scope_known = TRUE AND project_id IS NULL"
+
+
 async def save_message(session_id: str, role: str, content: str, model: str = ""):
     pool = await get_pool()
     async with pool.acquire() as conn:
@@ -953,7 +988,7 @@ async def delete_latest_assistant_message(session_id: str):
             WHERE id = (
                 SELECT id FROM conversations
                 WHERE session_id = $1 AND role = 'assistant'
-                ORDER BY created_at DESC
+                ORDER BY created_at DESC, id DESC
                 LIMIT 1
             )
             """,
@@ -965,7 +1000,8 @@ async def get_recent_messages(session_id: str, limit: int = 20):
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
-            "SELECT role, content, created_at FROM conversations WHERE session_id = $1 ORDER BY created_at DESC LIMIT $2",
+            "SELECT role, content, created_at FROM conversations WHERE session_id = $1 "
+            "ORDER BY created_at DESC, id DESC LIMIT $2",
             session_id, limit,
         )
         return list(reversed(rows))
@@ -976,10 +1012,225 @@ async def get_recent_conversation(limit: int = 20):
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch(
-            "SELECT role, content, created_at FROM conversations ORDER BY created_at DESC LIMIT $1",
+            "SELECT role, content, created_at FROM conversations "
+            "ORDER BY created_at DESC, id DESC LIMIT $1",
             limit,
         )
         return list(reversed(rows))
+
+
+async def _resolve_scope_tx(conn, session_id: str, *, client_gave_conv_id: bool,
+                            project_id_present: bool, payload_project_id):
+    """在事务内判定本轮事件的归属，返回 (scope_known, project_id, event_code|None)。
+
+    七行权威表（判定与写入共用同一事务快照）：
+      1. metadata 有且项目存在        → TRUE + metadata 值（payload 不一致仍以 metadata 为准）
+      2. metadata 有但项目已删        → TRUE + 原 project_id（历史归属是事实；TRUE+非空永不进全局）
+      3. metadata 有且 project_id 空  → TRUE + NULL（明确全局）
+      4. 服务端生成 session + 显式 null → TRUE + NULL（当轮唯一证据，采信）
+      5. 服务端生成 session + 有效项目 → TRUE + payload 值
+      6. 客户端给了 conversation_id 但 metadata 查无 → FALSE + NULL（无论 payload 写什么）
+      7. 其余（缺键 / 空串 / 项目不存在）→ FALSE + NULL
+    未经服务端验证的 payload 永不升格为权威：这正是行 6 与行 5 的分界。
+    """
+    metadata = await conn.fetchrow(
+        "SELECT project_id FROM chat_conversations WHERE id = $1", session_id
+    )
+    if metadata is not None:
+        meta_pid = metadata["project_id"]
+        if meta_pid:
+            project_alive = await conn.fetchval(
+                "SELECT EXISTS(SELECT 1 FROM chat_projects WHERE id = $1)", meta_pid
+            )
+            if not project_alive:
+                return True, meta_pid, "scope_project_missing"
+            if project_id_present and payload_project_id != meta_pid:
+                return True, meta_pid, "scope_mismatch"
+            return True, meta_pid, None
+        return True, None, None
+
+    if client_gave_conv_id:
+        # 同步缺口：会话身份来自客户端却查不到 metadata，无法证实归属
+        return False, None, "scope_unverified"
+
+    if project_id_present:
+        if payload_project_id is None:
+            return True, None, None
+        if payload_project_id:
+            payload_alive = await conn.fetchval(
+                "SELECT EXISTS(SELECT 1 FROM chat_projects WHERE id = $1)", payload_project_id
+            )
+            if payload_alive:
+                return True, payload_project_id, "scope_payload_trusted"
+        return False, None, "scope_unverified"
+    return False, None, None
+
+
+_NORMALIZED_USAGE_KEYS = {"prompt", "completion", "cached"}
+
+
+def normalize_usage_for_storage(usage):
+    """把一份 usage 归一化为 {prompt, completion, cached}，供事件账本落 usage 列。
+
+    兼容 OpenAI（prompt_tokens / completion_tokens / prompt_tokens_details.cached_tokens）
+    与 Anthropic 风格（input_tokens / output_tokens / cache_read_input_tokens）。
+    非 dict 或空 → None。
+
+    **幂等**：已经是归一化形状的输入原样返回。流式路径按轮累加的是归一化值，
+    落库时会再经过本函数一次；若不幂等，第二次会把三个字段全部清零。
+    """
+    if not isinstance(usage, dict) or not usage:
+        return None
+    if set(usage) == _NORMALIZED_USAGE_KEYS:
+        return dict(usage)
+    details = usage.get("prompt_tokens_details")
+    cached = details.get("cached_tokens") if isinstance(details, dict) else None
+    if cached is None:
+        cached = usage.get("cached_tokens") or usage.get("cache_read_input_tokens") or 0
+    return {
+        "prompt": usage.get("prompt_tokens") or usage.get("input_tokens") or 0,
+        "completion": usage.get("completion_tokens") or usage.get("output_tokens") or 0,
+        "cached": cached or 0,
+    }
+
+
+_LEDGER_INSERT_SQL = (
+    "INSERT INTO conversations "
+    "(session_id, role, content, model, project_id, scope_known, usage, turn_id, turn_key) "
+    "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)"
+)
+
+
+async def _regen_turn_tx(conn, session_id, assistant_content, model,
+                         scope_known, project_id, usage, turn_key):
+    """事务内的重生成：先定目标轮，再互斥选材，最后按 id 精确删并追加新回复。
+
+    绝不先删后猜。turn_id 非空与 legacy NULL 两条候选分支互斥、禁止 OR 混选——
+    混合期（闸门开→关→开）关闸行与新轮并存时，OR 混选会让带合法 turn_id 的新轮
+    误删后写入的 NULL 行。
+    """
+    latest_user = await conn.fetchrow(
+        "SELECT id, turn_id FROM conversations WHERE session_id = $1 AND role = 'user' "
+        "ORDER BY created_at DESC, id DESC LIMIT 1",
+        session_id,
+    )
+
+    if latest_user is None:
+        # 账本里没有该 session 的 user 行：带键必然查无 → 放弃；缺键走 orphan 分支。
+        # 本分支没有 user_id，不得复用 id > user_id 条件。
+        if turn_key is not None:
+            print("event=regen_target_invalid increment=1")
+            return {"ok": False, "path": "regen", "code": "regen_target_invalid"}
+        await conn.execute(
+            "DELETE FROM conversations WHERE id = ("
+            "  SELECT id FROM conversations WHERE session_id = $1 AND role = 'assistant' "
+            "  AND turn_id IS NULL ORDER BY created_at DESC, id DESC LIMIT 1)",
+            session_id,
+        )
+        await conn.execute(
+            _LEDGER_INSERT_SQL, session_id, "assistant", assistant_content, model,
+            project_id, scope_known, _to_json(normalize_usage_for_storage(usage)), None, turn_key,
+        )
+        print("event=turn_orphan increment=1")
+        return {"ok": True, "path": "regen", "turn_id": None}
+
+    user_id, latest_turn = latest_user["id"], latest_user["turn_id"]
+
+    if turn_key is not None:
+        # 事务内解析（不走独立连接，保证与选材/删除同一快照）：
+        # 键指向的轮必须就是最新轮，否则一律放弃——绝不猜测，也绝不改写历史轮。
+        key_turn = await conn.fetchval(
+            "SELECT turn_id FROM conversations WHERE session_id = $1 AND role = 'user' "
+            "AND turn_key = $2 ORDER BY id DESC LIMIT 1",
+            session_id, turn_key,
+        )
+        if key_turn is None or key_turn != latest_turn:
+            print("event=regen_target_invalid increment=1")
+            return {"ok": False, "path": "regen", "code": "regen_target_invalid"}
+
+    if latest_turn is not None:
+        await conn.execute(
+            "DELETE FROM conversations WHERE id = ("
+            "  SELECT id FROM conversations WHERE session_id = $1 AND role = 'assistant' "
+            "  AND turn_id = $2 ORDER BY created_at DESC, id DESC LIMIT 1)",
+            session_id, latest_turn,
+        )
+    else:
+        await conn.execute(
+            "DELETE FROM conversations WHERE id = ("
+            "  SELECT id FROM conversations WHERE session_id = $1 AND role = 'assistant' "
+            "  AND turn_id IS NULL AND id > $2 ORDER BY created_at DESC, id DESC LIMIT 1)",
+            session_id, user_id,
+        )
+
+    await conn.execute(
+        _LEDGER_INSERT_SQL, session_id, "assistant", assistant_content, model,
+        project_id, scope_known, _to_json(normalize_usage_for_storage(usage)), latest_turn, turn_key,
+    )
+    return {"ok": True, "path": "regen", "turn_id": latest_turn}
+
+
+async def append_turn_events_atomic(
+    session_id: str,
+    user_content: str,
+    assistant_content: str,
+    model: str = "",
+    *,
+    client_gave_conv_id: bool = False,
+    project_id_present: bool = False,
+    payload_project_id=None,
+    usage=None,
+    turn_key: str = None,
+    is_regenerate: bool = False,
+) -> dict:
+    """把一轮交互作为单个事务追加进事件账本。
+
+    正常轮：INSERT user（带 scope 与 turn_key）→ 用其自身 id 锚定 turn_id →
+    INSERT assistant（同 scope、同 turn_id/turn_key，外加归一化 usage）。
+    任一步失败整体回滚，绝不留下半轮。
+
+    失败不抛给调用方：暗写失败不得打断聊天，只记一条无标识的安全计数事件。
+    """
+    path = "regen" if is_regenerate else "atomic"
+    pool = await get_pool()
+    try:
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                scope_known, project_id, scope_event = await _resolve_scope_tx(
+                    conn, session_id,
+                    client_gave_conv_id=client_gave_conv_id,
+                    project_id_present=project_id_present,
+                    payload_project_id=payload_project_id,
+                )
+                if scope_event:
+                    print(f"event={scope_event} increment=1")
+
+                if is_regenerate:
+                    return await _regen_turn_tx(
+                        conn, session_id, assistant_content, model,
+                        scope_known, project_id, usage, turn_key,
+                    )
+
+                user_id = await conn.fetchval(
+                    "INSERT INTO conversations "
+                    "(session_id, role, content, model, project_id, scope_known, turn_key) "
+                    "VALUES ($1, 'user', $2, $3, $4, $5, $6) RETURNING id",
+                    session_id, user_content, model, project_id, scope_known, turn_key,
+                )
+                await conn.execute(
+                    "UPDATE conversations SET turn_id = id WHERE id = $1", user_id
+                )
+                await conn.execute(
+                    _LEDGER_INSERT_SQL, session_id, "assistant", assistant_content, model,
+                    project_id, scope_known, _to_json(normalize_usage_for_storage(usage)), user_id, turn_key,
+                )
+                return {"ok": True, "path": path, "turn_id": user_id,
+                        "scope_known": scope_known, "project_id": project_id}
+    except Exception as e:
+        # 无 payload、无正文、无 session/project 标识；异常类名单列，异常正文永不外泄。
+        print(f"event=ledger_write_failed path={path} code=write_failed "
+              f"exception_type={type(e).__name__} increment=1")
+        return {"ok": False, "path": path, "code": "write_failed"}
 
 
 async def get_handoff_source(exclude_conversation_id: str = None, project_id: str = None):

--- a/main.py
+++ b/main.py
@@ -28,6 +28,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from database import (
     init_tables, close_pool, get_pool, save_message, delete_latest_assistant_message, search_memories, save_memory,
+    append_turn_events_atomic, normalize_usage_for_storage as _normalize_usage_for_storage,
     track_memory_recall, touch_permanent_memories, search_scenes,
     get_all_memories_count, get_recent_memories, get_recent_conversation, delete_memory,
     batch_delete_memories_guarded, clear_all_memories, update_memory, check_memory_duplicate,
@@ -314,6 +315,9 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    # W2-03：会话身份 v2 把服务端生成的身份放在响应头里回传。浏览器 fetch 默认
+    # 读不到自定义响应头，必须显式 expose，否则前端拿不到、下轮无法带回。
+    expose_headers=["X-Kiwi-Session-Id"],
 )
 
 # ============================================================
@@ -1168,7 +1172,7 @@ def emotion_to_weight(level: str) -> int:
 MEMORY_TRIGGER_WORDS = ["记住", "记下", "帮我记", "请记", "别忘了", "不要忘记", "你要记得", "记一下"]
 
 
-async def process_memories_background(session_id: str, user_msg: str, assistant_msg: str, model: str, emotion_level: str = "normal", project_id: str = None, is_regenerate: bool = False):
+async def process_memories_background(session_id: str, user_msg: str, assistant_msg: str, model: str, emotion_level: str = "normal", project_id: str = None, is_regenerate: bool = False, *, extract_enabled: bool = True, usage: dict = None, turn_key: str = None, client_gave_conv_id: bool = False, project_id_present: bool = False, payload_project_id=None):
     """
     后台异步：存储对话 + 按间隔提取记忆（不阻塞主流程）
     
@@ -1198,12 +1202,27 @@ async def process_memories_background(session_id: str, user_msg: str, assistant_
     assistant_msg = strip_dream_tag(assistant_msg)
 
     try:
-        # 对话始终保存
-        if is_regenerate:
-            await delete_latest_assistant_message(session_id)
+        # 对话始终保存。W2-03：两条写法互斥，绝不双写——
+        #   闸门开 → 单事务原子落账（项目/轮次/用量三重身份）；
+        #   闸门关 → 字节级旧路径（两次独立 save_message，新列全默认）。
+        if await get_config_bool("memory_event_ledger_write_enabled", fallback=True):
+            await append_turn_events_atomic(
+                session_id, user_msg, assistant_msg, model,
+                client_gave_conv_id=client_gave_conv_id,
+                project_id_present=project_id_present,
+                payload_project_id=payload_project_id,
+                usage=usage, turn_key=turn_key, is_regenerate=is_regenerate,
+            )
         else:
-            await save_message(session_id, "user", user_msg, model)
-        await save_message(session_id, "assistant", assistant_msg, model)
+            if is_regenerate:
+                await delete_latest_assistant_message(session_id)
+            else:
+                await save_message(session_id, "user", user_msg, model)
+            await save_message(session_id, "assistant", assistant_msg, model)
+
+        # W2-03 分层：事件已经落账，但记忆关闭或内部请求时到此为止。
+        if not extract_enabled:
+            return {"action": "skip_extract_disabled"}
 
         # 项目对话默认不提取碎片（对话已保存，但不走记忆提取流程）
         # 未来做"碎片进全局"开关后，这里加条件判断
@@ -1837,10 +1856,35 @@ async def chat_completions(request: Request):
     }
     
     # v5.8：项目 ID（前端传来，用于项目指令/记忆/文件注入）
+    # W2-03：键存在性先于取值——缺键 / 显式 null / 空串是三种不同输入，
+    # 归属判定必须能区分它们，所以在 pop 抹平之前先记下来。
+    project_id_present = "project_id" in body
+    raw_project_id = body.get("project_id")
     project_id = body.pop('project_id', None) or None
     # v6.0：前端对话 ID，用于无缝换窗时避免衔接到当前对话自身
     conversation_id = body.pop('conversation_id', None) or None
     is_regenerate = bool(body.pop('is_regenerate', False))
+    # W2-03：客户端稳定轮次键。缺键放行（旧客户端兼容，重生成按最新轮）；
+    # 显式提供却非法则一律 400，不分是否重生成——把显式错误静默转成 None
+    # 等于让它伪装成旧客户端，与 W2-02 的两层拒绝哲学相悖。
+    _turn_key_raw = body.pop('turn_key', None)
+    if _turn_key_raw is None:
+        turn_key = None
+    elif (not isinstance(_turn_key_raw, str) or isinstance(_turn_key_raw, bool)
+          or not _turn_key_raw.strip() or len(_turn_key_raw) > 200):
+        return JSONResponse(status_code=400, content={"error": "turn_key 必须是 1-200 字符的非空字符串"})
+    else:
+        turn_key = _turn_key_raw.strip()
+    # 身份来源标记：贯穿 scope 判定——只有服务端自己生成 session 的请求，
+    # 其 payload 才可能成为归属的唯一证据。
+    client_gave_conv_id = bool(conversation_id)
+    # 归属上下文打包传递：从请求入口一路带到暗写，避免每层都摊开四个参数。
+    ledger_ctx = {
+        "client_gave_conv_id": client_gave_conv_id,
+        "project_id_present": project_id_present,
+        "payload_project_id": raw_project_id,
+        "turn_key": turn_key,
+    }
 
     # 先确定最终模型，后面的 prompt cache 判断要用它。
     # 如果客户端没传 model，这里会补上默认值，避免误判为“非 Claude”而跳过缓存。
@@ -1897,7 +1941,15 @@ async def chat_completions(request: Request):
     is_anthropic_fmt = (api_format == "anthropic")
     is_openrouter = "openrouter" in chat_api_url.lower()
 
-    mem_enabled = await get_memory_enabled()
+    # W2-03 分层双开关：把「记不记事件」与「提不提记忆」拆开。
+    #   record_events   —— 只要是真实聊天就落账，即使记忆总开关是关的；
+    #                      内部请求（标题生成、上下文压缩）不落原文。
+    #   extract_enabled —— 记忆开且非内部请求，才计数、提取、写 memories。
+    # mem_enabled 的下游语义仍是「记忆系统可用」（提示词注入等），等同 extract_enabled。
+    _raw_mem_enabled = await get_memory_enabled()
+    record_events = not skip_prompt
+    extract_enabled = _raw_mem_enabled and not skip_prompt
+    mem_enabled = extract_enabled
     prompt_meta = {}
     cache_on = False
     cache_ttl = "1h"
@@ -2103,8 +2155,16 @@ async def chat_completions(request: Request):
     # Bug #3：前端不传 conversation_id 时，退回用「首条用户消息」的 hash —— 它在同一段
     # 对话的多轮间稳定（不像 uuid 每轮都变），让上面说的“跨轮稳定”在无 conversation_id
     # 时也成立。
+    # W2-03 身份 v2（默认关）：短 hash 会把两段不同对话的相同开场白合并成同一 session，
+    # 事件、提取游标、工具抽屉与 OpenRouter 黏性路由会一起串线。开关打开后改用
+    # auto-r- + 完整 uuid4，并把身份回传给客户端，让它下轮带回来继续同一会话。
+    session_generated = False
     if conversation_id:
         session_id = conversation_id
+    elif await get_config_bool("session_identity_v2_enabled", fallback=False):
+        session_id = "auto-r-" + uuid.uuid4().hex
+        session_generated = True
+        print("event=session_generated increment=1")
     else:
         first_user = next(
             (
@@ -2390,7 +2450,7 @@ async def chat_completions(request: Request):
         print(f"🔧 工具模式: 共 {len(openai_tools)} 个工具可用")
 
         return StreamingResponse(
-            _stream_with_tools(
+            _with_ev_session(_stream_with_tools(
                 messages=messages,
                 tools=openai_tools,
                 tool_map=tool_map,
@@ -2410,17 +2470,25 @@ async def chat_completions(request: Request):
                 is_regenerate=is_regenerate,
                 reasoning_effort=reasoning_effort,
                 skip_prompt=skip_prompt,
-            ),
+                record_events=record_events,
+                extract_enabled=extract_enabled,
+                ledger_ctx=ledger_ctx,
+            ), session_id, session_generated),
             media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
+            headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no",
+                     **_session_headers(session_id, session_generated)},
         )
 
     # ========== 正常转发模式 ==========
     if is_stream:
         return StreamingResponse(
-            stream_and_capture(headers, body, session_id, user_message, model, tool_events, api_url=chat_api_url, project_id=project_id, prompt_meta=prompt_meta, api_format=api_format, api_key=chat_api_key, is_regenerate=is_regenerate, mem_enabled=mem_enabled),
+            _with_ev_session(
+                stream_and_capture(headers, body, session_id, user_message, model, tool_events, api_url=chat_api_url, project_id=project_id, prompt_meta=prompt_meta, api_format=api_format, api_key=chat_api_key, is_regenerate=is_regenerate, mem_enabled=mem_enabled, record_events=record_events, extract_enabled=extract_enabled, ledger_ctx=ledger_ctx),
+                session_id, session_generated,
+            ),
             media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no"},
+            headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "X-Accel-Buffering": "no",
+                     **_session_headers(session_id, session_generated)},
         )
     else:
         # 非流式：Anthropic 格式需要转换请求和响应
@@ -2440,22 +2508,32 @@ async def chat_completions(request: Request):
                     pass
                 dream_triggered = detect_dream_trigger(assistant_msg)
                 
-                if mem_enabled and user_message and assistant_msg:
+                # W2-03：落账门是 record_events（关记忆也记事件），提取由 extract_enabled 控制。
+                if record_events and user_message and assistant_msg:
                     _emo = merge_emotion_levels(detect_emotion_from_user_msg(user_message), detect_emotion_from_response(assistant_msg))
                     _spawn_background_task(
-                        process_memories_background(session_id, user_message, assistant_msg, model, emotion_level=_emo, project_id=project_id, is_regenerate=is_regenerate)
+                        process_memories_background(
+                            session_id, user_message, assistant_msg, model,
+                            emotion_level=_emo, project_id=project_id, is_regenerate=is_regenerate,
+                            extract_enabled=extract_enabled,
+                            usage=_normalize_usage_for_storage(resp_data.get("usage")),
+                            **ledger_ctx,
+                        )
                     )
                 
                 if dream_triggered:
                     print(f"🌙 检测到 Dream 标记，后台启动 Dream（非流式响应无 SSE 事件）...")
                     _launch_dream_from_marker()
-                return JSONResponse(status_code=200, content=resp_data)
+                return JSONResponse(status_code=200, content=resp_data,
+                                    headers=_session_headers(session_id, session_generated))
             else:
                 try:
                     err_content = response.json()
                 except Exception:
                     err_content = {"error": response.text[:500]}
-                return JSONResponse(status_code=response.status_code, content=err_content)
+                # 身份已受理即回传：它表示「重试时继续用哪个会话」，与上游是否成功无关。
+                return JSONResponse(status_code=response.status_code, content=err_content,
+                                    headers=_session_headers(session_id, session_generated))
 
 
 async def _execute_gateway_tool(tool_name: str, arguments: dict, tool_info: dict) -> tuple:
@@ -2641,7 +2719,7 @@ async def _execute_gateway_tool(tool_name: str, arguments: dict, tool_info: dict
     return f"未知的内置工具: {tool_name}", extra
 
 
-async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool_events, session_id, user_message, mem_enabled, api_url=None, api_key=None, project_id=None, prompt_meta=None, api_format="openai", is_regenerate: bool = False, reasoning_effort: str = None, skip_prompt: bool = False, top_p=None, max_tokens=None):
+async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool_events, session_id, user_message, mem_enabled, api_url=None, api_key=None, project_id=None, prompt_meta=None, api_format="openai", is_regenerate: bool = False, reasoning_effort: str = None, skip_prompt: bool = False, top_p=None, max_tokens=None, record_events: bool = None, extract_enabled: bool = None, ledger_ctx: dict = None):
     """
     工具 + 流式模式：tool call 轮次用非流式（需要完整看 tool_calls），
     最终回复直接输出已获得的内容（模拟流式），不再重复请求 LLM。
@@ -2649,6 +2727,7 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
     """
     import httpx as _httpx
 
+    _usage_total = None  # W2-03：D1 聚合——把每个工具轮的 usage 累加后落账本
     _request_meta_context = tool_map.get("_drawer_request_tools", {})
     if _request_meta_context.get("type") == "meta":
         _request_disabled_categories = set(_request_meta_context.get("disabled_categories") or ())
@@ -2745,6 +2824,8 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
                 yield "data: [DONE]\n\n"
                 return
             data = resp.json()
+            # W2-03 D1：工具循环每一轮的 usage 都累加，账本存整轮聚合值
+            _usage_total = _accumulate_usage(_usage_total, _normalize_usage_for_storage(data.get("usage")))
             # Anthropic 响应转回 OpenAI 格式
             if api_format == "anthropic":
                 data = from_anthropic_response(data, model)
@@ -2786,7 +2867,9 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
                     return
                 _emo = merge_emotion_levels(detect_emotion_from_user_msg(user_message), detect_emotion_from_response(assistant_msg))
                 mem_task = _spawn_background_task(
-                    _finalize_stream_memories(mem_enabled, session_id, user_message, assistant_msg, model, _emo, project_id, is_regenerate)
+                    _finalize_stream_memories(mem_enabled, session_id, user_message, assistant_msg, model, _emo, project_id, is_regenerate,
+                                              record_events=record_events, extract_enabled=extract_enabled,
+                                              usage=_usage_total, ledger_ctx=ledger_ctx)
                 )
 
             def _tool_spawn_dream():
@@ -3102,7 +3185,7 @@ async def _dream_fallback_after_grace(trigger_type: str = "auto", grace: float =
     _launch_dream_detached(trigger_type)
 
 
-async def _finalize_stream_memories(mem_enabled, session_id, user_message, assistant_msg, model, emotion_level, project_id, is_regenerate):
+async def _finalize_stream_memories(mem_enabled, session_id, user_message, assistant_msg, model, emotion_level, project_id, is_regenerate, *, record_events=None, extract_enabled=None, usage=None, ledger_ctx=None):
     """流式收尾的记忆工作（消息入库 + 情绪权重 + 按周期提取）。
 
     独立成协程，供上层用 _spawn_background_task 提为独立后台 task：客户端断连时
@@ -3112,11 +3195,16 @@ async def _finalize_stream_memories(mem_enabled, session_id, user_message, assis
     mem_enabled 由调用方传入（转发路径内联 get_memory_enabled()，工具路径用其 mem_enabled 参数，
     后者已含 skip_prompt 覆盖），保持与各自原有判定完全一致。
     """
-    if not (mem_enabled and user_message and assistant_msg):
+    # W2-03：落账门是 record_events（关记忆也记事件），提取门是 extract_enabled。
+    # 两者缺省时退回 mem_enabled，保持未迁移调用方的原有语义。
+    _record = mem_enabled if record_events is None else record_events
+    _extract = mem_enabled if extract_enabled is None else extract_enabled
+    if not (_record and user_message and assistant_msg):
         return None
     return await process_memories_background(
         session_id, user_message, assistant_msg, model,
         emotion_level=emotion_level, project_id=project_id, is_regenerate=is_regenerate,
+        extract_enabled=_extract, usage=usage, **(ledger_ctx or {}),
     )
 
 
@@ -3156,9 +3244,67 @@ def _capture_openai_sse_event(event: str, full_response: list) -> tuple[int, dic
     return reasoning_chunks, first_delta
 
 
-async def stream_and_capture(headers: dict, body: dict, session_id: str, user_message: str, model: str, tool_events: list = None, api_url: str = None, project_id: str = None, prompt_meta: dict = None, api_format: str = "openai", api_key: str = None, is_regenerate: bool = False, mem_enabled: bool = True):
+def _capture_stream_usage(event: str):
+    """从一个完整 SSE 事件里取出 usage 并归一化；没有就返回 None。
+
+    纯函数，只读事件文本，不写库也不改流。usage 通常在流末的独立事件里，
+    工具循环则每轮都有一份——由调用方按轮累加（D1 聚合）。
+    """
+    for line in event.split("\n"):
+        line = line.strip()
+        if not line.startswith("data: ") or line == "data: [DONE]":
+            continue
+        try:
+            data = json.loads(line[6:])
+        except (json.JSONDecodeError, TypeError, ValueError):
+            continue
+        if isinstance(data, dict) and isinstance(data.get("usage"), dict):
+            return _normalize_usage_for_storage(data["usage"])
+    return None
+
+
+def _accumulate_usage(total, addition):
+    """按字段累加两份归一化 usage；任一为空时返回另一份。"""
+    if not addition:
+        return total
+    if not total:
+        return dict(addition)
+    return {key: (total.get(key) or 0) + (addition.get(key) or 0)
+            for key in ("prompt", "completion", "cached")}
+
+
+def _ev_session_frame(session_id: str) -> bytes:
+    """服务端自产会话身份的流内回传帧。
+
+    语义＝「重试时继续使用的会话身份」，不表示模型调用成功：响应头先于生成器发出，
+    上游失败时收不回，语义上也不该收回。
+    """
+    payload = json.dumps({"ev_session": {"id": session_id, "generated": True}}, ensure_ascii=False)
+    return f"data: {payload}\n\n".encode("utf-8")
+
+
+def _with_ev_session(inner, session_id: str, generated: bool):
+    """把 ev_session 放在流的最前面（先于 ev_handoff / ev_tool / 正文 delta），每流恰一次。"""
+    if not generated:
+        return inner
+
+    async def _wrapped():
+        yield _ev_session_frame(session_id)
+        async for chunk in inner:
+            yield chunk
+
+    return _wrapped()
+
+
+def _session_headers(session_id: str, generated: bool) -> dict:
+    """服务端生成身份时才回传；客户端自带 conversation_id 一律零回显。"""
+    return {"X-Kiwi-Session-Id": session_id} if generated else {}
+
+
+async def stream_and_capture(headers: dict, body: dict, session_id: str, user_message: str, model: str, tool_events: list = None, api_url: str = None, project_id: str = None, prompt_meta: dict = None, api_format: str = "openai", api_key: str = None, is_regenerate: bool = False, mem_enabled: bool = True, record_events: bool = None, extract_enabled: bool = None, ledger_ctx: dict = None):
     """流式响应 + 捕获完整回复 + 工具事件"""
     _api_url = api_url or API_BASE_URL
+    _usage_total = None  # W2-03：按事件累加归一化 usage，流结束时落账本
 
     # 先发送衔接提示（如果有无缝切窗）
     if prompt_meta and prompt_meta.get("handoff"):
@@ -3191,7 +3337,9 @@ async def stream_and_capture(headers: dict, body: dict, session_id: str, user_me
             return
         _emo = merge_emotion_levels(detect_emotion_from_user_msg(user_message), detect_emotion_from_response(_asmsg))
         mem_task = _spawn_background_task(
-            _finalize_stream_memories(mem_enabled, session_id, user_message, _asmsg, model, _emo, project_id, is_regenerate)
+            _finalize_stream_memories(mem_enabled, session_id, user_message, _asmsg, model, _emo, project_id, is_regenerate,
+                                      record_events=record_events, extract_enabled=extract_enabled,
+                                      usage=_usage_total, ledger_ctx=ledger_ctx)
         )
         finalize_spawned = True
 
@@ -3234,11 +3382,13 @@ async def stream_and_capture(headers: dict, body: dict, session_id: str, user_me
                             if not event or event == "data: [DONE]":
                                 continue
                             captured_reasoning, _ = _capture_openai_sse_event(event, full_response)
+                            _usage_total = _accumulate_usage(_usage_total, _capture_stream_usage(event))
                             _reasoning_chunks += captured_reasoning
                             yield (event + "\n\n").encode("utf-8")
                     _tail = _ev_buf.strip()
                     if _tail and _tail != "data: [DONE]":
                         captured_reasoning, _ = _capture_openai_sse_event(_tail, full_response)
+                        _usage_total = _accumulate_usage(_usage_total, _capture_stream_usage(_tail))
                         _reasoning_chunks += captured_reasoning
                         yield (_tail + "\n\n").encode("utf-8")
         else:
@@ -3273,6 +3423,7 @@ async def stream_and_capture(headers: dict, body: dict, session_id: str, user_me
                             if not event or event == "data: [DONE]":
                                 continue
                             captured_reasoning, first_delta = _capture_openai_sse_event(event, full_response)
+                            _usage_total = _accumulate_usage(_usage_total, _capture_stream_usage(event))
                             _reasoning_chunks += captured_reasoning
 
                             # 🔍 调试日志：记录第一个有效delta的所有字段
@@ -3290,6 +3441,7 @@ async def stream_and_capture(headers: dict, body: dict, session_id: str, user_me
                     _tail = buffer.strip()
                     if _tail and _tail != "data: [DONE]":
                         captured_reasoning, _ = _capture_openai_sse_event(_tail, full_response)
+                        _usage_total = _accumulate_usage(_usage_total, _capture_stream_usage(_tail))
                         _reasoning_chunks += captured_reasoning
                         yield (_tail + "\n\n").encode("utf-8")
     finally:

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -2225,6 +2225,26 @@ async def _ledger_rows(session_id: str) -> list:
     )
 
 
+async def _await_ledger(session_id: str, expected: int, timeout: float = 5.0) -> list:
+    """等后台落账 task 跑完。
+
+    暗写被 _spawn_background_task 提成独立任务（断连也要跑完），HTTP 响应返回时
+    它通常还没落库，所以这里轮询而不是直接断言。
+    """
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    rows = await _ledger_rows(session_id)
+    while len(rows) < expected and loop.time() < deadline:
+        await asyncio.sleep(0.05)
+        rows = await _ledger_rows(session_id)
+    return rows
+
+
+async def _settle_background(seconds: float = 0.4) -> None:
+    """给后台任务一个真实的落库窗口，再断言「什么都没写」。"""
+    await asyncio.sleep(seconds)
+
+
 async def _set_ledger_gate(enabled: bool) -> None:
     await _upsert_config("memory_event_ledger_write_enabled", "true" if enabled else "false")
 
@@ -2535,7 +2555,10 @@ async def test_w2_03_scope_and_order() -> None:
 
     # ---- 18. turn_key must never be joined across tables --------------------
     db_source = (ROOT / "database.py").read_text(encoding="utf-8")
-    joined = re.findall(r"JOIN[^;]{0,200}turn_key|turn_key[^;]{0,200}JOIN", db_source, re.I)
+    # Scan code only: the prohibition itself is spelled out in comments, and a
+    # comment saying "never JOIN on turn_key" must not read as a JOIN on turn_key.
+    code_only = "\n".join(ln for ln in db_source.splitlines() if not ln.strip().startswith("#"))
+    joined = re.findall(r"JOIN[^;]{0,200}turn_key|turn_key[^;]{0,200}JOIN", code_only, re.I)
     require(not joined, f"turn_key appears in a JOIN: {joined[:1]}")
     require(db_source.count("同名不同义") >= 2,
             "both turn_key columns must carry the same-name-different-meaning warning")
@@ -2544,12 +2567,14 @@ async def test_w2_03_scope_and_order() -> None:
     # ---- 19. deterministic read order on tied timestamps --------------------
     await _truncate("conversations")
     tie_sid = "w203-tie"
-    tied = "2026-05-05 05:05:05+00"
+    # Identical timestamps on purpose: PG's NOW() is constant inside one transaction,
+    # so an atomic turn writes both rows with the exact same created_at.
+    tied = StdDateTime(2026, 5, 5, 5, 5, 5, tzinfo=timezone.utc)
     await _pool_execute(
         "INSERT INTO conversations (session_id, role, content, model, created_at) VALUES "
-        "($1,'user','u-first','m',$2::timestamptz), "
-        "($1,'assistant','a-second','m',$2::timestamptz), "
-        "($1,'assistant','a-third','m',$2::timestamptz)",
+        "($1,'user','u-first','m',$2), "
+        "($1,'assistant','a-second','m',$2), "
+        "($1,'assistant','a-third','m',$2)",
         tie_sid, tied,
     )
     recent = await database.get_recent_messages(tie_sid, limit=10)
@@ -2602,7 +2627,9 @@ async def test_w2_03_entry_and_panel(client: httpx.AsyncClient) -> None:
         require(key in config.CONFIG_SCHEMA, f"{key} is missing from the backend registry")
         require(re.search(rf"\b{key}\s*:", schema_js),
                 f"{key} is missing from config-schema.js CONFIG_META (the panel would not show it)")
-        require(re.search(rf"['\"]{key}['\"]", schema_js.split("CONFIG_PAGES")[-1]),
+        # Split at the *first* CONFIG_PAGES (its definition); the name also appears
+        # later where the table is consumed, and splitting on that would drop the groups.
+        require(re.search(rf"['\"]{key}['\"]", schema_js.split("CONFIG_PAGES", 1)[-1]),
                 f"{key} is registered but never placed in a CONFIG_PAGES group")
     gate_key = "memory_event_ledger_write_enabled"
     had_row = await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM gateway_config WHERE key = $1)", gate_key)
@@ -2622,7 +2649,10 @@ async def test_w2_03_entry_and_panel(client: httpx.AsyncClient) -> None:
     passed("T-W2-03-24 both gates are dual-registered and settable through the admin endpoint")
 
     # ---- 25. CORS actually exposes the session header ----------------------
-    response = await client.get("/", headers={"Origin": "http://kiwi.example"})
+    # Use an origin the deployment actually allows: CORS headers are only emitted
+    # for allowed origins, so a foreign origin would fail this guard for the wrong reason.
+    allowed_origin = (os.environ.get("CORS_ORIGINS", "http://localhost:5173").split(",")[0]).strip()
+    response = await client.get("/", headers={"Origin": allowed_origin})
     exposed = response.headers.get("access-control-expose-headers", "")
     require("X-Kiwi-Session-Id" in exposed,
             f"CORS does not expose X-Kiwi-Session-Id (browsers could not read it): {exposed!r}")
@@ -2691,13 +2721,19 @@ _USAGE_TAIL = _sse({"choices": [], "usage": {"prompt_tokens": 11, "completion_to
 
 async def _chat(client, body, *, sse_events=None, json_body=None, status_code=200):
     """POST /v1/chat/completions against a canned upstream; returns the response."""
-    async def fake_resolve(_model):
-        return "http://127.0.0.1:9/mock-chat", "mock-key", "openai"
+    async def fake_provider(_model, provider_model_id=None):
+        return {
+            "model_id": "mock-model",
+            "api_key": "mock-key",
+            "api_format": "openai",
+            "api_base_url": "http://127.0.0.1:9/mock-chat",
+            "provider_name": "mock-provider",
+        }
 
     with (
         patch.object(app_module.httpx, "AsyncClient",
                      _fake_upstream(sse_events=sse_events, json_body=json_body, status_code=status_code)),
-        patch.object(database, "resolve_model_endpoint", fake_resolve),
+        patch.object(app_module, "resolve_provider_for_model", fake_provider),
     ):
         return await client.post("/v1/chat/completions", json=body)
 
@@ -2716,14 +2752,16 @@ async def test_w2_03_chat_paths(client: httpx.AsyncClient) -> None:
         await _upsert_config(mem_key, "false")
 
         # ---- 20. memory off still records events, never extracts ------------
-        await _truncate("conversations")
+        # memories is cleared too: earlier guards seed it, and "zero extraction"
+        # must be measured against an empty table, not against their leftovers.
+        await _truncate("conversations", "memories")
         await _set_identity_gate(False)
         response = await _chat(client, {
             "model": "mock-model", "stream": False, "conversation_id": "w203-layer-a",
             "messages": [{"role": "user", "content": "hi"}],
         }, json_body={"choices": [{"message": {"content": "a-body"}}], "model": "mock-model"})
         require(response.status_code == 200, f"buffered chat failed: {response.status_code} {response.text[:200]}")
-        rows = await _ledger_rows("w203-layer-a")
+        rows = await _await_ledger("w203-layer-a", 2)
         require(len(rows) == 2, f"memory-off chat must still write 2 ledger rows, got {len(rows)}")
         require(await _pool_fetchval("SELECT COUNT(*) FROM memories") == 0,
                 "memory-off chat must not extract any memory")
@@ -2737,6 +2775,7 @@ async def test_w2_03_chat_paths(client: httpx.AsyncClient) -> None:
             "messages": [{"role": "user", "content": "summarize"}],
         }, json_body={"choices": [{"message": {"content": "title"}}], "model": "mock-model"})
         require(response.status_code == 200, "internal request failed")
+        await _settle_background()
         require(not await _ledger_rows("w203-internal"),
                 "an internal request (skip_system_prompt) must not touch the ledger")
         passed("T-W2-03-21 internal requests write neither events nor memories")
@@ -2767,12 +2806,16 @@ async def test_w2_03_chat_paths(client: httpx.AsyncClient) -> None:
         passed("T-W2-03-13 identity v2 gives distinct full-uuid sessions and never echoes client IDs")
 
         await _set_identity_gate(False)
+        # Let the previous block's background writes land before truncating, or
+        # their late rows reappear inside this guard's window.
+        await _settle_background()
         await _truncate("conversations")
         for _ in range(2):
             await _chat(client, {
                 "model": "mock-model", "stream": False,
                 "messages": [{"role": "user", "content": "same opening line"}],
             }, json_body={"choices": [{"message": {"content": "a"}}], "model": "mock-model"})
+        await _settle_background()
         legacy_sessions = {r["session_id"] for r in await _pool_fetch(
             "SELECT DISTINCT session_id FROM conversations")}
         require(len(legacy_sessions) == 1 and next(iter(legacy_sessions)).startswith("auto-"),
@@ -2822,9 +2865,12 @@ async def test_w2_03_chat_paths(client: httpx.AsyncClient) -> None:
         response = await _chat(client, {
             "model": "mock-model", "stream": True, "conversation_id": "w203-usage",
             "messages": [{"role": "user", "content": "count me"}],
-        }, sse_events=[_DELTA, _USAGE_TAIL, "data: [DONE]\n\n"])
+        }, sse_events=[_DELTA, _USAGE_TAIL, "data: [DONE]\n\n"],
+           json_body={"choices": [{"message": {"content": "a-body"}}], "model": "mock-model",
+                      "usage": {"prompt_tokens": 11, "completion_tokens": 5,
+                                "prompt_tokens_details": {"cached_tokens": 2}}})
         require(response.status_code == 200, "usage stream failed")
-        rows = await _ledger_rows("w203-usage")
+        rows = await _await_ledger("w203-usage", 2)
         require(len(rows) == 2, f"usage stream must land a full turn: {len(rows)} rows")
         require(json.loads(rows[1]["usage"]) == {"prompt": 11, "completion": 5, "cached": 2},
                 f"streamed usage was not captured/normalized: {rows[1]['usage']!r}")
@@ -2834,7 +2880,7 @@ async def test_w2_03_chat_paths(client: httpx.AsyncClient) -> None:
             "model": "mock-model", "stream": True, "conversation_id": "w203-nousage",
             "messages": [{"role": "user", "content": "no usage block"}],
         }, sse_events=[_DELTA, "data: [DONE]\n\n"])
-        rows = await _ledger_rows("w203-nousage")
+        rows = await _await_ledger("w203-nousage", 2)
         require(rows and rows[1]["usage"] is None,
                 f"a stream without a usage block must store NULL: {rows[1]['usage'] if rows else 'no rows'!r}")
         passed("T-W2-03-16 usage is normalized for both vendors and captured/NULL across streams")

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -2444,23 +2444,27 @@ async def test_w2_03_schema_and_atomic() -> None:
                 f"{label} key abandon did not emit regen_target_invalid: {capture.getvalue()!r}")
     passed("T-W2-03-9 regenerate abandons on historical or unknown turn_key and keeps the old reply")
 
-    # mixed era: gate-off rows (turn_id NULL) must survive a new-turn regenerate
+    # Mixed era (gate on -> off -> on): the dangerous shape is a gate-off row written
+    # AFTER a proper turn.  Ordering by time alone would then pick the NULL row, so the
+    # legacy row must be the *newest* one here — a legacy row placed before the turn
+    # would be selected correctly even by a broken OR-merged candidate set.
     await _truncate("conversations")
     mix_sid = "w203-mixed"
-    await _pool_execute(
-        "INSERT INTO conversations (session_id, role, content, model) VALUES "
-        "($1,'user','legacy-u','m'), ($1,'assistant','legacy-a','m')", mix_sid
-    )
     await database.append_turn_events_atomic(mix_sid, "new-u", "new-a", "m", turn_key="mk")
+    await _pool_execute(
+        "INSERT INTO conversations (session_id, role, content, model, created_at) "
+        "VALUES ($1, 'assistant', 'gate-off-a', 'm', NOW() + INTERVAL '1 minute')", mix_sid
+    )
     await database.append_turn_events_atomic(
         mix_sid, "new-u", "new-a-regen", "m", is_regenerate=True
     )
     rows = await _ledger_rows(mix_sid)
-    legacy_bodies = [r["content"] for r in rows if r["turn_id"] is None]
-    require(legacy_bodies == ["legacy-u", "legacy-a"],
-            f"mixed-era regenerate damaged the gate-off rows: {legacy_bodies}")
+    require("gate-off-a" in [r["content"] for r in rows],
+            "mixed-era regenerate deleted the gate-off row: the candidate branches were OR-merged")
     require([r["content"] for r in rows if r["turn_id"] is not None] == ["new-u", "new-a-regen"],
             f"mixed-era regenerate did not replace within its own turn: {[r['content'] for r in rows]}")
+    require("new-a" not in [r["content"] for r in rows],
+            "mixed-era regenerate left the superseded reply of its own turn behind")
     passed("T-W2-03-10 mixed-era regenerate stays inside its own turn branch")
 
 
@@ -2580,6 +2584,16 @@ async def test_w2_03_scope_and_order() -> None:
     recent = await database.get_recent_messages(tie_sid, limit=10)
     require([r["content"] for r in recent] == ["u-first", "a-second", "a-third"],
             f"get_recent_messages is unstable on tied timestamps: {[r['content'] for r in recent]}")
+    # A behavioural check alone is not enough here: on a small table PG's sequential
+    # scan happens to return insertion (= id) order, so a missing tiebreak can pass by
+    # luck.  Pin the tiebreak in the SQL of every ledger reader as well.
+    reader_source = (ROOT / "database.py").read_text(encoding="utf-8")
+    for reader in ("get_recent_messages", "get_recent_conversation",
+                   "delete_latest_assistant_message"):
+        body = re.search(rf"async def {reader}\(.*?(?=\nasync def )", reader_source, re.S)
+        require(body, f"{reader} not found for the read-order guard")
+        require("ORDER BY created_at DESC, id DESC" in body.group(0),
+                f"{reader} orders by time without an id tiebreak; tied rows sort arbitrarily")
     await database.delete_latest_assistant_message(tie_sid)
     left = [r["content"] for r in await _ledger_rows(tie_sid)]
     require(left == ["u-first", "a-second"],

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -2422,7 +2422,42 @@ async def test_w2_03_schema_and_atomic() -> None:
     require(rows[0]["id"] == before[0]["id"], "regenerate must not touch the user row")
     require(rows[1]["content"] == "a1-regenerated", "regenerate did not replace the assistant body")
     require(rows[1]["turn_id"] == target_turn, "regenerated assistant lost its turn anchor")
-    passed("T-W2-03-8 keyless regenerate replaces the newest assistant of the newest turn")
+    # A keyless regenerate must not blank the turn's key: the user row still says k1,
+    # so an assistant carrying NULL would split the turn's identity in half.
+    require(rows[1]["turn_key"] == "k1",
+            f"replacement assistant must inherit the user's turn_key, got {rows[1]['turn_key']!r}")
+
+    # The turn's scope is decided once, when the turn is written.  If the conversation
+    # is later moved into a project (or its metadata only syncs afterwards), a regenerate
+    # must still inherit the original attribution — otherwise one turn ends up "question
+    # global, answer in project", and W2-06's scope-based consumers tear it apart.
+    await _truncate("conversations", "chat_conversations", "chat_projects")
+    moved_sid = "w203-moved"
+    await _pool_execute("INSERT INTO chat_projects (id, name) VALUES ('w203-moved-p', 'moved')")
+    await _pool_execute(
+        "INSERT INTO chat_conversations (id, title, project_id) VALUES ($1, 'c', NULL)", moved_sid
+    )
+    await database.append_turn_events_atomic(
+        moved_sid, "u", "a", "m", client_gave_conv_id=True, turn_key="mk"
+    )
+    original = await _ledger_rows(moved_sid)
+    await _pool_execute(
+        "UPDATE chat_conversations SET project_id = 'w203-moved-p' WHERE id = $1", moved_sid
+    )
+    await database.append_turn_events_atomic(
+        moved_sid, "u", "a-after-move", "m", client_gave_conv_id=True, is_regenerate=True
+    )
+    after = await _ledger_rows(moved_sid)
+    require(len(after) == 2, f"regenerate after a move must still leave one turn: {len(after)} rows")
+    require((after[0]["scope_known"], after[0]["project_id"])
+            == (after[1]["scope_known"], after[1]["project_id"]),
+            f"regenerate split the turn's scope: user={(after[0]['scope_known'], after[0]['project_id'])} "
+            f"assistant={(after[1]['scope_known'], after[1]['project_id'])}")
+    require((after[1]["scope_known"], after[1]["project_id"])
+            == (original[0]["scope_known"], original[0]["project_id"]),
+            "replacement assistant re-judged scope instead of inheriting the original turn's")
+    require(after[1]["turn_key"] == "mk", "replacement assistant lost the original turn_key")
+    passed("T-W2-03-8 keyless regenerate replaces within the turn and inherits its whole identity")
 
     # historical key -> abandon, unknown key -> abandon; the old assistant survives both
     await _truncate("conversations")
@@ -2526,11 +2561,35 @@ async def test_w2_03_scope_and_order() -> None:
 
     # ---- 16 (pure half). usage normalization shapes ------------------------
     normalize = app_module._normalize_usage_for_storage
+    # OpenAI: prompt_tokens already includes the cached part — adding it again double counts.
     require(normalize({"prompt_tokens": 7, "completion_tokens": 2,
                        "prompt_tokens_details": {"cached_tokens": 5}})
-            == {"prompt": 7, "completion": 2, "cached": 5}, "OpenAI usage shape mis-normalized")
+            == {"prompt": 7, "completion": 2, "cached": 5},
+            "OpenAI prompt_tokens already counts cached tokens; it must not be added twice")
+    # Anthropic: input_tokens EXCLUDES cache creation and cache read, so the real total
+    # input is input + creation + read (Anthropic's own billing definition).  Three
+    # distinct values so a dropped term cannot coincidentally produce the right sum.
+    require(normalize({"input_tokens": 9, "output_tokens": 3,
+                       "cache_creation_input_tokens": 40, "cache_read_input_tokens": 100})
+            == {"prompt": 149, "completion": 3, "cached": 100},
+            "Anthropic prompt must add cache creation and cache read to input_tokens")
     require(normalize({"input_tokens": 9, "output_tokens": 3, "cache_read_input_tokens": 1})
-            == {"prompt": 9, "completion": 3, "cached": 1}, "Anthropic usage shape mis-normalized")
+            == {"prompt": 10, "completion": 3, "cached": 1},
+            "Anthropic read-only cache still belongs in the prompt total")
+    require(normalize({"input_tokens": 9, "output_tokens": 3})
+            == {"prompt": 9, "completion": 3, "cached": 0},
+            "Anthropic without cache must stay unchanged")
+    require(normalize({"prompt": 149, "completion": 3, "cached": 100})
+            == {"prompt": 149, "completion": 3, "cached": 100},
+            "already-normalized usage must pass through unchanged (streams re-normalize on write)")
+    # Multi-round aggregation adds field by field.
+    acc = app_module._accumulate_usage(None, normalize(
+        {"input_tokens": 9, "output_tokens": 3, "cache_creation_input_tokens": 40,
+         "cache_read_input_tokens": 100}))
+    acc = app_module._accumulate_usage(acc, normalize(
+        {"input_tokens": 1, "output_tokens": 2, "cache_read_input_tokens": 7}))
+    require(acc == {"prompt": 157, "completion": 5, "cached": 107},
+            f"multi-round usage aggregation is wrong: {acc}")
     for empty in (None, "", [], {}, 0):
         require(normalize(empty) is None, f"non-dict usage must normalize to None: {empty!r}")
     # Counted once, together with the streaming half, as T-W2-03-16.
@@ -2617,23 +2676,44 @@ async def test_w2_03_entry_and_panel(client: httpx.AsyncClient) -> None:
     passed("T-W2-03-11 explicitly invalid turn_key is rejected at the request entry")
 
     # ---- 23. project turns keep their scope and still skip extraction -------
-    await _truncate("conversations", "chat_conversations", "chat_projects")
+    # This must go through process_memories_background with memory ON and a trigger
+    # word present, so the turn would genuinely reach extraction if the project skip
+    # were removed.  Calling append_turn_events_atomic directly would never enter the
+    # extraction path at all, and the guard would stay green with the skip deleted.
+    await _truncate("conversations", "chat_conversations", "chat_projects", "memories")
     await _pool_execute("INSERT INTO chat_projects (id, name) VALUES ('w203-proj', 'p')")
     await _pool_execute(
         "INSERT INTO chat_conversations (id, title, project_id) VALUES ('w203-proj-c','c','w203-proj')"
     )
-    await database.append_turn_events_atomic(
-        "w203-proj-c", "u", "a", "m", client_gave_conv_id=True, turn_key="pk"
-    )
-    rows = await _ledger_rows("w203-proj-c")
-    require(len(rows) == 2, f"project turn must still land two ledger rows, got {len(rows)}")
-    require(all(r["scope_known"] is True and r["project_id"] == "w203-proj" for r in rows),
-            f"project turn lost its scope: {[(r['scope_known'], r['project_id']) for r in rows]}")
-    require(not await _pool_fetchval(
-        "SELECT EXISTS(SELECT 1 FROM conversations WHERE session_id = 'w203-proj-c' "
-        "AND scope_known = TRUE AND project_id IS NULL)"),
-        "a project turn must never satisfy the global scope condition")
-    passed("T-W2-03-23 project turns carry their scope and stay out of the global pool")
+    mem_key = "memory_enabled"
+    mem_had = await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM gateway_config WHERE key = $1)", mem_key)
+    mem_prev = await _config_row(mem_key)
+    try:
+        await _upsert_config(mem_key, "true")
+        trigger_word = next(w for w in app_module.MEMORY_TRIGGER_WORDS if w)
+        result = await app_module.process_memories_background(
+            "w203-proj-c", f"{trigger_word}我最喜欢奇异果", "好，我记住了", "m",
+            project_id="w203-proj", extract_enabled=True,
+            client_gave_conv_id=True, turn_key="pk",
+        )
+        require(isinstance(result, dict) and result.get("action") == "skip_project",
+                f"a project turn must short-circuit before extraction, got {result!r}")
+        rows = await _ledger_rows("w203-proj-c")
+        require(len(rows) == 2, f"project turn must still land two ledger rows, got {len(rows)}")
+        require(all(r["scope_known"] is True and r["project_id"] == "w203-proj" for r in rows),
+                f"project turn lost its scope: {[(r['scope_known'], r['project_id']) for r in rows]}")
+        require(await _pool_fetchval("SELECT COUNT(*) FROM memories") == 0,
+                "a project turn leaked fragments into the global memory pool")
+        require(not await _pool_fetchval(
+            "SELECT EXISTS(SELECT 1 FROM conversations WHERE session_id = 'w203-proj-c' "
+            "AND scope_known = TRUE AND project_id IS NULL)"),
+            "a project turn must never satisfy the global scope condition")
+    finally:
+        if mem_had:
+            await _upsert_config(mem_key, mem_prev)
+        else:
+            await _pool_execute("DELETE FROM gateway_config WHERE key = $1", mem_key)
+    passed("T-W2-03-23 project turns record their scope and never reach global extraction")
 
     # ---- 24. both gates are registered on both sides and settable ----------
     schema_js = (ROOT / "admin-panel" / "js" / "config-schema.js").read_text(encoding="utf-8")
@@ -2897,6 +2977,21 @@ async def test_w2_03_chat_paths(client: httpx.AsyncClient) -> None:
         rows = await _await_ledger("w203-nousage", 2)
         require(rows and rows[1]["usage"] is None,
                 f"a stream without a usage block must store NULL: {rows[1]['usage'] if rows else 'no rows'!r}")
+
+        # End to end with an Anthropic-shaped usage block.  The tool loop normalizes the
+        # raw upstream usage *before* from_anthropic_response(), so this is the shape that
+        # actually reaches the ledger there — a dropped cache term shows up as a low prompt.
+        await _truncate("conversations")
+        await _chat(client, {
+            "model": "mock-model", "stream": True, "conversation_id": "w203-anthropic-usage",
+            "messages": [{"role": "user", "content": "cached prompt"}],
+        }, sse_events=[_DELTA, "data: [DONE]\n\n"],
+           json_body={"choices": [{"message": {"content": "a-body"}}], "model": "mock-model",
+                      "usage": {"input_tokens": 9, "output_tokens": 3,
+                                "cache_creation_input_tokens": 40, "cache_read_input_tokens": 100}})
+        rows = await _await_ledger("w203-anthropic-usage", 2)
+        require(json.loads(rows[1]["usage"]) == {"prompt": 149, "completion": 3, "cached": 100},
+                f"Anthropic cache tokens were lost end to end: {rows[1]['usage']!r}")
         passed("T-W2-03-16 usage is normalized for both vendors and captured/NULL across streams")
     finally:
         for key, had, prev in ((mem_key, mem_had, mem_prev), (id_key, id_had, id_prev)):

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -150,6 +150,8 @@ async def _truncate(*tables: str) -> None:
         "comments",
         "dream_logs",
         "mem_scenes",
+        "conversations",
+        "memory_extraction_state",
     }
     require(bool(tables) and set(tables) <= allowed, "unsafe TRUNCATE table")
     await _pool_execute(f"TRUNCATE TABLE {', '.join(tables)} RESTART IDENTITY CASCADE")
@@ -2202,6 +2204,648 @@ async def test_w2_02(client: httpx.AsyncClient) -> None:
     passed("T-W2-02-22 reject and failure observability keep codes and drop entity IDs")
 
 
+# ---------------------------------------------------------------------------
+# W2-03 | M1 ledger schema, authoritative scope, and dark writes
+# ---------------------------------------------------------------------------
+
+_LEDGER_NEW_COLUMNS = {
+    "project_id": "text",
+    "scope_known": "boolean",
+    "usage": "jsonb",
+    "turn_id": "bigint",
+    "turn_key": "text",
+}
+
+
+async def _ledger_rows(session_id: str) -> list:
+    return await _pool_fetch(
+        "SELECT id, role, content, model, project_id, scope_known, usage, turn_id, turn_key "
+        "FROM conversations WHERE session_id = $1 ORDER BY id",
+        session_id,
+    )
+
+
+async def _set_ledger_gate(enabled: bool) -> None:
+    await _upsert_config("memory_event_ledger_write_enabled", "true" if enabled else "false")
+
+
+async def _set_identity_gate(enabled: bool) -> None:
+    await _upsert_config("session_identity_v2_enabled", "true" if enabled else "false")
+
+
+async def test_w2_03_schema_and_atomic() -> None:
+    """T-W2-03-1..10: schema, migration, atomic turn writes, regenerate."""
+    # ---- 1. five columns + extraction state table --------------------------
+    rows = {
+        r["column_name"]: r
+        for r in await _pool_fetch(
+            "SELECT column_name, data_type, is_nullable, column_default "
+            "FROM information_schema.columns WHERE table_name = 'conversations'"
+        )
+    }
+    missing = sorted(set(_LEDGER_NEW_COLUMNS) - set(rows))
+    require(not missing, f"W2-03 conversations columns missing: {missing}")
+    for col, want_type in _LEDGER_NEW_COLUMNS.items():
+        require(rows[col]["data_type"] == want_type,
+                f"{col} must be {want_type}, got {rows[col]['data_type']}")
+    require(rows["scope_known"]["is_nullable"] == "NO", "scope_known must be NOT NULL")
+    require("false" in (rows["scope_known"]["column_default"] or "").lower(),
+            f"scope_known must default FALSE, got {rows['scope_known']['column_default']!r}")
+    for col in ("project_id", "usage", "turn_id", "turn_key"):
+        require(rows[col]["is_nullable"] == "YES", f"{col} must be nullable")
+        require(rows[col]["column_default"] is None, f"{col} must have no default")
+    state_cols = {
+        r["column_name"]
+        for r in await _pool_fetch(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_name = 'memory_extraction_state'"
+        )
+    }
+    require({"session_id", "last_extracted_message_id", "claimed_until", "updated_at", "claim_token"}
+            <= state_cols, f"memory_extraction_state columns missing: {sorted(state_cols)}")
+    passed("T-W2-03-1 ledger gains five columns and memory_extraction_state exists")
+
+    # ---- 2/3. idempotent migration, untouched legacy rows -------------------
+    await _truncate("conversations")
+    legacy_id = await _pool_fetchval(
+        "INSERT INTO conversations (session_id, role, content, model) "
+        "VALUES ('w203-legacy', 'user', 'legacy-body', 'm') RETURNING id"
+    )
+    await database.init_tables()
+    await database.init_tables()
+    recheck = await _pool_fetchval(
+        "SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'conversations' "
+        "AND column_name = ANY($1::text[])",
+        list(_LEDGER_NEW_COLUMNS),
+    )
+    require(recheck == 5, "repeat init_tables() disturbed the W2-03 columns")
+    passed("T-W2-03-2 repeat init_tables() is idempotent for the ledger columns")
+
+    legacy = await _pool_fetchrow(
+        "SELECT content, project_id, scope_known, usage, turn_id, turn_key "
+        "FROM conversations WHERE id = $1", legacy_id
+    )
+    require(legacy["content"] == "legacy-body", "migration damaged an existing ledger row")
+    require(legacy["scope_known"] is False, "legacy rows must stay scope_known = FALSE")
+    for col in ("project_id", "usage", "turn_id", "turn_key"):
+        require(legacy[col] is None, f"legacy row must keep {col} NULL, got {legacy[col]!r}")
+    passed("T-W2-03-3 legacy ledger rows stay blank and unclaimed")
+
+    # ---- 4. atomic normal turn ---------------------------------------------
+    await _truncate("conversations", "chat_conversations", "chat_projects")
+    sid = "w203-atomic"
+    result = await database.append_turn_events_atomic(
+        sid, "u-body", "a-body", "m-1",
+        usage={"prompt_tokens": 10, "completion_tokens": 4,
+               "prompt_tokens_details": {"cached_tokens": 3}},
+        turn_key="tk-1",
+    )
+    require(result.get("ok") is True, f"atomic append failed: {result!r}")
+    rows = await _ledger_rows(sid)
+    require(len(rows) == 2, f"atomic turn must write exactly two rows, got {len(rows)}")
+    user_row, asst_row = rows
+    require((user_row["role"], asst_row["role"]) == ("user", "assistant"),
+            f"row order wrong: {[r['role'] for r in rows]}")
+    require(user_row["turn_id"] == user_row["id"],
+            f"user turn_id must anchor to its own id: {user_row['turn_id']} != {user_row['id']}")
+    require(asst_row["turn_id"] == user_row["id"],
+            "assistant must share the user's turn_id")
+    require(user_row["turn_key"] == "tk-1" and asst_row["turn_key"] == "tk-1",
+            "both rows must carry the same turn_key")
+    require(user_row["usage"] is None, "usage belongs on the assistant row only")
+    require(json.loads(asst_row["usage"]) == {"prompt": 10, "completion": 4, "cached": 3},
+            f"usage was not normalized: {asst_row['usage']!r}")
+    passed("T-W2-03-4 an atomic turn writes both rows with shared identity and normalized usage")
+
+    # ---- 5. transaction rollback + safe failure event -----------------------
+    await _truncate("conversations")
+    fail_sid = "w203-rollback"
+    await _pool_execute(
+        """
+        CREATE OR REPLACE FUNCTION w203_fail_assistant() RETURNS trigger AS $fn$
+        BEGIN
+            IF NEW.role = 'assistant' AND NEW.session_id = 'w203-rollback'
+            THEN RAISE EXCEPTION 'W2_03_INJECTED_LEDGER_FAILURE'; END IF;
+            RETURN NEW;
+        END; $fn$ LANGUAGE plpgsql
+        """
+    )
+    await _pool_execute("DROP TRIGGER IF EXISTS w203_fail_assistant_trg ON conversations")
+    await _pool_execute(
+        "CREATE TRIGGER w203_fail_assistant_trg BEFORE INSERT ON conversations "
+        "FOR EACH ROW EXECUTE FUNCTION w203_fail_assistant()"
+    )
+    try:
+        capture = io.StringIO()
+        with redirect_stdout(capture):
+            result = await database.append_turn_events_atomic(fail_sid, "u", "a", "m")
+        require(result.get("ok") is False, "a failed atomic append must report ok=False")
+        require(not await _ledger_rows(fail_sid),
+                "half-written turn survived: the user row was not rolled back")
+        events = [ln.strip() for ln in capture.getvalue().splitlines()
+                  if ln.startswith("event=ledger_write_failed ")]
+        require(events, f"no ledger_write_failed event: {capture.getvalue()!r}")
+        require(all("code=write_failed" in e for e in events),
+                f"ledger_write_failed must use the stable code: {events}")
+        require(all("exception_type=" in e for e in events),
+                f"ledger_write_failed must name the exception type: {events}")
+        require(all("W2_03_INJECTED_LEDGER_FAILURE" not in e for e in events),
+                "ledger_write_failed leaked the exception body")
+        require(all(fail_sid not in e for e in events),
+                "ledger_write_failed leaked the session id")
+        passed("T-W2-03-5 a failed turn rolls back entirely and emits a safe coded event")
+    finally:
+        await _pool_execute("DROP TRIGGER IF EXISTS w203_fail_assistant_trg ON conversations")
+        await _pool_execute("DROP FUNCTION IF EXISTS w203_fail_assistant()")
+
+    # ---- 6/7. gate exclusivity ---------------------------------------------
+    await _truncate("conversations")
+    gate_key = "memory_event_ledger_write_enabled"
+    gate_had_row = await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM gateway_config WHERE key = $1)", gate_key)
+    gate_previous = await _config_row(gate_key)
+    try:
+        require(config.CONFIG_SCHEMA.get(gate_key, (None, None))[1] == "true",
+                "memory_event_ledger_write_enabled must exist and default to true")
+        await _set_ledger_gate(True)
+        open_sid = "w203-gate-open"
+        await database.append_turn_events_atomic(open_sid, "u", "a", "m", turn_key="tk")
+        rows = await _ledger_rows(open_sid)
+        require(len(rows) == 2, f"gate-open path must write exactly 2 rows, got {len(rows)} (double write?)")
+        passed("T-W2-03-6 the open gate writes one atomic pair, never a doubled turn")
+
+        source = (ROOT / "database.py").read_text(encoding="utf-8")
+        legacy_sql = re.search(r"async def save_message\(.*?\n\n", source, re.S)
+        require(legacy_sql, "save_message not found for the static legacy-SQL guard")
+        body = legacy_sql.group(0)
+        for forbidden in ("project_id", "scope_known", "usage", "turn_id", "turn_key"):
+            require(forbidden not in body,
+                    f"save_message must stay byte-compatible; it now mentions {forbidden}")
+        passed("T-W2-03-7 the closed-gate path keeps save_message free of the new columns")
+    finally:
+        if gate_had_row:
+            await _upsert_config(gate_key, gate_previous)
+        else:
+            await _pool_execute("DELETE FROM gateway_config WHERE key = $1", gate_key)
+
+    # ---- 8/9/10. regenerate ------------------------------------------------
+    await _truncate("conversations")
+    regen_sid = "w203-regen"
+    await database.append_turn_events_atomic(regen_sid, "u1", "a1", "m", turn_key="k1")
+    before = await _ledger_rows(regen_sid)
+    target_turn = before[0]["id"]
+    result = await database.append_turn_events_atomic(
+        regen_sid, "u1", "a1-regenerated", "m", turn_key=None, is_regenerate=True
+    )
+    require(result.get("ok") is True, f"regenerate failed: {result!r}")
+    rows = await _ledger_rows(regen_sid)
+    require(len(rows) == 2, f"regenerate must replace, not append: {len(rows)} rows")
+    require(rows[0]["id"] == before[0]["id"], "regenerate must not touch the user row")
+    require(rows[1]["content"] == "a1-regenerated", "regenerate did not replace the assistant body")
+    require(rows[1]["turn_id"] == target_turn, "regenerated assistant lost its turn anchor")
+    passed("T-W2-03-8 keyless regenerate replaces the newest assistant of the newest turn")
+
+    # historical key -> abandon, unknown key -> abandon; the old assistant survives both
+    await _truncate("conversations")
+    await database.append_turn_events_atomic(regen_sid, "u1", "a1", "m", turn_key="k1")
+    await database.append_turn_events_atomic(regen_sid, "u2", "a2", "m", turn_key="k2")
+    for bad_key, label in (("k1", "historical"), ("k-nope", "unknown")):
+        capture = io.StringIO()
+        with redirect_stdout(capture):
+            result = await database.append_turn_events_atomic(
+                regen_sid, "u2", "should-not-land", "m", turn_key=bad_key, is_regenerate=True
+            )
+        require(result.get("ok") is False,
+                f"{label} turn_key regenerate must be abandoned, got {result!r}")
+        rows = await _ledger_rows(regen_sid)
+        require(len(rows) == 4, f"{label} key regenerate changed the ledger: {len(rows)} rows")
+        require(rows[-1]["content"] == "a2",
+                f"{label} key regenerate destroyed the newest assistant")
+        require(any(ln.startswith("event=regen_target_invalid ") for ln in capture.getvalue().splitlines()),
+                f"{label} key abandon did not emit regen_target_invalid: {capture.getvalue()!r}")
+    passed("T-W2-03-9 regenerate abandons on historical or unknown turn_key and keeps the old reply")
+
+    # mixed era: gate-off rows (turn_id NULL) must survive a new-turn regenerate
+    await _truncate("conversations")
+    mix_sid = "w203-mixed"
+    await _pool_execute(
+        "INSERT INTO conversations (session_id, role, content, model) VALUES "
+        "($1,'user','legacy-u','m'), ($1,'assistant','legacy-a','m')", mix_sid
+    )
+    await database.append_turn_events_atomic(mix_sid, "new-u", "new-a", "m", turn_key="mk")
+    await database.append_turn_events_atomic(
+        mix_sid, "new-u", "new-a-regen", "m", is_regenerate=True
+    )
+    rows = await _ledger_rows(mix_sid)
+    legacy_bodies = [r["content"] for r in rows if r["turn_id"] is None]
+    require(legacy_bodies == ["legacy-u", "legacy-a"],
+            f"mixed-era regenerate damaged the gate-off rows: {legacy_bodies}")
+    require([r["content"] for r in rows if r["turn_id"] is not None] == ["new-u", "new-a-regen"],
+            f"mixed-era regenerate did not replace within its own turn: {[r['content'] for r in rows]}")
+    passed("T-W2-03-10 mixed-era regenerate stays inside its own turn branch")
+
+
+async def test_w2_03_scope_and_order() -> None:
+    """T-W2-03-12, 16(pure), 17, 18, 19: scope authority, usage shape, observability, read order."""
+    # ---- 12. authority table, row by row -----------------------------------
+    await _truncate("conversations", "chat_conversations", "chat_projects")
+    await _pool_execute("INSERT INTO chat_projects (id, name) VALUES ('w203-p-live', 'live')")
+    await _pool_execute(
+        "INSERT INTO chat_conversations (id, title, project_id) VALUES "
+        "('w203-c-live','c','w203-p-live'), ('w203-c-dead','c','w203-p-gone'), ('w203-c-null','c',NULL)"
+    )
+
+    async def scope_of(sid, **kwargs):
+        capture = io.StringIO()
+        with redirect_stdout(capture):
+            await database.append_turn_events_atomic(sid, "u", "a", "m", **kwargs)
+        row = (await _ledger_rows(sid))[0]
+        codes = {ln.split()[0].split("=", 1)[1]
+                 for ln in capture.getvalue().splitlines() if ln.startswith("event=scope_")}
+        return row["scope_known"], row["project_id"], codes
+
+    # row 1: metadata wins even when payload disagrees
+    known, pid, codes = await scope_of("w203-c-live", client_gave_conv_id=True,
+                                       project_id_present=True, payload_project_id="w203-p-other")
+    require((known, pid) == (True, "w203-p-live"),
+            f"row 1: metadata must win, got {(known, pid)}")
+    require("scope_mismatch" in codes, f"row 1 must emit scope_mismatch, got {codes}")
+    # row 2: project deleted -> keep the historical attribution, never global
+    known, pid, codes = await scope_of("w203-c-dead", client_gave_conv_id=True)
+    require((known, pid) == (True, "w203-p-gone"),
+            f"row 2: deleted project keeps TRUE + original id, got {(known, pid)}")
+    require("scope_project_missing" in codes, f"row 2 must emit scope_project_missing, got {codes}")
+    # row 3: metadata says global
+    known, pid, _ = await scope_of("w203-c-null", client_gave_conv_id=True)
+    require((known, pid) == (True, None), f"row 3: metadata NULL means global, got {(known, pid)}")
+    # row 4/5: only a server-generated session may trust the payload
+    known, pid, _ = await scope_of("w203-gen-null", client_gave_conv_id=False,
+                                   project_id_present=True, payload_project_id=None)
+    require((known, pid) == (True, None), f"row 4: explicit null is trusted, got {(known, pid)}")
+    known, pid, codes = await scope_of("w203-gen-proj", client_gave_conv_id=False,
+                                       project_id_present=True, payload_project_id="w203-p-live")
+    require((known, pid) == (True, "w203-p-live"), f"row 5: payload trusted, got {(known, pid)}")
+    require("scope_payload_trusted" in codes, f"row 5 must emit scope_payload_trusted, got {codes}")
+    # row 6: client supplied a conversation_id but metadata is missing -> never trust payload
+    known, pid, codes = await scope_of("w203-c-missing", client_gave_conv_id=True,
+                                       project_id_present=True, payload_project_id="w203-p-live")
+    require((known, pid) == (False, None),
+            f"row 6: unverified session must stay FALSE+NULL regardless of payload, got {(known, pid)}")
+    require("scope_unverified" in codes, f"row 6 must emit scope_unverified, got {codes}")
+    # row 7: absent key on a generated session stays unknown
+    known, pid, _ = await scope_of("w203-gen-absent", client_gave_conv_id=False)
+    require((known, pid) == (False, None), f"row 7: absent key stays unknown, got {(known, pid)}")
+    known, pid, codes = await scope_of("w203-gen-blank", client_gave_conv_id=False,
+                                       project_id_present=True, payload_project_id="")
+    require((known, pid) == (False, None), f"row 7: blank payload stays unknown, got {(known, pid)}")
+    require("scope_unverified" in codes, f"row 7 blank must emit scope_unverified, got {codes}")
+    passed("T-W2-03-12 the scope authority table holds row by row against a real database")
+
+    # ---- 16 (pure half). usage normalization shapes ------------------------
+    normalize = app_module._normalize_usage_for_storage
+    require(normalize({"prompt_tokens": 7, "completion_tokens": 2,
+                       "prompt_tokens_details": {"cached_tokens": 5}})
+            == {"prompt": 7, "completion": 2, "cached": 5}, "OpenAI usage shape mis-normalized")
+    require(normalize({"input_tokens": 9, "output_tokens": 3, "cache_read_input_tokens": 1})
+            == {"prompt": 9, "completion": 3, "cached": 1}, "Anthropic usage shape mis-normalized")
+    for empty in (None, "", [], {}, 0):
+        require(normalize(empty) is None, f"non-dict usage must normalize to None: {empty!r}")
+    # Counted once, together with the streaming half, as T-W2-03-16.
+
+    # ---- 17. observability sentinels ---------------------------------------
+    await _truncate("conversations", "chat_conversations", "chat_projects")
+    obs_sid = f"W2_03_OBS_SID_{uuid.uuid4().hex}"
+    obs_pid = f"W2_03_OBS_PID_{uuid.uuid4().hex}"
+    await _pool_execute("INSERT INTO chat_projects (id, name) VALUES ($1, 'obs')", obs_pid)
+    await _pool_execute(
+        "INSERT INTO chat_conversations (id, title, project_id) VALUES ($1, 'obs', $2)", obs_sid, obs_pid
+    )
+    out_cap, err_cap = io.StringIO(), io.StringIO()
+    with redirect_stdout(out_cap), redirect_stderr(err_cap):
+        await database.append_turn_events_atomic(
+            obs_sid, "u", "a", "m", client_gave_conv_id=True,
+            project_id_present=True, payload_project_id="w203-p-other",
+        )
+    logs = out_cap.getvalue() + err_cap.getvalue()
+    require(obs_sid not in logs, "observability leaked the session id")
+    require(obs_pid not in logs, "observability leaked the project id")
+    events = [ln.strip() for ln in logs.splitlines() if ln.startswith("event=scope_mismatch ")]
+    require(events, f"scope_mismatch event missing: {logs!r}")
+    require(all("increment=" in e for e in events), f"scope event lost increment: {events}")
+    passed("T-W2-03-17 scope observability keeps counters and drops session/project IDs")
+
+    # ---- 18. turn_key must never be joined across tables --------------------
+    db_source = (ROOT / "database.py").read_text(encoding="utf-8")
+    joined = re.findall(r"JOIN[^;]{0,200}turn_key|turn_key[^;]{0,200}JOIN", db_source, re.I)
+    require(not joined, f"turn_key appears in a JOIN: {joined[:1]}")
+    require(db_source.count("同名不同义") >= 2,
+            "both turn_key columns must carry the same-name-different-meaning warning")
+    passed("T-W2-03-18 the two turn_key columns stay unjoined and both warn in place")
+
+    # ---- 19. deterministic read order on tied timestamps --------------------
+    await _truncate("conversations")
+    tie_sid = "w203-tie"
+    tied = "2026-05-05 05:05:05+00"
+    await _pool_execute(
+        "INSERT INTO conversations (session_id, role, content, model, created_at) VALUES "
+        "($1,'user','u-first','m',$2::timestamptz), "
+        "($1,'assistant','a-second','m',$2::timestamptz), "
+        "($1,'assistant','a-third','m',$2::timestamptz)",
+        tie_sid, tied,
+    )
+    recent = await database.get_recent_messages(tie_sid, limit=10)
+    require([r["content"] for r in recent] == ["u-first", "a-second", "a-third"],
+            f"get_recent_messages is unstable on tied timestamps: {[r['content'] for r in recent]}")
+    await database.delete_latest_assistant_message(tie_sid)
+    left = [r["content"] for r in await _ledger_rows(tie_sid)]
+    require(left == ["u-first", "a-second"],
+            f"delete_latest_assistant_message removed the wrong tied row: {left}")
+    passed("T-W2-03-19 ledger readers break timestamp ties by id, deterministically")
+
+
+async def test_w2_03_entry_and_panel(client: httpx.AsyncClient) -> None:
+    """T-W2-03-11, 23, 24, 25: request-entry validation, project turns, panel wiring, CORS."""
+    # ---- 11. turn_key entry validation -------------------------------------
+    # Rejections happen while parsing the body, before any upstream call, so no
+    # model boundary is exercised here.
+    for bad, label in ((["x"], "list"), ({"a": 1}, "dict"), (7, "int"),
+                       ("", "empty"), ("   ", "blank"), ("k" * 201, "201 chars")):
+        response = await client.post("/v1/chat/completions", json={
+            "model": "mock-model", "stream": False, "turn_key": bad,
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+        require(response.status_code == 400,
+                f"explicit invalid turn_key ({label}) must be 400, got {response.status_code}")
+    passed("T-W2-03-11 explicitly invalid turn_key is rejected at the request entry")
+
+    # ---- 23. project turns keep their scope and still skip extraction -------
+    await _truncate("conversations", "chat_conversations", "chat_projects")
+    await _pool_execute("INSERT INTO chat_projects (id, name) VALUES ('w203-proj', 'p')")
+    await _pool_execute(
+        "INSERT INTO chat_conversations (id, title, project_id) VALUES ('w203-proj-c','c','w203-proj')"
+    )
+    await database.append_turn_events_atomic(
+        "w203-proj-c", "u", "a", "m", client_gave_conv_id=True, turn_key="pk"
+    )
+    rows = await _ledger_rows("w203-proj-c")
+    require(len(rows) == 2, f"project turn must still land two ledger rows, got {len(rows)}")
+    require(all(r["scope_known"] is True and r["project_id"] == "w203-proj" for r in rows),
+            f"project turn lost its scope: {[(r['scope_known'], r['project_id']) for r in rows]}")
+    require(not await _pool_fetchval(
+        "SELECT EXISTS(SELECT 1 FROM conversations WHERE session_id = 'w203-proj-c' "
+        "AND scope_known = TRUE AND project_id IS NULL)"),
+        "a project turn must never satisfy the global scope condition")
+    passed("T-W2-03-23 project turns carry their scope and stay out of the global pool")
+
+    # ---- 24. both gates are registered on both sides and settable ----------
+    schema_js = (ROOT / "admin-panel" / "js" / "config-schema.js").read_text(encoding="utf-8")
+    for key in ("memory_event_ledger_write_enabled", "session_identity_v2_enabled"):
+        require(key in config.CONFIG_SCHEMA, f"{key} is missing from the backend registry")
+        require(re.search(rf"\b{key}\s*:", schema_js),
+                f"{key} is missing from config-schema.js CONFIG_META (the panel would not show it)")
+        require(re.search(rf"['\"]{key}['\"]", schema_js.split("CONFIG_PAGES")[-1]),
+                f"{key} is registered but never placed in a CONFIG_PAGES group")
+    gate_key = "memory_event_ledger_write_enabled"
+    had_row = await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM gateway_config WHERE key = $1)", gate_key)
+    previous = await _config_row(gate_key)
+    try:
+        response = await client.put(f"/admin/config/{gate_key}", json={"value": "false"})
+        require(response.status_code == 200, f"PUT /admin/config failed: {response.status_code}")
+        require(await config.get_config_bool(gate_key, True) is False,
+                "PUT /admin/config did not actually change the gate")
+        response = await client.put(f"/admin/config/{gate_key}", json={"value": "true"})
+        require(await config.get_config_bool(gate_key, False) is True, "gate could not be turned back on")
+    finally:
+        if had_row:
+            await _upsert_config(gate_key, previous)
+        else:
+            await _pool_execute("DELETE FROM gateway_config WHERE key = $1", gate_key)
+    passed("T-W2-03-24 both gates are dual-registered and settable through the admin endpoint")
+
+    # ---- 25. CORS actually exposes the session header ----------------------
+    response = await client.get("/", headers={"Origin": "http://kiwi.example"})
+    exposed = response.headers.get("access-control-expose-headers", "")
+    require("X-Kiwi-Session-Id" in exposed,
+            f"CORS does not expose X-Kiwi-Session-Id (browsers could not read it): {exposed!r}")
+    passed("T-W2-03-25 a real cross-origin response exposes X-Kiwi-Session-Id")
+
+
+def _fake_upstream(*, sse_events=None, json_body=None, status_code=200):
+    """Fake httpx.AsyncClient serving one canned upstream reply (streaming or not).
+
+    Only the surface main.py actually uses is implemented: async context manager,
+    .post() for the buffered path and .stream() for the streaming path.
+    """
+    class _Resp:
+        def __init__(self):
+            self.status_code = status_code
+            self.headers = {"content-type": "text/event-stream"}
+
+        def json(self):
+            return json_body or {"choices": [{"message": {"content": "a-body"}}], "model": "mock-model"}
+
+        @property
+        def text(self):
+            return json.dumps(self.json(), ensure_ascii=False)
+
+        async def aiter_bytes(self, chunk_size=None):
+            for event in (sse_events or []):
+                yield event if isinstance(event, bytes) else event.encode("utf-8")
+
+        async def aread(self):
+            return b""
+
+    class _StreamCtx:
+        async def __aenter__(self):
+            return _Resp()
+
+        async def __aexit__(self, *args):
+            return None
+
+    class _Client:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        def stream(self, *args, **kwargs):
+            return _StreamCtx()
+
+        async def post(self, *args, **kwargs):
+            return _Resp()
+
+    return _Client
+
+
+def _sse(payload: dict) -> str:
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+_DELTA = _sse({"choices": [{"delta": {"content": "hello"}, "finish_reason": None}], "model": "mock-model"})
+_USAGE_TAIL = _sse({"choices": [], "usage": {"prompt_tokens": 11, "completion_tokens": 5,
+                                             "prompt_tokens_details": {"cached_tokens": 2}}})
+
+
+async def _chat(client, body, *, sse_events=None, json_body=None, status_code=200):
+    """POST /v1/chat/completions against a canned upstream; returns the response."""
+    async def fake_resolve(_model):
+        return "http://127.0.0.1:9/mock-chat", "mock-key", "openai"
+
+    with (
+        patch.object(app_module.httpx, "AsyncClient",
+                     _fake_upstream(sse_events=sse_events, json_body=json_body, status_code=status_code)),
+        patch.object(database, "resolve_model_endpoint", fake_resolve),
+    ):
+        return await client.post("/v1/chat/completions", json=body)
+
+
+async def test_w2_03_chat_paths(client: httpx.AsyncClient) -> None:
+    """T-W2-03-13, 14, 15, 16b, 20, 21, 22: identity v2, ev_session, usage, layering."""
+    mem_key = "memory_enabled"
+    mem_had = await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM gateway_config WHERE key = $1)", mem_key)
+    mem_prev = await _config_row(mem_key)
+    id_key = "session_identity_v2_enabled"
+    id_had = await _pool_fetchval("SELECT EXISTS(SELECT 1 FROM gateway_config WHERE key = $1)", id_key)
+    id_prev = await _config_row(id_key)
+    try:
+        # Memory off for the whole block: proves the layering contract and keeps the
+        # embedding/extraction boundaries out of these guards entirely.
+        await _upsert_config(mem_key, "false")
+
+        # ---- 20. memory off still records events, never extracts ------------
+        await _truncate("conversations")
+        await _set_identity_gate(False)
+        response = await _chat(client, {
+            "model": "mock-model", "stream": False, "conversation_id": "w203-layer-a",
+            "messages": [{"role": "user", "content": "hi"}],
+        }, json_body={"choices": [{"message": {"content": "a-body"}}], "model": "mock-model"})
+        require(response.status_code == 200, f"buffered chat failed: {response.status_code} {response.text[:200]}")
+        rows = await _ledger_rows("w203-layer-a")
+        require(len(rows) == 2, f"memory-off chat must still write 2 ledger rows, got {len(rows)}")
+        require(await _pool_fetchval("SELECT COUNT(*) FROM memories") == 0,
+                "memory-off chat must not extract any memory")
+        passed("T-W2-03-20 with memory off the ledger still records the turn and nothing is extracted")
+
+        # ---- 21. internal requests write nothing ----------------------------
+        await _truncate("conversations")
+        response = await _chat(client, {
+            "model": "mock-model", "stream": False, "conversation_id": "w203-internal",
+            "skip_system_prompt": True,
+            "messages": [{"role": "user", "content": "summarize"}],
+        }, json_body={"choices": [{"message": {"content": "title"}}], "model": "mock-model"})
+        require(response.status_code == 200, "internal request failed")
+        require(not await _ledger_rows("w203-internal"),
+                "an internal request (skip_system_prompt) must not touch the ledger")
+        passed("T-W2-03-21 internal requests write neither events nor memories")
+
+        # ---- 13/22. session identity v2 -------------------------------------
+        await _truncate("conversations")
+        await _set_identity_gate(True)
+        seen = []
+        for _ in range(2):
+            response = await _chat(client, {
+                "model": "mock-model", "stream": False,
+                "messages": [{"role": "user", "content": "same opening line"}],
+            }, json_body={"choices": [{"message": {"content": "a"}}], "model": "mock-model"})
+            require(response.status_code == 200, "identity-v2 chat failed")
+            sid = response.headers.get("x-kiwi-session-id")
+            require(sid, "server-generated session must be returned in X-Kiwi-Session-Id")
+            seen.append(sid)
+        require(seen[0] != seen[1],
+                f"identical opening lines must not collapse into one session: {seen}")
+        require(all(s.startswith("auto-r-") and len(s) == len("auto-r-") + 32 for s in seen),
+                f"identity v2 must be auto-r- plus a full uuid4 hex: {seen}")
+        response = await _chat(client, {
+            "model": "mock-model", "stream": False, "conversation_id": "w203-own-id",
+            "messages": [{"role": "user", "content": "hi"}],
+        }, json_body={"choices": [{"message": {"content": "a"}}], "model": "mock-model"})
+        require("x-kiwi-session-id" not in response.headers,
+                "a client-supplied conversation_id must never be echoed back")
+        passed("T-W2-03-13 identity v2 gives distinct full-uuid sessions and never echoes client IDs")
+
+        await _set_identity_gate(False)
+        await _truncate("conversations")
+        for _ in range(2):
+            await _chat(client, {
+                "model": "mock-model", "stream": False,
+                "messages": [{"role": "user", "content": "same opening line"}],
+            }, json_body={"choices": [{"message": {"content": "a"}}], "model": "mock-model"})
+        legacy_sessions = {r["session_id"] for r in await _pool_fetch(
+            "SELECT DISTINCT session_id FROM conversations")}
+        require(len(legacy_sessions) == 1 and next(iter(legacy_sessions)).startswith("auto-"),
+                f"gate-off must fall back to the md5 session exactly: {legacy_sessions}")
+        require(not next(iter(legacy_sessions)).startswith("auto-r-"),
+                "gate-off must not use the v2 prefix")
+        passed("T-W2-03-22 with identity v2 off the legacy md5 session is restored byte for byte")
+
+        # ---- 14/15. ev_session contract on streams --------------------------
+        await _set_identity_gate(True)
+        await _truncate("conversations")
+        response = await _chat(client, {
+            "model": "mock-model", "stream": True,
+            "messages": [{"role": "user", "content": "stream me"}],
+        }, sse_events=[_DELTA, _USAGE_TAIL, "data: [DONE]\n\n"])
+        require(response.status_code == 200, "streaming chat failed")
+        require(response.headers.get("x-kiwi-session-id"), "stream response lost X-Kiwi-Session-Id")
+        events = [e for e in response.text.split("\n\n") if e.strip()]
+        ev_indexes = [i for i, e in enumerate(events) if '"ev_session"' in e]
+        require(len(ev_indexes) == 1, f"ev_session must appear exactly once per stream: {ev_indexes}")
+        require(ev_indexes[0] == 0, f"ev_session must precede every other stream event: {events[:2]}")
+        require(events[-1].strip() == "data: [DONE]", f"[DONE] must stay last: {events[-1]!r}")
+        payload = json.loads(events[0].split("data: ", 1)[1])
+        require(payload["ev_session"]["generated"] is True and payload["ev_session"]["id"],
+                f"ev_session payload malformed: {payload}")
+        passed("T-W2-03-14 ev_session is emitted once, first, and the header travels with the stream")
+
+        response = await _chat(client, {
+            "model": "mock-model", "stream": True,
+            "messages": [{"role": "user", "content": "upstream will fail"}],
+        }, sse_events=[], status_code=502)
+        require(response.headers.get("x-kiwi-session-id"),
+                "an upstream failure must still carry the retry identity (headers cannot be recalled)")
+        require('"ev_session"' in response.text,
+                "ev_session must still be present when the upstream fails")
+        bad = await client.post("/v1/chat/completions", json={
+            "model": "mock-model", "stream": True, "turn_key": "",
+            "messages": [{"role": "user", "content": "rejected before identity"}],
+        })
+        require(bad.status_code == 400, "entry validation must still reject before identity")
+        require("x-kiwi-session-id" not in bad.headers,
+                "a request rejected before identity generation must not carry a session header")
+        passed("T-W2-03-15 identity survives upstream failure but is absent on pre-identity 4xx")
+
+        # ---- 16b. usage aggregation across the stream -----------------------
+        await _truncate("conversations")
+        response = await _chat(client, {
+            "model": "mock-model", "stream": True, "conversation_id": "w203-usage",
+            "messages": [{"role": "user", "content": "count me"}],
+        }, sse_events=[_DELTA, _USAGE_TAIL, "data: [DONE]\n\n"])
+        require(response.status_code == 200, "usage stream failed")
+        rows = await _ledger_rows("w203-usage")
+        require(len(rows) == 2, f"usage stream must land a full turn: {len(rows)} rows")
+        require(json.loads(rows[1]["usage"]) == {"prompt": 11, "completion": 5, "cached": 2},
+                f"streamed usage was not captured/normalized: {rows[1]['usage']!r}")
+
+        await _truncate("conversations")
+        response = await _chat(client, {
+            "model": "mock-model", "stream": True, "conversation_id": "w203-nousage",
+            "messages": [{"role": "user", "content": "no usage block"}],
+        }, sse_events=[_DELTA, "data: [DONE]\n\n"])
+        rows = await _ledger_rows("w203-nousage")
+        require(rows and rows[1]["usage"] is None,
+                f"a stream without a usage block must store NULL: {rows[1]['usage'] if rows else 'no rows'!r}")
+        passed("T-W2-03-16 usage is normalized for both vendors and captured/NULL across streams")
+    finally:
+        for key, had, prev in ((mem_key, mem_had, mem_prev), (id_key, id_had, id_prev)):
+            if had:
+                await _upsert_config(key, prev)
+            else:
+                await _pool_execute("DELETE FROM gateway_config WHERE key = $1", key)
+
+
 async def run_suite(test_dsn: str) -> None:
     global database, config, app_module, memory_extractor
 
@@ -2243,6 +2887,10 @@ async def run_suite(test_dsn: str) -> None:
         await test_w1_01()
         await test_w2_01(client)
         await test_w2_02(client)
+        await test_w2_03_schema_and_atomic()
+        await test_w2_03_scope_and_order()
+        await test_w2_03_entry_and_panel(client)
+        await test_w2_03_chat_paths(client)
 
 
 async def async_main() -> int:
@@ -2258,12 +2906,14 @@ async def async_main() -> int:
         w1_08_passed = [name for name in PASSED if name.startswith("T-W1-08-")]
         w2_01_passed = [name for name in PASSED if name.startswith("T-W2-01-")]
         w2_02_passed = [name for name in PASSED if name.startswith("T-W2-02-")]
+        w2_03_passed = [name for name in PASSED if name.startswith("T-W2-03-")]
         print(f"\nPASS: {len(legacy_passed)} permanent S1-S6 behavior guards")
         print(f"PASS: {len(w1_01_passed)} W1-01 isolation/permanent guards")
         print(f"PASS: {len(w1_06_passed)} W1-06 calendar-delete atomicity guards")
         print(f"PASS: {len(w1_08_passed)} W1-08 calendar-period guards")
         print(f"PASS: {len(w2_01_passed)} W2-01 granular-sync guards")
         print(f"PASS: {len(w2_02_passed)} W2-02 message-identity/atomic-import guards")
+        print(f"PASS: {len(w2_03_passed)} W2-03 ledger-schema/scope/dark-write guards")
         print(f"PASS: {len(PASSED)} total permanent behavior guards")
         print("Real database path: disposable PostgreSQL verified")
         print("Real model/API path: not called; embedding/model/HTTP boundaries were mocked")

--- a/scripts/test_stream_capture.py
+++ b/scripts/test_stream_capture.py
@@ -115,7 +115,11 @@ async def fake_finalize(
     emotion_level,
     project_id,
     is_regenerate,
+    **ledger_kwargs,
 ):
+    # W2-03 扩了 _finalize_stream_memories 的关键字参数（record_events / extract_enabled /
+    # usage / ledger_ctx）。替身照单收下并记录，本脚本断言的仍是 W1-02 的流式合同：
+    # 何时 spawn、spawn 几次、正文捕获是否完整。
     FINALIZE_CALLS.append(
         {
             "mem_enabled": mem_enabled,
@@ -126,6 +130,7 @@ async def fake_finalize(
             "emotion_level": emotion_level,
             "project_id": project_id,
             "is_regenerate": is_regenerate,
+            **ledger_kwargs,
         }
     )
     return {"action": "skip"}


### PR DESCRIPTION
## 范围

给事件账本 `conversations` 补上项目、轮次、用量三重身份；一轮写入变单事务原子；聊天记录与记忆提取分层解耦；废除短 hash 会话合并（独立开关默认关）。基线 `main@8652d9c`。

## 实现

**schema** — `conversations` 增 `project_id / scope_known / usage / turn_id / turn_key`，全部 `ADD COLUMN IF NOT EXISTS`，零存量改写；`scope_known NOT NULL DEFAULT FALSE` 让存量行永久留白。`memory_extraction_state` 建表（本票零读写，接线留 W2-07）。三态语义与 `turn_key` 同名不同义警告写进 schema 段注释。

**原子写入** — `append_turn_events_atomic`：单连接单事务 `INSERT user` → 用其自身 id 锚定 `turn_id` → `INSERT assistant`。任一步失败整体回滚；异常不外抛，只记 `ledger_write_failed`（`path` + `code=write_failed` + `exception_type`，无正文无标识）。

**regenerate** — 先定目标再动手：取最新 user 事件定轮；带 `turn_key` 时在同事务内解析，指向非最新轮或查无一律放弃并计 `regen_target_invalid`；`turn_id` 非空与 legacy NULL 两分支**互斥禁 OR 混选**；删除走子查询精确选 id。**替换进来的 assistant 的 `turn_id / turn_key / scope_known / project_id` 一律继承目标 user**，当前 scope 判定只在没有目标 user 可继承的 orphan 分支兜底——否则旧客户端不带 `turn_key` 重生成会让 user 的 `k1` 配上 assistant 的 `NULL`，会话移进/移出项目后重生成会让同一轮变成「问题在全局、回答在项目」，W2-06 按 scope 消费时该轮被撕成两半。

**权威 scope** — 七行表，判定与写入同一事务快照：metadata 优先于 payload；项目已删仍保 `TRUE + 原 ID`；只有服务端自己生成 session 的请求才可采信 payload；客户端给了 `conversation_id` 但 metadata 查无 → 一律 `FALSE+NULL`。

**读序确定性** — 三个账本读者一律加 `id` 决胜。PG 同事务 `NOW()` 恒定，原子写入的同轮两行时间戳完全相同。

**分层与入口** — `record_events = not skip_prompt`、`extract_enabled = mem_enabled and not skip_prompt`；`turn_key` 缺键放行，显式非法一律 400。

**身份 v2（默认关）** — `auto-r-` + 完整 uuid4，响应头 `X-Kiwi-Session-Id` 与流内 `ev_session` 回传；客户端自带 `conversation_id` 零回显。语义是「重试时继续使用的会话身份」，故上游失败仍回传，身份生成前的 4xx 不带。`ev_session` 每流恰一次且位于所有流内事件之前；CORS `expose_headers` 放行该头。

**usage** — 转发流按 SSE 事件捕获、工具循环按轮累加（D1 聚合），断连落 NULL。归一化落在 `database.py` 作单一事实源并**幂等**。**Anthropic 口径**：`input_tokens` 不含缓存，总输入须加 `cache_creation_input_tokens + cache_read_input_tokens`（官方计费定义），`cached` 只记读命中；OpenAI 的 `prompt_tokens` 已含 cached，走另一分支不重复累加。工具循环在 `from_anthropic_response()` 之前归一化原始 usage，拿到的正是 Anthropic 形状，漏加会让开了 prompt cache 的多轮工具聊天持续少记。

**闸门** — 两键在 `config.py` 与 `admin-panel/js/config-schema.js` 双登记，编排进网关页新分组「兼容与回退」。

| 开关 | 默认 | 开 | 关 |
|---|---|---|---|
| `memory_event_ledger_write_enabled` | true | 原子函数全量新列 | 旧两次 `save_message` 全默认 |
| `session_identity_v2_enabled` | false | `auto-r-` + 全 UUID + 回传 | md5 原样 |

## 证据

| 项 | 值 |
|---|---|
| 基线 | `main@8652d9c6cee77fd1f3d9b1c87dd2b283d5215297` |
| tests-only 红证 head | `a420f2604b8d0e4720990f06ebad394a51a18789` |
| 实现 head | `2a483133e15ce939932afc0bcde6490ad4bb75d2` |
| 守卫补强 head | `2d210fcc4cdcae233bdd2acea4d47292da46c49d` |
| **终审整改 head** | **`7c230180e78a542a7f7b26a254be232dd018c3ed`** |
| 修复前 PG16 CI | Run [`31816384070`](https://github.com/LucieEveille/kiwi-mem/actions/runs/31816384070) — **failure** |
| 实现 PG16 CI | Run [`31817720990`](https://github.com/LucieEveille/kiwi-mem/actions/runs/31817720990) — success |
| 守卫补强 PG16 CI | Run [`31818047972`](https://github.com/LucieEveille/kiwi-mem/actions/runs/31818047972) — success |
| **终审整改 PG16 CI** | Run [`31882891918`](https://github.com/LucieEveille/kiwi-mem/actions/runs/31882891918) — **success** |
| 守卫计数 | 既有 82 + W2-03 **25** = **107** 条永久真库守卫全绿 |
| diff | 6 文件，1277 insertions / 25 deletions |

**修复前红证**：既有回归步骤 success、守卫步骤 failure；既有 82 条守卫全部 PASS 后，精确失败于
`AssertionError: W2-03 conversations columns missing: ['project_id', 'scope_known', 'turn_id', 'turn_key', 'usage']`。

**修复后**：`[PG16 真库]` CI 全绿；`[本地 PG16.13 真库]` 107 条守卫 + 12 套既有回归全绿；`[静态]` `compileall` 与 `git diff --check` 通过。`[真实供应商]` 未调用。`[生产部署]` N/A。

## 终审整改（`2d210fc` → `7c23018`）

| 问题 | 处置 |
|---|---|
| 重生成拆散同一轮身份 | replacement assistant 继承目标 user 的 `turn_id / turn_key / scope_known / project_id`；当前判定退为 orphan 兜底 |
| Anthropic 缓存输入少记 | 总输入按官方口径加 cache creation + read；`cached` 仍只记读命中；OpenAI 分支不重复累加；幂等保持 |
| `T-23` 空心 | 改走 `process_memories_background`，记忆开启且用户消息带主动记忆触发词，断言短路动作 + 账本两行与 scope + `memories` 零新增 |

`T-16` 原先把少记结果写成了期望值，已改用三个互不相同的数值（9 / 40 / 100 → 149），漏任何一项都凑不出正确和；另补 read-only、无缓存、幂等、多轮聚合四组，以及一条让 Anthropic 形状真正流经工具路径落库的端到端用例。

Gateway 同名归一化 helper 有相同口径缺口，其主路径先经 Anthropic adapter、影响面不同，按终审意见另挂反向核查票，本 PR 不跨仓修改。

## 负向变异（16 + 3 = 19 把，全部杀死，均未提交）

**终审整改轮**

| 刀 | 红点 |
|---|---|
| regenerate 改回用当前判定 | `T-8`：replacement assistant must inherit the user's turn_key, got None |
| Anthropic 漏加 cache creation/read | `T-16`：Anthropic prompt must add cache creation and cache read |
| 删掉项目跳过提取分支 | `T-23`：got `{'action': 'extract', ...}`（证明守卫确实进入了提取流程） |

**主体轮 16 把**

| # | 刀 | 红点 |
|---|---|---|
| 1 | 去掉原子函数外层事务 | `T-5`：half-written turn survived |
| 2 | 身份 v2 开着却回退 md5 | `T-13` |
| 3 | scope 改信 payload 旁路 metadata | `T-12`：row 1 metadata must win |
| 4 | 缺键路径落 TRUE | `T-12`：row 7 absent key stays unknown |
| 5 | 行 6 改信 payload | `T-12`：row 6 must stay FALSE+NULL |
| 6 | 工具路径不再聚合 usage | `T-16` |
| 7 | `turn_key` 跨表联查 | `T-18` |
| 8 | 闸门开时同时走旧两次写入 | `T-6`：got 4 rows |
| 9 | 观测事件附带 session_id | `T-17` |
| 10 | 读序去掉 id 决胜 | `T-19`（加强后） |
| 11 | regenerate 先删后定 | `T-9` |
| 12 | regenerate 恢复 OR 混选 | `T-10`（修正后） |
| 13 | 非法 `turn_key` 静默转 None | `T-11`：must be 400, got 500 |
| 14 | `save_message` 偷加新列 | `T-7` |
| 15 | 分层退回单一 mem 门 | `T-20`：got 0 rows |
| 16 | 前端登记撤除一键 | `T-24` |

主体轮首跑有 2 把存活（刀 10、刀 12），原因是守卫检测力不足而非实现正确：`T-19` 原先只有行为断言，小表上 PG 顺序扫描恰好按物理（=插入=id）顺序返回；`T-10` 原先把关闸行造在新轮之前，OR 合并后按时间倒序选出的仍是新轮那条。两处均**加强守卫**、合同未放宽、生产实现未改，加强后两把刀精准变红。全程无「红点被既有守卫抢走」的情形。

## 数据影响与回滚

零存量改写、metadata-only DDL。代码＝revert；账本行为＝关 `memory_event_ledger_write_enabled`（面板或 `PUT /admin/config/{key}`）；身份＝关 `session_identity_v2_enabled`（默认即关）；schema 留置。

## 非范围

不切消费者；不动 `_conversation_counter`；`memory_extraction_state` 零读写；**`save_message` 签名与 SQL 一字未动**；不动 chat_messages / sync 通道、提取跳过逻辑、prompt 组装/缓存断点/tools；不做 backfill；前端采纳 `ev_session` 另票；不发版；Gateway 归一化口径另票。

`scripts/test_stream_capture.py` 的替身接受新增关键字参数并记录，断言的仍是 W1-02 的流式合同——签名扩展导致的替身适配，非行为变更。

## 诚实边界

① 关记忆的聊天将进入账本，`get_recent_conversation` 可见素材变全；② 身份 v2 开启后未采纳回传的第三方会每轮断 OpenRouter 黏性与抽屉状态——默认关的理由；③ 关闸期写入与存量同池；④ `memory_extraction_state` 本票是死表；⑤ 跨轮 usage 以捕获到的轮为准；⑥ 项目对话首轮常处于 `chat_conversations` 尚未同步的窗口，按行 6 落 `FALSE`，W2-05 可回填；⑦ 流式上游失败时已发出的身份头收不回，语义上也不该收回。

保持 Draft，未经露露授权不转 Ready、不合并。