### PR TITLE
W2-04.1: narrow delete-privacy backfill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: 票 C 十刀变异账（一次性证据）
         env:
           KIWI_KNIFE_DSN: postgresql://postgres:postgres@127.0.0.1:5432/postgres
-          KIWI_KNIFE_SHA: ${{ github.event.pull_request.head.sha }}
+          KIWI_KNIFE_SHA: ${{ github.sha }}
           KIWI_KNIFE_OUT: ${{ runner.temp }}/ticket-c-knife-results.json
         run: >-
           python scripts/w2_04_knives.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,24 @@ jobs:
 
       - name: 运行 S1-S6 永久真库行为守卫
         run: python scripts/test_kiwi_safety_sync.py
+
+      # Ticket C one-shot evidence step. This commit is reverted after the
+      # mutation JSON is downloaded; the final PR does not retain this cost.
+      - name: 票 C 十刀变异账（一次性证据）
+        env:
+          KIWI_KNIFE_DSN: postgresql://postgres:postgres@127.0.0.1:5432/postgres
+          KIWI_KNIFE_SHA: ${{ github.event.pull_request.head.sha }}
+          KIWI_KNIFE_OUT: ${{ runner.temp }}/ticket-c-knife-results.json
+        run: >-
+          python scripts/w2_04_knives.py
+          C-delete-stamps C-reset-stamps C-restore-metadata C-restore-unnamed
+          C-restore-handoff C-filter-outside-tx C-capability-schema
+          C-list-revision C-search-final C-reminder-source
+
+      - name: 上传票 C 十刀 JSON
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ticket-c-knife-results
+          path: ${{ runner.temp }}/ticket-c-knife-results.json
+          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,22 +74,3 @@ jobs:
 
       - name: 运行 S1-S6 永久真库行为守卫
         run: python scripts/test_kiwi_safety_sync.py
-
-      - name: 票 C 十二刀变异账（r1 返工一次性证据）
-        env:
-          KIWI_KNIFE_DSN: postgresql://postgres:postgres@127.0.0.1:5432/postgres
-          KIWI_KNIFE_SHA: ${{ github.sha }}
-          KIWI_KNIFE_OUT: ${{ runner.temp }}/ticket-c-r1-knife-results.json
-        run: >-
-          python scripts/w2_04_knives.py
-          C-delete-stamps C-reset-stamps C-restore-metadata C-restore-unnamed
-          C-restore-handoff C-filter-outside-tx C-capability-schema C-list-revision
-          C-search-final C-reminder-source C-gate-gates-stamps C-handoff-select-star
-
-      - name: 上传票 C 十二刀变异账
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ticket-c-r1-knife-results
-          path: ${{ runner.temp }}/ticket-c-r1-knife-results.json
-          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,24 +74,3 @@ jobs:
 
       - name: 运行 S1-S6 永久真库行为守卫
         run: python scripts/test_kiwi_safety_sync.py
-
-      # Ticket C one-shot evidence step. This commit is reverted after the
-      # mutation JSON is downloaded; the final PR does not retain this cost.
-      - name: 票 C 十刀变异账（一次性证据）
-        env:
-          KIWI_KNIFE_DSN: postgresql://postgres:postgres@127.0.0.1:5432/postgres
-          KIWI_KNIFE_SHA: ${{ github.sha }}
-          KIWI_KNIFE_OUT: ${{ runner.temp }}/ticket-c-knife-results.json
-        run: >-
-          python scripts/w2_04_knives.py
-          C-delete-stamps C-reset-stamps C-restore-metadata C-restore-unnamed
-          C-restore-handoff C-filter-outside-tx C-capability-schema
-          C-list-revision C-search-final C-reminder-source
-
-      - name: 上传票 C 十刀 JSON
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ticket-c-knife-results
-          path: ${{ runner.temp }}/ticket-c-knife-results.json
-          if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,22 @@ jobs:
 
       - name: 运行 S1-S6 永久真库行为守卫
         run: python scripts/test_kiwi_safety_sync.py
+
+      - name: 票 C 十二刀变异账（r1 返工一次性证据）
+        env:
+          KIWI_KNIFE_DSN: postgresql://postgres:postgres@127.0.0.1:5432/postgres
+          KIWI_KNIFE_SHA: ${{ github.sha }}
+          KIWI_KNIFE_OUT: ${{ runner.temp }}/ticket-c-r1-knife-results.json
+        run: >-
+          python scripts/w2_04_knives.py
+          C-delete-stamps C-reset-stamps C-restore-metadata C-restore-unnamed
+          C-restore-handoff C-filter-outside-tx C-capability-schema C-list-revision
+          C-search-final C-reminder-source C-gate-gates-stamps C-handoff-select-star
+
+      - name: 上传票 C 十二刀变异账
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ticket-c-r1-knife-results
+          path: ${{ runner.temp }}/ticket-c-r1-knife-results.json
+          if-no-files-found: error

--- a/admin-panel/js/config-schema.js
+++ b/admin-panel/js/config-schema.js
@@ -109,6 +109,7 @@ export const CONFIG_META = {
   // —— 兼容与回退（W2-03）——
   memory_event_ledger_write_enabled: { label:'事件账本原子写入', type:'bool', def:'true', input:'bool', desc:'开启后一轮对话作为单个事务写入事件账本，带上项目、轮次与用量身份，任一步失败整体回滚。关闭则退回旧的两次独立写入（新字段留空）。出问题时关掉即可回退，不需要发版。' },
   session_identity_v2_enabled: { label:'会话身份 v2', type:'bool', def:'false', input:'bool', desc:'前端没传对话 ID 时如何生成会话身份。关闭＝沿用「首条消息内容哈希」，同样的开场白会被并成同一段会话。开启＝改用随机 ID 并回传给前端，会话不再串线；但尚未采纳回传 ID 的第三方客户端会每轮换会话，工具抽屉状态与 OpenRouter 黏性路由会断。前端适配完成前保持关闭。' },
+  sync_delete_privacy_capability_enabled: { label:'同步删除隐私能力', type:'bool', def:'true', input:'bool', desc:'关闭后能力端点宣称 ready=false，客户端保持休眠；删除章、清理与迟到写保护仍然继续生效。' },
 
   // —— 联网搜索 ——
   search_engine:          { label:'搜索引擎', type:'text', def:'', input:'engine', desc:'联网搜索使用的引擎。' },
@@ -209,7 +210,7 @@ export const CONFIG_PAGES = {
     groups: [
       { title:'对话行为', desc:'网关转发对话时的行为：标题生成与思考强度。', keys:['default_title_model','prompt_title_summary','reasoning_effort'] },
       { title:'性能', keys:['prompt_cache_enabled','prompt_cache_ttl'] },
-      { title:'兼容与回退', desc:'出问题时可以立刻关掉的新行为开关，改完即时生效、无需发版。', keys:['memory_event_ledger_write_enabled','session_identity_v2_enabled'] },
+      { title:'兼容与回退', desc:'出问题时可以立刻关掉的新行为开关，改完即时生效、无需发版。', keys:['memory_event_ledger_write_enabled','session_identity_v2_enabled','sync_delete_privacy_capability_enabled'] },
     ],
   },
 };

--- a/config.py
+++ b/config.py
@@ -126,6 +126,7 @@ CONFIG_SCHEMA = {
     #        并把身份回传给客户端；关=沿用旧的首条文本 md5 短 hash。
     #        开启后未采纳回传的第三方客户端会每轮换 session，断 OpenRouter 黏性与抽屉状态。
     "session_identity_v2_enabled": ("",                  "false","会话身份 v2",       "bool"),
+    "sync_delete_privacy_capability_enabled": ("",       "true", "同步删除隐私能力",   "bool"),
 }
 
 

--- a/database.py
+++ b/database.py
@@ -66,6 +66,11 @@ def _get_embedding_url() -> str:
 
 _pool: Optional[asyncpg.Pool] = None
 
+# W2-04.1 capability readiness is process-local.  A database left over from an
+# earlier successful run can have every table while this process's migration
+# failed halfway through, so schema presence alone must never advertise ready.
+_w2_04_ready = False
+
 
 async def get_pool() -> asyncpg.Pool:
     global _pool
@@ -90,6 +95,8 @@ async def close_pool():
 # ============================================================
 
 async def init_tables():
+    global _w2_04_ready
+    _w2_04_ready = False
     pool = await get_pool()
     async with pool.acquire() as conn:
         await conn.execute("""
@@ -299,6 +306,7 @@ async def init_tables():
                 summary         TEXT,
                 dream_event     JSONB,
                 turn_key        TEXT,
+                reminder_source_id TEXT,
                 sort_order      INTEGER DEFAULT 0
             );
         """)
@@ -541,6 +549,7 @@ async def init_tables():
         for col_name, col_def in [
             ("dream_event", "JSONB"),
             ("turn_key", "TEXT"),
+            ("reminder_source_id", "TEXT"),
         ]:
             has_col = await conn.fetchval("""
                 SELECT EXISTS (
@@ -550,7 +559,7 @@ async def init_tables():
             """, col_name)
             if not has_col:
                 await conn.execute(f"ALTER TABLE chat_messages ADD COLUMN {col_name} {col_def}")
-                print(f"✅ chat_messages 表已添加 {col_name} 列（W2-02 消息身份）")
+                print(f"✅ chat_messages 表已添加 {col_name} 列（消息身份同步）")
 
         # W2-03：事件账本 conversations 扩展 — 项目、轮次、用量三重身份。
         # 三态语义（scope_known 取代空串哨兵，与 memories.project_id IS NULL=全局 对齐）：
@@ -767,7 +776,37 @@ async def init_tables():
             await conn.execute("ALTER TABLE provider_models ADD COLUMN api_format TEXT DEFAULT NULL")
             print("✅ provider_models 表已添加 api_format 列（模型级覆盖）")
 
+    _w2_04_ready = True
     print("✅ 数据库表结构已就绪（v6.2b 模型级 API 格式支持）")
+
+
+def w2_04_initialized() -> bool:
+    """Whether this process completed the full database initialization path."""
+    return _w2_04_ready
+
+
+async def probe_w2_04_schema() -> bool:
+    """Read-only W2-04.1 schema probe used by the capability endpoint."""
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        return bool(await conn.fetchval("""
+            SELECT
+                to_regclass('session_tombstones') IS NOT NULL
+                AND to_regclass('turn_tombstones') IS NOT NULL
+                AND to_regclass('message_tombstones') IS NOT NULL
+                AND to_regclass('session_source_rev') IS NOT NULL
+                AND to_regclass('deletion_epoch') IS NOT NULL
+                AND EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'conversations'
+                      AND column_name = 'source_message_id'
+                )
+                AND EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_name = 'chat_messages'
+                      AND column_name = 'reminder_source_id'
+                )
+        """))
 
 
 # ============================================================
@@ -1235,6 +1274,47 @@ async def _stamp_session_tx(conn, session_id: str) -> None:
         "INSERT INTO session_tombstones (session_id) VALUES ($1) ON CONFLICT DO NOTHING",
         session_id,
     )
+
+
+async def _stamp_visible_messages_tx(conn, session_id: str) -> dict:
+    """Stamp every currently visible message id and turn key for one session.
+
+    The front-end snapshot and the immutable event ledger are separate copies.
+    A ledger row may already exist before Chat has uploaded the matching
+    ``chat_messages`` row, so deletion must take the non-empty union of both.
+    The two set-based statements keep the lock window independent of message
+    count and run inside the caller's existing transaction.
+    """
+    messages = await conn.execute("""
+        INSERT INTO message_tombstones (session_id, message_id)
+        SELECT $1, visible.message_id
+        FROM (
+            SELECT id AS message_id
+            FROM chat_messages
+            WHERE conversation_id = $1 AND NULLIF(BTRIM(id), '') IS NOT NULL
+            UNION
+            SELECT source_message_id AS message_id
+            FROM conversations
+            WHERE session_id = $1
+              AND NULLIF(BTRIM(source_message_id), '') IS NOT NULL
+        ) AS visible
+        ON CONFLICT DO NOTHING
+    """, session_id)
+    turns = await conn.execute("""
+        INSERT INTO turn_tombstones (session_id, turn_key)
+        SELECT $1, visible.turn_key
+        FROM (
+            SELECT turn_key
+            FROM chat_messages
+            WHERE conversation_id = $1 AND NULLIF(BTRIM(turn_key), '') IS NOT NULL
+            UNION
+            SELECT turn_key
+            FROM conversations
+            WHERE session_id = $1 AND NULLIF(BTRIM(turn_key), '') IS NOT NULL
+        ) AS visible
+        ON CONFLICT DO NOTHING
+    """, session_id)
+    return {"messages": _rowcount(messages), "turns": _rowcount(turns)}
 
 
 def _rowcount(status) -> int:
@@ -1795,6 +1875,7 @@ async def reset_all_chat_data(sync_setting_keys=()) -> dict:
             )
             session_ids = [r["session_id"] for r in rows if r["session_id"]]
             for session_id in session_ids:
+                await _stamp_visible_messages_tx(conn, session_id)
                 await _stamp_session_tx(conn, session_id)
                 await _bump_source_rev_tx(conn, session_id)
             generation = await conn.fetchval(
@@ -3537,9 +3618,12 @@ async def sync_get_conversations():
     pool = await get_pool()
     async with pool.acquire() as conn:
         rows = await conn.fetch("""
-            SELECT id, title, model, provider_model_id, project_id, pinned, sort_order, created_at, updated_at
-            FROM chat_conversations
-            ORDER BY pinned DESC, updated_at DESC
+            SELECT c.id, c.title, c.model, c.provider_model_id, c.project_id,
+                   c.pinned, c.sort_order, c.created_at, c.updated_at,
+                   COALESCE(r.rev, 0) AS source_rev
+            FROM chat_conversations c
+            LEFT JOIN session_source_rev r ON r.session_id = c.id
+            ORDER BY c.pinned DESC, c.updated_at DESC
         """)
         return [dict(r) for r in rows]
 
@@ -3721,6 +3805,7 @@ async def sync_delete_conversation(conv_id: str):
             # 换窗副本散在别的会话里；持 S 锁前先问候选目标，再按 ID 排序一起取锁。
             targets = await _handoff_target_sessions_tx(conn, conv_id)
             await _lock_sessions_exclusive(conn, [conv_id, *targets])
+            await _stamp_visible_messages_tx(conn, conv_id)
             await _stamp_session_tx(conn, conv_id)
             await _bump_source_rev_tx(conn, conv_id)
             handoff_purged = await _purge_handoff_copies_tx(conn, conv_id)
@@ -3752,7 +3837,7 @@ async def sync_delete_conversation(conv_id: str):
 
 
 def _message_content_values(msg: dict) -> list:
-    """装配 chat_messages 中 role..turn_key 的 22 个内容字段。
+    """装配 chat_messages 中 role..reminder_source_id 的 23 个内容字段。
 
     全量 import、legacy 全量替换与 W2-01 单消息 upsert 三条通道共用本函数，
     新增字段只在这里追加一次，避免通道之间出现字段分叉或默认值分叉。
@@ -3782,6 +3867,9 @@ def _message_content_values(msg: dict) -> list:
         _to_json(msg.get("dreamEvent") or msg.get("dream_event")),
         (msg.get("turnKey") if isinstance(msg.get("turnKey"), str)
          else msg.get("turn_key") if isinstance(msg.get("turn_key"), str) else None),
+        (msg.get("reminderSourceId") if isinstance(msg.get("reminderSourceId"), str)
+         else msg.get("reminder_source_id")
+         if isinstance(msg.get("reminder_source_id"), str) else None),
     ]
 
 
@@ -3790,12 +3878,12 @@ _MESSAGE_INSERT_SQL = """
         id, conversation_id, role, content, time, model,
         streaming, error, token_info, thinking, status_events, tool_events,
         memory_result, memory_event, handoff_info, web_search_results, versions, version_index,
-        images, attachments, usage, summary, dream_event, turn_key, sort_order
+        images, attachments, usage, summary, dream_event, turn_key, reminder_source_id, sort_order
     ) VALUES (
         $1, $2, $3, $4, $5, $6,
         $7, $8, $9, $10, $11, $12,
         $13, $14, $15, $16, $17, $18,
-        $19, $20, $21, $22, $23, $24, $25
+        $19, $20, $21, $22, $23, $24, $25, $26
     )
 """
 
@@ -3916,7 +4004,46 @@ async def _filter_stamped_messages_tx(conn, conv_id: str, messages: list):
     return kept, skipped
 
 
-async def _restore_conversation_tx(conn, conv: dict, messages: list) -> None:
+def _is_sourceless_handoff_divider(msg: dict) -> bool:
+    """Match the startup SQL's definition of an untraceable handoff card."""
+    if not isinstance(msg, dict) or (msg.get("role") or "") != "divider":
+        return False
+    if "handoffInfo" in msg:
+        raw = msg.get("handoffInfo")
+    elif "handoff_info" in msg:
+        raw = msg.get("handoff_info")
+    else:
+        return False
+    if raw is None:
+        return False
+    decoded = raw
+    if isinstance(raw, str):
+        try:
+            decoded = json.loads(raw)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return True
+    if not isinstance(decoded, dict):
+        return True
+    source_id = decoded.get("sourceId")
+    if source_id is None:
+        return True
+    if isinstance(source_id, str):
+        return not source_id.strip()
+    # PostgreSQL JSONB ->> renders every non-null value as non-empty text.
+    return not str(source_id).strip()
+
+
+def _drop_sourceless_handoffs(messages: list) -> tuple:
+    kept, dropped = [], 0
+    for message in messages:
+        if _is_sourceless_handoff_divider(message):
+            dropped += 1
+        else:
+            kept.append(message)
+    return kept, dropped
+
+
+async def _restore_conversation_tx(conn, conv: dict, messages: list) -> int:
     """从用户明确选择的备份文件恢复一段对话——**全仓唯一撤章处**。
 
     理念：恢复备份是用户明确的「把它带回来」；对话 POST、legacy PUT、/sync/import
@@ -3937,6 +4064,9 @@ async def _restore_conversation_tx(conn, conv: dict, messages: list) -> None:
     session_id = str(conv.get("id", ""))
     await _lock_global_shared(conn)
     await _lock_session(conn, session_id)
+    filtered_count = 0
+    if messages is not None:
+        messages, filtered_count = _drop_sourceless_handoffs(messages)
     await conn.execute("DELETE FROM session_tombstones WHERE session_id = $1", session_id)
     if messages:
         named_ids = [str(m.get("id")) for m in messages if m.get("id")]
@@ -3958,14 +4088,15 @@ async def _restore_conversation_tx(conn, conv: dict, messages: list) -> None:
     # 旧正文就留在库里了。
     if messages is not None:
         await _replace_messages_tx(conn, session_id, messages)
+    return filtered_count
 
 
-async def restore_conversation_from_backup(conv: dict, messages: list) -> None:
+async def restore_conversation_from_backup(conv: dict, messages: list) -> int:
     """备份恢复的公开入口：一段对话一个事务，原子完成撤章与重建。"""
     pool = await get_pool()
     async with pool.acquire() as conn:
         async with conn.transaction():
-            await _restore_conversation_tx(conn, conv, messages)
+            return await _restore_conversation_tx(conn, conv, messages)
 
 
 def _handoff_divider_source(msg: dict):
@@ -4058,12 +4189,13 @@ async def sync_upsert_single_message(conv_id: str, msg_id: str, msg: dict):
                     id, conversation_id, role, content, time, model,
                     streaming, error, token_info, thinking, status_events, tool_events,
                     memory_result, memory_event, handoff_info, web_search_results, versions, version_index,
-                    images, attachments, usage, summary, dream_event, turn_key, sort_order
+                    images, attachments, usage, summary, dream_event, turn_key,
+                    reminder_source_id, sort_order
                 ) VALUES (
                     $1, $2, $3, $4, $5, $6,
                     $7, $8, $9, $10, $11, $12,
                     $13, $14, $15, $16, $17, $18,
-                    $19, $20, $21, $22, $23, $24, COALESCE($25, 0)
+                    $19, $20, $21, $22, $23, $24, $25, COALESCE($26, 0)
                 )
                 ON CONFLICT (id) DO UPDATE SET
                     role = EXCLUDED.role,
@@ -4088,7 +4220,8 @@ async def sync_upsert_single_message(conv_id: str, msg_id: str, msg: dict):
                     summary = EXCLUDED.summary,
                     dream_event = EXCLUDED.dream_event,
                     turn_key = EXCLUDED.turn_key,
-                    sort_order = COALESCE($25, chat_messages.sort_order)
+                    reminder_source_id = EXCLUDED.reminder_source_id,
+                    sort_order = COALESCE($26, chat_messages.sort_order)
                 WHERE chat_messages.conversation_id = EXCLUDED.conversation_id
                 RETURNING id
             """, msg_id, conv_id, *content_values, sort_order)
@@ -6050,129 +6183,154 @@ async def delete_all_file_chunks(project_id: str) -> int:
 # v5.8：对话搜索
 # ============================================================
 
-async def search_chat_messages(query: str, project_id: str = None, limit: int = 20, context_size: int = 2):
-    """
-    搜索对话消息内容 + 对话标题。
-    
-    参数：
-        query: 搜索关键词
-        project_id: 项目ID（提供时只搜该项目内的对话，'none' 表示只搜无项目的对话）
-        limit: 最多返回多少条匹配
-        context_size: 每条匹配上下各取几条消息作为上下文
-    
-    返回按对话分组的结果，每组包含对话信息和匹配消息（含上下文）。
-    """
+async def _search_initial_state_tx(conn, session_ids: list) -> dict:
+    """Read tombstone/revision state in the caller's phase-one snapshot."""
+    if not session_ids:
+        return {}
+    rows = await conn.fetch("""
+        SELECT ids.session_id,
+               EXISTS(
+                   SELECT 1 FROM session_tombstones t
+                   WHERE t.session_id = ids.session_id
+               ) AS tombstoned,
+               COALESCE(r.rev, 0) AS source_rev
+        FROM UNNEST($1::text[]) AS ids(session_id)
+        LEFT JOIN session_source_rev r ON r.session_id = ids.session_id
+    """, sorted(set(session_ids)))
+    return {
+        row["session_id"]: {
+            "tombstoned": bool(row["tombstoned"]),
+            "source_rev": int(row["source_rev"]),
+        }
+        for row in rows
+    }
+
+
+async def _search_final_check(conn, results: dict, initial_state: dict) -> dict:
+    """Drop every source deleted or revision-changed after phase one."""
+    current_state = await _search_initial_state_tx(conn, list(initial_state))
+    allowed = {
+        session_id
+        for session_id, initial in initial_state.items()
+        if not initial["tombstoned"]
+        and session_id in current_state
+        and not current_state[session_id]["tombstoned"]
+        and current_state[session_id]["source_rev"] == initial["source_rev"]
+    }
+    return {
+        "title_matches": [
+            row for row in results["title_matches"]
+            if row["conversation_id"] in allowed
+        ],
+        "message_matches": [
+            row for row in results["message_matches"]
+            if row["conversation_id"] in allowed
+        ],
+    }
+
+
+async def search_chat_messages(query: str, project_id: str = None, limit: int = 20,
+                               context_size: int = 2):
+    """Search message bodies and titles, then reject sources that changed mid-read."""
     if not query or not query.strip():
         return {"title_matches": [], "message_matches": []}
-    
+
     pool = await get_pool()
     async with pool.acquire() as conn:
-        # 构建项目过滤
-        params = [f"%{query.strip()}%"]
-        
-        if project_id == 'none':
-            proj_filter = "AND c.project_id IS NULL"
-        elif project_id:
-            proj_filter = f"AND c.project_id = ${len(params) + 1}"
-            params.append(project_id)
-        else:
-            proj_filter = ""
-        
-        # 搜索消息内容（只搜 user 和 assistant 的消息）
-        params.append(limit)
-        limit_idx = len(params)
-        
-        msg_sql = f"""
-            SELECT m.id, m.conversation_id, m.role, m.content, m.time, m.sort_order,
-                   c.title as conv_title, c.project_id, c.created_at as conv_created_at
-            FROM chat_messages m
-            JOIN chat_conversations c ON c.id = m.conversation_id
-            WHERE m.content ILIKE $1
-              AND m.role IN ('user', 'assistant')
-              AND m.error = false
-              {proj_filter}
-            ORDER BY m.time DESC
-            LIMIT ${limit_idx}
-        """
-        
-        msg_rows = await conn.fetch(msg_sql, *params)
-        
-        # 搜索对话标题
-        title_params = [f"%{query.strip()}%"]
-        if project_id == 'none':
-            title_proj_filter = "AND project_id IS NULL"
-        elif project_id:
-            title_proj_filter = f"AND project_id = $2"
-            title_params.append(project_id)
-        else:
-            title_proj_filter = ""
-        
-        title_sql = f"""
-            SELECT id, title, project_id, created_at, updated_at
-            FROM chat_conversations
-            WHERE title ILIKE $1
-              {title_proj_filter}
-            ORDER BY updated_at DESC
-            LIMIT 10
-        """
-        title_rows = await conn.fetch(title_sql, *title_params)
-        
-        # 为每条匹配消息获取上下文
-        results_by_conv = {}
-        
-        for row in msg_rows:
-            conv_id = row["conversation_id"]
-            
-            if conv_id not in results_by_conv:
-                results_by_conv[conv_id] = {
-                    "conversation_id": conv_id,
-                    "title": row["conv_title"] or "新对话",
-                    "project_id": row["project_id"],
-                    "date": row["conv_created_at"].isoformat() if row["conv_created_at"] else None,
-                    "matches": [],
-                }
-            
-            # 获取该消息前后 context_size 条消息
-            ctx_rows = await conn.fetch("""
-                SELECT id, role, content, time, sort_order
-                FROM chat_messages
-                WHERE conversation_id = $1
-                  AND sort_order BETWEEN $2 AND $3
-                  AND role IN ('user', 'assistant')
-                ORDER BY sort_order ASC
-            """, conv_id, row["sort_order"] - context_size, row["sort_order"] + context_size)
-            
-            context_msgs = []
-            for cr in ctx_rows:
-                content = cr["content"] or ""
-                # 截断过长的消息
-                if len(content) > 300:
-                    content = content[:300] + "…"
-                context_msgs.append({
-                    "id": cr["id"],
-                    "role": cr["role"],
-                    "content": content,
-                    "time": cr["time"].isoformat() if cr["time"] else None,
-                    "is_match": cr["id"] == row["id"],
+        async with conn.transaction(isolation="repeatable_read", readonly=True):
+            params = [f"%{query.strip()}%"]
+            if project_id == "none":
+                proj_filter = "AND c.project_id IS NULL"
+            elif project_id:
+                proj_filter = f"AND c.project_id = ${len(params) + 1}"
+                params.append(project_id)
+            else:
+                proj_filter = ""
+            params.append(limit)
+            limit_idx = len(params)
+            msg_rows = await conn.fetch(f"""
+                SELECT m.id, m.conversation_id, m.role, m.content, m.time, m.sort_order,
+                       c.title AS conv_title, c.project_id,
+                       c.created_at AS conv_created_at
+                FROM chat_messages m
+                JOIN chat_conversations c ON c.id = m.conversation_id
+                WHERE m.content ILIKE $1
+                  AND m.role IN ('user', 'assistant')
+                  AND m.error = false
+                  {proj_filter}
+                ORDER BY m.time DESC
+                LIMIT ${limit_idx}
+            """, *params)
+
+            title_params = [f"%{query.strip()}%"]
+            if project_id == "none":
+                title_proj_filter = "AND project_id IS NULL"
+            elif project_id:
+                title_proj_filter = "AND project_id = $2"
+                title_params.append(project_id)
+            else:
+                title_proj_filter = ""
+            title_rows = await conn.fetch(f"""
+                SELECT id, title, project_id, created_at, updated_at
+                FROM chat_conversations
+                WHERE title ILIKE $1
+                  {title_proj_filter}
+                ORDER BY updated_at DESC
+                LIMIT 10
+            """, *title_params)
+
+            results_by_conv = {}
+            for row in msg_rows:
+                conv_id = row["conversation_id"]
+                if conv_id not in results_by_conv:
+                    results_by_conv[conv_id] = {
+                        "conversation_id": conv_id,
+                        "title": row["conv_title"] or "新对话",
+                        "project_id": row["project_id"],
+                        "date": (row["conv_created_at"].isoformat()
+                                 if row["conv_created_at"] else None),
+                        "matches": [],
+                    }
+                ctx_rows = await conn.fetch("""
+                    SELECT id, role, content, time, sort_order
+                    FROM chat_messages
+                    WHERE conversation_id = $1
+                      AND sort_order BETWEEN $2 AND $3
+                      AND role IN ('user', 'assistant')
+                    ORDER BY sort_order ASC
+                """, conv_id, row["sort_order"] - context_size,
+                     row["sort_order"] + context_size)
+                context_msgs = []
+                for context_row in ctx_rows:
+                    content = context_row["content"] or ""
+                    if len(content) > 300:
+                        content = content[:300] + "…"
+                    context_msgs.append({
+                        "id": context_row["id"],
+                        "role": context_row["role"],
+                        "content": content,
+                        "time": (context_row["time"].isoformat()
+                                 if context_row["time"] else None),
+                        "is_match": context_row["id"] == row["id"],
+                    })
+                results_by_conv[conv_id]["matches"].append({
+                    "message_id": row["id"],
+                    "sort_order": row["sort_order"],
+                    "context": context_msgs,
                 })
-            
-            results_by_conv[conv_id]["matches"].append({
-                "message_id": row["id"],
-                "sort_order": row["sort_order"],
-                "context": context_msgs,
-            })
-        
-        # 组装标题匹配结果
-        title_matches = []
-        for tr in title_rows:
-            title_matches.append({
-                "conversation_id": tr["id"],
-                "title": tr["title"],
-                "project_id": tr["project_id"],
-                "date": tr["created_at"].isoformat() if tr["created_at"] else None,
-            })
-        
-        return {
-            "title_matches": title_matches,
-            "message_matches": list(results_by_conv.values()),
-        }
+
+            title_matches = [{
+                "conversation_id": row["id"],
+                "title": row["title"],
+                "project_id": row["project_id"],
+                "date": row["created_at"].isoformat() if row["created_at"] else None,
+            } for row in title_rows]
+            results = {
+                "title_matches": title_matches,
+                "message_matches": list(results_by_conv.values()),
+            }
+            session_ids = [row["conversation_id"] for row in title_matches]
+            session_ids.extend(results_by_conv)
+            initial_state = await _search_initial_state_tx(conn, session_ids)
+
+        return await _search_final_check(conn, results, initial_state)

--- a/main.py
+++ b/main.py
@@ -51,6 +51,7 @@ from database import (
     append_legacy_turn_if_not_deleted, reset_all_chat_data, save_compression_summary,
     restore_conversation_from_backup, get_reset_generation,
     snapshot_recent_conversation, save_if_sources_unchanged, _insert_memory_tx,
+    w2_04_initialized, probe_w2_04_schema,
     SessionDeletedError,
     # v4.2 提醒系统
     create_reminder, get_reminders, update_reminder, delete_reminder, get_due_reminders, fire_reminder,
@@ -5495,6 +5496,30 @@ async def api_search_messages(q: str = "", project_id: str = None, limit: int = 
 # 云端同步 API（v4.1）
 # ============================================================
 
+async def _capabilities_payload() -> dict:
+    """Build the additive sync capability document; every failure is fail-closed."""
+    ready = False
+    try:
+        ready = (
+            w2_04_initialized()
+            and await probe_w2_04_schema()
+            and await get_config_bool(
+                "sync_delete_privacy_capability_enabled", fallback=True)
+        )
+    except Exception:
+        ready = False
+    return {
+        "contracts": {"w2_04_delete_privacy": 1},
+        "ready": bool(ready),
+        "revision": os.getenv("KIWI_REVISION", "").strip(),
+    }
+
+
+@app.get("/sync/capabilities")
+async def api_sync_capabilities():
+    """Advertise the shared delete-privacy contract without adding a kiwi-only auth layer."""
+    return await _capabilities_payload()
+
 async def _read_json_object(request: Request):
     """解析 JSON 对象；非法 JSON 或非对象请求统一返回 400。"""
     try:
@@ -5955,7 +5980,8 @@ async def api_sync_import_backup(file: UploadFile = File(...)):
 
         buf.seek(0)
         result = {"conversations": 0, "messages": 0, "projects": 0, "memories": 0,
-                  "settings": 0, "config": 0, "failed_conversations": 0}
+                  "settings": 0, "config": 0, "failed_conversations": 0,
+                  "filtered_sourceless_handoffs": 0}
 
         with zipfile.ZipFile(buf, 'r') as zf:
             names = zf.namelist()
@@ -5976,13 +6002,14 @@ async def api_sync_import_backup(file: UploadFile = File(...)):
                     # 缺键取 None（只恢复元数据），不能取 []——那是「权威空快照」的意思。
                     messages = conv.pop("messages", None)
                     try:
-                        await restore_conversation_from_backup(conv, messages)
+                        filtered = await restore_conversation_from_backup(conv, messages)
                     except Exception as e:
                         result["failed_conversations"] += 1
                         print(f"event=backup_restore_failed "
                               f"exception_type={type(e).__name__} increment=1")
                         continue
                     result["messages"] += len(messages or [])
+                    result["filtered_sourceless_handoffs"] += filtered
                     result["conversations"] += 1
 
             # 导入记忆

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -6015,6 +6015,44 @@ async def test_w2_04_1_ticket_c(client: httpx.AsyncClient) -> None:
     require((await client.get("/sync/capabilities")).json()["ready"] is True,
             "direct table update did not reopen the capability gate immediately")
 
+    gate_key = "sync_delete_privacy_capability_enabled"
+    await _w204_reset_tables()
+    require(await config.set_config(gate_key, "false"),
+            "could not close the capability gate through set_config")
+    try:
+        gate_off = await client.get("/sync/capabilities")
+        gate_payload = gate_off.json()
+        require(gate_off.status_code == 200 and gate_payload.get("ready") is False,
+                f"gate off did not advertise ready:false: {gate_off.status_code} {gate_off.text}")
+        require(gate_payload.get("contracts", {}).get("w2_04_delete_privacy") == 1,
+                f"gate off changed the fixed delete-privacy contract: {gate_payload}")
+
+        gate_sid = "tc07-gate-off"
+        await _seed_conversation(
+            gate_sid,
+            messages=[("tc07-m1", "user", "visible", "tc07-k1")],
+            events=[("assistant", "ledger-only", "tc07-k1", "tc07-lm1")],
+        )
+        response = await client.delete(f"/sync/conversations/{gate_sid}")
+        require(response.status_code == 200,
+                f"conversation delete failed while capability gate was off: {response.text}")
+        stamped_ids = {row["message_id"] for row in await _pool_fetch(
+            "SELECT message_id FROM message_tombstones WHERE session_id = $1", gate_sid)}
+        require({"tc07-m1", "tc07-lm1"} <= stamped_ids,
+                f"gate off stopped delete stamping visible message ids: {sorted(stamped_ids)}")
+        require(await _pool_fetchval(
+            "SELECT EXISTS(SELECT 1 FROM turn_tombstones "
+            "WHERE session_id = $1 AND turn_key = 'tc07-k1')", gate_sid),
+            "gate off stopped delete stamping the visible turn key")
+        late = await client.put(f"/sync/conversations/{gate_sid}/messages/tc07-m1", json={
+            "role": "user", "content": "late replay", "turnKey": "tc07-k1"})
+        require(late.status_code == 410,
+                f"gate off let a late PUT resurrect a deleted message: "
+                f"{late.status_code} {late.text}")
+    finally:
+        require(await config.set_config(gate_key, "true"),
+                "could not restore the capability gate after the gate-off guard")
+
     await _pool_execute("ALTER TABLE chat_messages DROP COLUMN reminder_source_id")
     probe_payload = (await client.get("/sync/capabilities")).json()
     require(probe_payload["ready"] is False
@@ -6254,9 +6292,27 @@ async def test_w2_04_1_ticket_c(client: httpx.AsyncClient) -> None:
         detail = (await client.get(f"/sync/conversations/{sid}")).json()
         require(detail["messages"][0].get("reminder_source_id") == expected,
                 f"backup round-trip lost reminder_source_id for {sid}")
-    main_source = (ROOT / "main.py").read_text(encoding="utf-8")
-    require("reminder_source_id" not in main_source and "reminderSourceId" not in main_source,
-            "reminder source identity leaked into an upstream-model assembly path")
+
+    upstream_sid = "tc12-upstream"
+    response = await client.post(
+        "/sync/conversations", json={"id": upstream_sid, "title": upstream_sid})
+    require(response.status_code == 200,
+            f"failed to create the upstream isolation fixture: {response.text}")
+    response = await client.put(f"/sync/conversations/{upstream_sid}/messages/tc12-upstream-m", json={
+        "role": "assistant", "content": "upstream body", "reminderSourceId": "tc12-rs"})
+    require(response.status_code == 200,
+            f"failed to seed the upstream isolation fixture: {response.text}")
+    pool = await database.get_pool()
+    async with pool.acquire() as conn:
+        handoff_messages = [
+            dict(row) for row in await database._handoff_messages_tx(conn, upstream_sid)
+        ]
+    require(handoff_messages, "the handoff reader did not return its seeded message")
+    for message in handoff_messages:
+        require(not {"reminder_source_id", "reminderSourceId"}.intersection(message),
+                f"handoff upstream row exposed reminder source keys: {sorted(message)}")
+    require("tc12-rs" not in json.dumps(handoff_messages, ensure_ascii=False, default=str),
+            "handoff upstream row exposed the reminder source value")
     passed("T-C-12 reminder_source_id round-trips all sync channels and stays out of upstream messages")
 
 

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -5923,6 +5923,11 @@ async def test_w2_04_1_ticket_c(client: httpx.AsyncClient) -> None:
     passed("T-C-05 backup restore filters seven SQL-equivalent sourceless handoff faces and reconciles counts")
 
     begin("T-C-06")
+    restore_tx_source = inspect.getsource(database._restore_conversation_tx)
+    restore_public_source = inspect.getsource(database.restore_conversation_from_backup)
+    require("_drop_sourceless_handoffs" in restore_tx_source
+            and "_drop_sourceless_handoffs" not in restore_public_source,
+            "sourceless handoff filtering moved outside the restore transaction")
     await _w204_reset_tables()
     sid = "tc06-rollback"
     await _seed_conversation(
@@ -6178,6 +6183,34 @@ async def test_w2_04_1_ticket_c(client: httpx.AsyncClient) -> None:
         "chat_messages.reminder_source_id migration is missing")
     require(len(database._message_content_values({})) == 23,
             "the shared message serializer did not gain exactly one nullable field")
+    await _w204_reset_tables()
+    migration_sessions = [f"tc12-migration-{index}" for index in range(3)]
+    for index, migration_sid in enumerate(migration_sessions):
+        await _seed_conversation(
+            migration_sid,
+            messages=[(f"{migration_sid}-m", "user", f"legacy-{index}",
+                       f"{migration_sid}-k")],
+        )
+    migration_before = [dict(row) for row in await _pool_fetch(
+        "SELECT id, conversation_id, role, content, turn_key, sort_order "
+        "FROM chat_messages WHERE conversation_id = ANY($1::text[]) ORDER BY id",
+        migration_sessions,
+    )]
+    await _pool_execute("ALTER TABLE chat_messages DROP COLUMN reminder_source_id")
+    await database.init_tables()
+    await database.init_tables()
+    migration_after = [dict(row) for row in await _pool_fetch(
+        "SELECT id, conversation_id, role, content, turn_key, sort_order "
+        "FROM chat_messages WHERE conversation_id = ANY($1::text[]) ORDER BY id",
+        migration_sessions,
+    )]
+    require(migration_after == migration_before and len(migration_after) == 3,
+            f"reminder_source_id migration rewrote legacy message rows: "
+            f"before={migration_before} after={migration_after}")
+    require(await _pool_fetchval(
+        "SELECT COUNT(*) FROM chat_messages WHERE conversation_id = ANY($1::text[]) "
+        "AND reminder_source_id IS NULL", migration_sessions) == 3,
+        "legacy message rows did not receive the nullable reminder_source_id default")
     await _w204_reset_tables()
     single, legacy, imported, missing = (
         "tc12-single", "tc12-legacy", "tc12-import", "tc12-missing")

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -5691,6 +5691,542 @@ async def test_w2_04_restore_stamp_states(client: httpx.AsyncClient) -> None:
     passed("T-W2-04-39 backup restore lifts exactly the stamps its file speaks for")
 
 
+async def test_w2_04_1_ticket_c(client: httpx.AsyncClient) -> None:
+    """T-C-01..12: W2-04.1 narrow privacy and compatibility backfill."""
+    begin("T-C-01")
+    await _w204_reset_tables()
+    sid = "tc01-delete-restore"
+    await _seed_conversation(
+        sid,
+        messages=[("tc01-chat-m1", "user", "chat body", "tc01-chat-turn")],
+        events=[("assistant", "ledger body", "tc01-ledger-turn", "tc01-ledger-m1")],
+    )
+    response = await client.delete(f"/sync/conversations/{sid}")
+    require(response.status_code == 200, f"ticket C delete fixture failed: {response.text}")
+    for mid in ("tc01-chat-m1", "tc01-ledger-m1"):
+        require(await _pool_fetchval(
+            "SELECT EXISTS(SELECT 1 FROM message_tombstones "
+            "WHERE session_id = $1 AND message_id = $2)", sid, mid),
+            f"conversation delete failed to stamp visible message id {mid}")
+    for turn_key in ("tc01-chat-turn", "tc01-ledger-turn"):
+        require(await _pool_fetchval(
+            "SELECT EXISTS(SELECT 1 FROM turn_tombstones "
+            "WHERE session_id = $1 AND turn_key = $2)", sid, turn_key),
+            f"conversation delete failed to stamp visible turn key {turn_key}")
+    response = await client.post("/sync/import-backup", files={"file": (
+        "backup.zip", _backup_zip([{"id": sid, "title": "metadata only"}]),
+        "application/zip")})
+    require(response.status_code == 200 and response.json()["conversations"] == 1,
+            f"metadata-only restore failed: {response.text}")
+    response = await client.put(f"/sync/conversations/{sid}/messages/tc01-ledger-m1", json={
+        "role": "assistant", "content": "late replay", "turnKey": "tc01-ledger-turn"})
+    require(response.status_code == 410 and response.json().get("code") in {
+        "message_deleted", "turn_deleted"},
+        f"metadata-only restore reopened a ledger-only message: {response.status_code} {response.text}")
+    require(not await _pool_fetchval(
+        "SELECT EXISTS(SELECT 1 FROM chat_messages WHERE id = 'tc01-ledger-m1')"),
+        "the refused ledger-only message still landed")
+    passed("T-C-01 delete stamps chat and ledger identities before metadata-only restore")
+
+    begin("T-C-02")
+    await _w204_reset_tables()
+    sid = "tc02-empty-restore"
+    await _seed_conversation(
+        sid,
+        messages=[("tc02-m1", "user", "one", "tc02-k1"),
+                  ("tc02-m2", "assistant", "two", "tc02-k1")],
+        events=[("user", "one", "tc02-k1", "tc02-m1"),
+                ("assistant", "two", "tc02-k1", "tc02-m2")],
+    )
+    await client.delete(f"/sync/conversations/{sid}")
+    response = await client.post("/sync/import-backup", files={"file": (
+        "backup.zip", _backup_zip([{"id": sid, "title": "empty", "messages": []}]),
+        "application/zip")})
+    require(response.status_code == 200, f"empty restore failed: {response.text}")
+    response = await client.put(f"/sync/conversations/{sid}/messages/tc02-m1", json={
+        "role": "user", "content": "single replay", "turnKey": "tc02-k1"})
+    require(response.status_code == 410, "single PUT reopened an id after empty restore")
+    await _upsert_config("sync_legacy_write_enabled", "true")
+    response = await client.put(f"/sync/conversations/{sid}", json={
+        "title": "legacy replay", "messages": [
+            {"id": "tc02-m2", "role": "assistant", "content": "legacy", "turnKey": "tc02-k1"}]})
+    require(response.status_code == 200 and "tc02-m2" in (
+        response.json().get("skipped_deleted_messages") or []),
+        f"legacy full replace did not report the stamped id: {response.text}")
+    response = await client.post("/sync/import", json={"projects": [], "conversations": [{
+        "id": sid, "title": "ordinary import", "messages": [
+            {"id": "tc02-m1", "role": "user", "content": "import", "turnKey": "tc02-k1"}]}]})
+    rejects = response.json().get("rejected_details") or []
+    require(any(d.get("type") == "message" and d.get("id") == sid
+                and d.get("code") in {"message_deleted", "turn_deleted"}
+                and "tc02-m1" in (d.get("message_ids") or []) for d in rejects),
+            f"ordinary import did not name its stamped message rejection: {rejects}")
+    require(sid in (response.json().get("imported_conversation_ids") or []),
+            "message rejection incorrectly rejected the whole live conversation")
+    require(await _pool_fetchval(
+        "SELECT COUNT(*) FROM chat_messages WHERE conversation_id = $1", sid) == 0,
+        "an ordinary write channel reopened content after an authoritative empty restore")
+    passed("T-C-02 empty restore keeps delete stamps across every ordinary write channel")
+
+    begin("T-C-03")
+    await _w204_reset_tables()
+    sid = "tc03-partial-restore"
+    await _seed_conversation(
+        sid,
+        messages=[("tc03-m1", "user", "one", "tc03-k1"),
+                  ("tc03-m2", "assistant", "two", "tc03-k1"),
+                  ("tc03-m3", "user", "three", "tc03-k2")],
+        events=[("user", "one", "tc03-k1", "tc03-m1"),
+                ("assistant", "two", "tc03-k1", "tc03-m2"),
+                ("user", "three", "tc03-k2", "tc03-m3")],
+    )
+    await client.delete(f"/sync/conversations/{sid}")
+    response = await client.post("/sync/import-backup", files={"file": (
+        "backup.zip", _backup_zip([{"id": sid, "title": "partial", "messages": [
+            {"id": "tc03-m1", "role": "user", "content": "restored", "turnKey": "tc03-k1"}
+        ]}]), "application/zip")})
+    require(response.status_code == 200, f"partial restore failed: {response.text}")
+    require(not await _pool_fetchval(
+        "SELECT EXISTS(SELECT 1 FROM message_tombstones "
+        "WHERE session_id = $1 AND message_id = 'tc03-m1')", sid),
+        "partial restore did not lift the named message stamp")
+    require(await _pool_fetchval(
+        "SELECT EXISTS(SELECT 1 FROM message_tombstones "
+        "WHERE session_id = $1 AND message_id = 'tc03-m2')", sid),
+        "partial restore lifted an unnamed message stamp")
+    require(await _pool_fetchval(
+        "SELECT EXISTS(SELECT 1 FROM turn_tombstones "
+        "WHERE session_id = $1 AND turn_key = 'tc03-k2')", sid),
+        "partial restore lifted an unnamed turn stamp")
+    response = await client.put(f"/sync/conversations/{sid}/messages/tc03-m2", json={
+        "role": "assistant", "content": "old id", "turnKey": "tc03-k1"})
+    require(response.status_code == 410 and response.json().get("code") == "message_deleted",
+            f"partial restore reopened an unnamed id: {response.status_code} {response.text}")
+    response = await client.put(f"/sync/conversations/{sid}/messages/tc03-new-k2", json={
+        "role": "assistant", "content": "dead turn", "turnKey": "tc03-k2"})
+    require(response.status_code == 410 and response.json().get("code") == "turn_deleted",
+            f"partial restore reopened an unnamed turn: {response.status_code} {response.text}")
+    passed("T-C-03 non-empty restore lifts only identities explicitly named by the backup")
+
+    begin("T-C-04")
+    await _w204_reset_tables()
+    generation_before = await _pool_fetchval(
+        "SELECT reset_generation FROM deletion_epoch WHERE id = 1")
+    for index in range(3):
+        current = f"tc04-reset-{index}"
+        await _seed_conversation(
+            current,
+            messages=[(f"{current}-chat", "user", "chat", f"{current}-chat-k")],
+            events=[("assistant", "ledger", f"{current}-ledger-k", f"{current}-ledger")],
+        )
+    response = await _reset_all(client)
+    require(response.status_code == 200, f"reset fixture failed: {response.text}")
+    sid = "tc04-reset-0"
+    response = await client.post("/sync/import-backup", files={"file": (
+        "backup.zip", _backup_zip([{"id": sid, "title": "metadata only"}]),
+        "application/zip")})
+    require(response.status_code == 200, f"post-reset restore failed: {response.text}")
+    response = await client.put(f"/sync/conversations/{sid}/messages/{sid}-ledger", json={
+        "role": "assistant", "content": "late", "turnKey": f"{sid}-ledger-k"})
+    require(response.status_code == 410,
+            f"reset + metadata restore reopened a ledger-only identity: {response.text}")
+    response = await client.put("/sync/conversations/tc04-reset-1/messages/tc04-reset-1-chat", json={
+        "role": "user", "content": "late", "turnKey": "tc04-reset-1-chat-k"})
+    require(response.status_code == 410 and response.json().get("code") == "deleted",
+            "an unrestored reset conversation lost its session stamp")
+    late = await database.append_turn_events_atomic(
+        sid, "late user", "late assistant", "m", turn_key="tc04-late-k",
+        user_message_id="tc04-late-u", assistant_message_id="tc04-late-a",
+        reset_generation=generation_before,
+    )
+    require(late == {"ok": False, "path": "tombstoned", "reason": "reset"},
+            f"an old-generation ledger write survived reset: {late}")
+    passed("T-C-04 reset stamps every visible identity and rejects old-generation writes")
+
+    begin("T-C-05")
+    require(hasattr(database, "_is_sourceless_handoff_divider"),
+            "restore has no SQL-aligned sourceless handoff predicate")
+    faces = [
+        ("missing", {}),
+        ("empty", {"sourceId": ""}),
+        ("blank", {"sourceId": "   "}),
+        ("json-object-string", json.dumps({"sourceId": ""})),
+        ("array", []),
+        ("scalar", "x"),
+        ("bad-json-string", "{oops"),
+    ]
+    pool = await database.get_pool()
+    async with pool.acquire() as conn:
+        for label, value in faces:
+            msg = {"role": "divider", "handoff_info": value}
+            python_result = database._is_sourceless_handoff_divider(msg)
+            sql_result = await conn.fetchval(
+                "SELECT $1::jsonb IS NOT NULL AND "
+                "NULLIF(BTRIM(COALESCE($1::jsonb->>'sourceId', '')), '') IS NULL",
+                json.dumps(value, ensure_ascii=False),
+            )
+            require(python_result is True and python_result == sql_result,
+                    f"Python/SQL sourceless classification diverged for {label}: "
+                    f"python={python_result} sql={sql_result}")
+    require(not database._is_sourceless_handoff_divider({
+        "role": "divider", "handoff_info": {"sourceId": " live "}}),
+        "a non-blank sourceId was classified as sourceless")
+    require(not database._is_sourceless_handoff_divider({
+        "role": "divider", "summary": "ordinary"}),
+        "an ordinary divider without handoff_info was classified as a handoff")
+
+    await _w204_reset_tables()
+    source_id, target_id = "tc05-live-source", "tc05-restore-target"
+    await _seed_conversation(source_id, messages=[("tc05-source-m", "user", "source", "tc05-source-k")])
+    messages = [
+        {"id": f"tc05-{label}", "role": "divider", "content": "",
+         "handoffInfo": value, "summary": f"filtered-{label}"}
+        for label, value in faces
+    ]
+    messages.extend([
+        {"id": "tc05-live-handoff", "role": "divider", "content": "",
+         "handoffInfo": {"version": 2, "sourceId": source_id, "sourceRev": 0},
+         "summary": "live handoff"},
+        {"id": "tc05-ordinary-divider", "role": "divider", "content": "",
+         "summary": "ordinary divider"},
+        {"id": "tc05-normal", "role": "user", "content": "normal"},
+    ])
+    await _pool_execute(
+        "INSERT INTO message_tombstones (session_id, message_id) VALUES ($1, $2)",
+        target_id, "tc05-missing")
+    sentinel = f"TC05_BODY_{uuid.uuid4().hex}"
+    messages[0]["content"] = sentinel
+    capture = io.StringIO()
+    with redirect_stdout(capture):
+        response = await client.post("/sync/import-backup", files={"file": (
+            "backup.zip", _backup_zip([{"id": target_id, "title": "restore", "messages": messages}]),
+            "application/zip")})
+    body = response.json()
+    require(response.status_code == 200 and body.get("messages") == len(messages),
+            f"restore changed the legacy file-count meaning of messages: {body}")
+    require(body.get("filtered_sourceless_handoffs") == 7,
+            f"restore did not report all seven filtered handoffs: {body}")
+    actual = await _pool_fetchval(
+        "SELECT COUNT(*) FROM chat_messages WHERE conversation_id = $1", target_id)
+    require(actual == body["messages"] - body["filtered_sourceless_handoffs"] == 3,
+            f"restore receipt does not reconcile with committed messages: actual={actual} body={body}")
+    kept = {r["id"] for r in await _pool_fetch(
+        "SELECT id FROM chat_messages WHERE conversation_id = $1", target_id)}
+    require(kept == {"tc05-live-handoff", "tc05-ordinary-divider", "tc05-normal"},
+            f"restore kept or dropped the wrong handoff faces: {sorted(kept)}")
+    require(await _pool_fetchval(
+        "SELECT EXISTS(SELECT 1 FROM message_tombstones "
+        "WHERE session_id = $1 AND message_id = 'tc05-missing')", target_id),
+        "filtering happened after named-id un-stamping")
+    require(sentinel not in response.text and sentinel not in capture.getvalue(),
+            "filtered handoff content leaked through the receipt or audit log")
+    passed("T-C-05 backup restore filters seven SQL-equivalent sourceless handoff faces and reconciles counts")
+
+    begin("T-C-06")
+    await _w204_reset_tables()
+    sid = "tc06-rollback"
+    await _seed_conversation(
+        sid,
+        messages=[("tc06-old", "user", "old", "tc06-old-k")],
+        events=[("user", "old", "tc06-old-k", "tc06-old")],
+    )
+    await client.delete(f"/sync/conversations/{sid}")
+    await _install_fail_trigger("chat_messages", "tc06_restore_fail", "conversation_id", sid,
+                                "TC06 injected restore failure")
+    try:
+        response = await client.post("/sync/import-backup", files={"file": (
+            "backup.zip", _backup_zip([{"id": sid, "title": "doomed", "messages": [
+                {"id": "tc06-filtered", "role": "divider", "content": "",
+                 "handoffInfo": {}},
+                {"id": "tc06-new", "role": "user", "content": "new", "turnKey": "tc06-new-k"},
+            ]}]), "application/zip")})
+        body = response.json()
+        require(body.get("failed_conversations") == 1 and body.get("conversations") == 0,
+                f"failed restore receipt was not isolated: {body}")
+        require(body.get("messages") == 0 and body.get("filtered_sourceless_handoffs") == 0,
+                f"failed restore claimed uncommitted message/filter counts: {body}")
+        require(await _has_session_tombstone(sid),
+                "failed restore committed its session un-stamp")
+        require(await _pool_fetchval(
+            "SELECT EXISTS(SELECT 1 FROM message_tombstones "
+            "WHERE session_id = $1 AND message_id = 'tc06-old')", sid),
+            "failed restore committed its message un-stamp")
+        require(not await _pool_fetchval(
+            "SELECT EXISTS(SELECT 1 FROM chat_conversations WHERE id = $1)", sid),
+            "failed restore left a metadata shell")
+        require(not await _pool_fetchval(
+            "SELECT EXISTS(SELECT 1 FROM chat_messages WHERE conversation_id = $1)", sid),
+            "failed restore left message rows")
+    finally:
+        await _drop_fail_trigger("chat_messages", "tc06_restore_fail")
+    passed("T-C-06 restore filtering, un-stamping and writes roll back as one transaction")
+
+    begin("T-C-07")
+    require(hasattr(database, "_w2_04_ready"),
+            "capability readiness has no process-local initialization flag")
+    require("sync_delete_privacy_capability_enabled" in config.CONFIG_SCHEMA,
+            "the capability gate is not registered in CONFIG_SCHEMA")
+    admin_schema = (ROOT / "admin-panel/js/config-schema.js").read_text(encoding="utf-8")
+    require("sync_delete_privacy_capability_enabled" in admin_schema,
+            "the capability gate is missing from the admin configuration schema")
+    require("sync_delete_privacy_capability_enabled" not in app_module.SYNC_SETTING_KEYS,
+            "a service behavior gate leaked into client sync settings")
+    with patch.dict(os.environ, {"KIWI_REVISION": "  tc07-revision  "}, clear=False):
+        responses = [
+            await client.get("/sync/capabilities"),
+            await client.get("/sync/capabilities", headers={"Authorization": "Bearer wrong"}),
+            await client.get("/sync/capabilities", headers={"Authorization": "Bearer chat-token"}),
+        ]
+    require(all(r.status_code == 200 for r in responses),
+            f"kiwi capability probe added a private auth boundary: {[r.status_code for r in responses]}")
+    payload = responses[0].json()
+    require(all(r.json() == payload for r in responses),
+            "authorization headers changed the public kiwi capability response")
+    require({"contracts", "ready", "revision"} <= set(payload),
+            f"capability response dropped a required key: {payload}")
+    version = payload["contracts"].get("w2_04_delete_privacy")
+    require(isinstance(version, int) and not isinstance(version, bool) and version == 1,
+            f"capability contract version is not strict integer 1: {version!r}")
+    require(isinstance(payload["ready"], bool) and payload["ready"] is True,
+            f"initialized schema with default-on gate is not ready: {payload}")
+    require(payload["revision"] == "tc07-revision" and isinstance(payload["revision"], str),
+            f"revision did not use trimmed KIWI_REVISION: {payload}")
+
+    response = await client.put(
+        "/admin/config/sync_delete_privacy_capability_enabled", json={"value": "false"})
+    require(response.status_code == 200 and response.json().get("status") == "updated",
+            f"admin API could not close the capability gate: {response.text}")
+    require((await client.get("/sync/capabilities")).json()["ready"] is False,
+            "closing the capability gate did not take effect immediately")
+    response = await client.put("/sync/settings", json={
+        "sync_delete_privacy_capability_enabled": "true"})
+    require("sync_delete_privacy_capability_enabled" in (response.json().get("rejected") or []),
+            f"/sync/settings accepted a service behavior gate: {response.text}")
+    require(await _config_row("sync_delete_privacy_capability_enabled") == "false",
+            "/sync/settings changed the rejected capability gate")
+    await _pool_execute(
+        "UPDATE gateway_config SET value = 'true' "
+        "WHERE key = 'sync_delete_privacy_capability_enabled'")
+    require((await client.get("/sync/capabilities")).json()["ready"] is True,
+            "direct table update did not reopen the capability gate immediately")
+
+    await _pool_execute("ALTER TABLE chat_messages DROP COLUMN reminder_source_id")
+    probe_payload = (await client.get("/sync/capabilities")).json()
+    require(probe_payload["ready"] is False
+            and probe_payload["contracts"].get("w2_04_delete_privacy") == 1,
+            f"missing ticket-C schema did not fail closed with a fixed contract: {probe_payload}")
+    await database.init_tables()
+    require((await client.get("/sync/capabilities")).json()["ready"] is True,
+            "idempotent migration did not restore capability readiness")
+
+    database._w2_04_ready = False
+    try:
+        flag_payload = (await client.get("/sync/capabilities")).json()
+        require(flag_payload["ready"] is False
+                and flag_payload["contracts"].get("w2_04_delete_privacy") == 1,
+                f"schema-only probe ignored the failed current-process init flag: {flag_payload}")
+        with patch.object(app_module, "MEMORY_ENABLED", False):
+            require((await client.get("/sync/capabilities")).json()["ready"] is False,
+                    "MEMORY_ENABLED=false was reported ready without initialization")
+    finally:
+        database._w2_04_ready = True
+
+    gate_sentinel = f"TC07_DSN_{uuid.uuid4().hex}"
+    async def _gate_crash(*args, **kwargs):
+        raise RuntimeError(gate_sentinel)
+    with patch.object(app_module, "get_config_bool", _gate_crash):
+        response = await client.get("/sync/capabilities")
+    require(response.status_code == 200 and response.json()["ready"] is False,
+            f"gate read failure did not fail closed: {response.status_code} {response.text}")
+    require(gate_sentinel not in response.text,
+            "capability error response leaked an exception or database detail")
+    passed("T-C-07 capability shape, readiness, public auth layer and live admin gate are fail-closed")
+
+    begin("T-C-08")
+    await _w204_reset_tables()
+    zero_sid, bumped_sid = "tc08-zero", "tc08-bumped"
+    await _seed_conversation(zero_sid, messages=[("tc08-zero-m", "user", "zero", "tc08-zero-k")])
+    await _seed_conversation(
+        bumped_sid,
+        messages=[("tc08-bump-u", "user", "u", "tc08-bump-k"),
+                  ("tc08-bump-a", "assistant", "a", "tc08-bump-k")],
+        events=[("user", "u", "tc08-bump-k", "tc08-bump-u"),
+                ("assistant", "a", "tc08-bump-k", "tc08-bump-a")],
+    )
+    await client.delete(f"/sync/conversations/{bumped_sid}/messages/tc08-bump-a")
+    listed = {c["id"]: c for c in await database.sync_get_conversations()}
+    require(isinstance(listed[zero_sid].get("source_rev"), int)
+            and listed[zero_sid]["source_rev"] == 0,
+            f"a never-bumped conversation did not list integer source_rev=0: {listed[zero_sid]}")
+    detail = await database.sync_get_conversation(bumped_sid)
+    require(listed[bumped_sid]["source_rev"] == detail["source_rev"],
+            f"list/detail source_rev disagree: list={listed[bumped_sid]} detail={detail}")
+    old_updated, old_rev = listed[zero_sid]["updated_at"], listed[zero_sid]["source_rev"]
+    pool = await database.get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await database._bump_source_rev_tx(conn, zero_sid)
+    listed_after = {c["id"]: c for c in await database.sync_get_conversations()}
+    require(listed_after[zero_sid]["updated_at"] == old_updated
+            and listed_after[zero_sid]["source_rev"] == old_rev + 1,
+            "a source-revision-only change was hidden by the conversation list")
+    passed("T-C-08 conversation lists expose integer source_rev consistent with detail reads")
+
+    begin("T-C-09")
+    require(hasattr(database, "_search_final_check")
+            and hasattr(database, "_search_initial_state_tx"),
+            "search has no two-stage snapshot/final-check seam")
+    search_source = inspect.getsource(database.search_chat_messages)
+    require('transaction(isolation="repeatable_read", readonly=True)' in search_source,
+            "search phase one is not a repeatable-read readonly snapshot")
+    await _w204_reset_tables()
+    doomed, healthy = "tc09-doomed", "tc09-healthy"
+    for sid in (doomed, healthy):
+        await _seed_conversation(
+            sid,
+            messages=[(f"{sid}-m", "user", f"needle body {sid}", f"{sid}-k")],
+        )
+        await _pool_execute("UPDATE chat_conversations SET title = $2 WHERE id = $1",
+                            sid, f"needle title {sid}")
+    original_final = database._search_final_check
+    fired = []
+    async def _delete_before_final(conn, results, initial_state):
+        if not fired:
+            fired.append(True)
+            await database.sync_delete_conversation(doomed)
+        return await original_final(conn, results, initial_state)
+    with patch.object(database, "_search_final_check", _delete_before_final):
+        results = await database.search_chat_messages("needle", limit=20, context_size=2)
+    require(fired, "the search final-check seam was never reached")
+    ids = {r["conversation_id"] for r in results["message_matches"]}
+    title_ids = {r["conversation_id"] for r in results["title_matches"]}
+    require(doomed not in ids and doomed not in title_ids,
+            f"search returned committed-deleted content: {results}")
+    require(healthy in ids and healthy in title_ids,
+            f"search final check damaged an unaffected conversation: {results}")
+    require(results["message_matches"][0]["matches"][0].get("context"),
+            "search final check changed the result/context shape")
+
+    await _w204_reset_tables()
+    stale, control = "tc09-stale", "tc09-control"
+    for sid in (stale, control):
+        await _seed_conversation(
+            sid,
+            messages=[(f"{sid}-m", "user", f"phaseone body {sid}", f"{sid}-k")],
+        )
+    original_initial = database._search_initial_state_tx
+    bumped = []
+    async def _bump_during_phase_one(conn, session_ids):
+        if not bumped:
+            bumped.append(True)
+            pool = await database.get_pool()
+            async with pool.acquire() as other:
+                async with other.transaction():
+                    await database._bump_source_rev_tx(other, stale)
+        return await original_initial(conn, session_ids)
+    with patch.object(database, "_search_initial_state_tx", _bump_during_phase_one):
+        results = await database.search_chat_messages("phaseone", limit=20, context_size=2)
+    ids = {r["conversation_id"] for r in results["message_matches"]}
+    require(bumped and stale not in ids and control in ids,
+            f"phase-one content and initial rev were not from one snapshot: {results}")
+
+    calls = []
+    async def _fake_search(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"title_matches": [{"conversation_id": "tc09-route", "title": "route",
+                                   "project_id": None, "date": None}],
+                "message_matches": []}
+    with patch.object(database, "search_chat_messages", _fake_search):
+        response = await client.get("/search/messages", params={"q": "route"})
+        tool_text, _ = await app_module._execute_gateway_tool(
+            "gateway_search_conversations", {"query": "route"}, {"project_id": None})
+    require(response.status_code == 200 and response.json()["title_matches"][0]["title"] == "route",
+            "the public search route bypassed the shared database search primitive")
+    require("route" in tool_text and len(calls) == 2,
+            "the model search tool bypassed the shared database search primitive")
+    passed("T-C-09 search uses one phase-one snapshot and filters changed sources before both callers return")
+
+    begin("T-C-10")
+    inherited = {
+        "T-S": 34, "T-W1-01-": 4, "T-W1-06-": 4, "T-W1-08-": 6,
+        "T-W2-01-": 12, "T-W2-02-": 22, "T-W2-03-": 25, "T-W2-04-": 40,
+    }
+    for prefix, expected in inherited.items():
+        actual = len([name for name in PASSED if name.startswith(prefix)])
+        require(actual == expected,
+                f"ticket C changed inherited guard count {prefix}: {actual} != {expected}")
+    require(sum(inherited.values()) == 147, "the inherited ticket-C baseline must stay at 147")
+    passed("T-C-10 all 147 inherited permanent guards still ran and pass unchanged")
+
+    begin("T-C-11")
+    builder_source = inspect.getsource(app_module.build_system_prompt_with_memories)
+    require('"sourceId": source["id"]' in builder_source
+            and '"sourceRev": data["source_rev"]' in builder_source,
+            "ev_handoff no longer carries the snapshot sourceId/sourceRev pair")
+    for streamer in (app_module._stream_with_tools, app_module.stream_and_capture):
+        stream_source = inspect.getsource(streamer)
+        require("'ev_handoff': prompt_meta['handoff']" in stream_source,
+                f"{streamer.__name__} no longer emits the frozen handoff payload")
+        require("source_rev" not in stream_source,
+                f"{streamer.__name__} re-reads or guesses a source revision at emission time")
+    passed("T-C-11 both stream paths emit the snapshot-frozen ev_handoff source identity")
+
+    begin("T-C-12")
+    require(await _pool_fetchval(
+        "SELECT EXISTS(SELECT 1 FROM information_schema.columns "
+        "WHERE table_name = 'chat_messages' AND column_name = 'reminder_source_id')"),
+        "chat_messages.reminder_source_id migration is missing")
+    require(len(database._message_content_values({})) == 23,
+            "the shared message serializer did not gain exactly one nullable field")
+    await _w204_reset_tables()
+    single, legacy, imported, missing = (
+        "tc12-single", "tc12-legacy", "tc12-import", "tc12-missing")
+    for sid in (single, missing):
+        response = await client.post("/sync/conversations", json={"id": sid, "title": sid})
+        require(response.status_code == 200, f"failed to create ticket-C fixture {sid}")
+    response = await client.put(f"/sync/conversations/{single}/messages/tc12-single-m", json={
+        "role": "assistant", "content": "single", "reminderSourceId": "reminder-single"})
+    require(response.status_code == 200, f"single reminderSourceId write failed: {response.text}")
+    response = await client.put(f"/sync/conversations/{missing}/messages/tc12-missing-m", json={
+        "role": "user", "content": "missing"})
+    require(response.status_code == 200, f"missing-field write failed: {response.text}")
+    await _upsert_config("sync_legacy_write_enabled", "true")
+    response = await client.put(f"/sync/conversations/{legacy}", json={
+        "title": legacy, "messages": [{"id": "tc12-legacy-m", "role": "user",
+        "content": "legacy", "reminder_source_id": "reminder-legacy"}]})
+    require(response.status_code == 200, f"legacy reminder_source_id write failed: {response.text}")
+    response = await client.post("/sync/import", json={"projects": [], "conversations": [{
+        "id": imported, "title": imported, "messages": [{"id": "tc12-import-m",
+        "role": "assistant", "content": "import", "reminderSourceId": "reminder-import"}]}]})
+    require(response.status_code == 200 and imported in response.json()["imported_conversation_ids"],
+            f"import reminderSourceId write failed: {response.text}")
+    expectations = {
+        single: "reminder-single", legacy: "reminder-legacy", imported: "reminder-import",
+        missing: None,
+    }
+    for sid, expected in expectations.items():
+        detail = (await client.get(f"/sync/conversations/{sid}")).json()
+        require(detail["messages"][0].get("reminder_source_id") == expected,
+                f"detail lost reminder_source_id for {sid}: {detail['messages'][0]}")
+
+    exported = await client.get("/sync/export")
+    require(exported.status_code == 200 and zipfile.is_zipfile(io.BytesIO(exported.content)),
+            "sync export did not produce a backup zip")
+    await _w204_reset_tables()
+    response = await client.post("/sync/import-backup", files={"file": (
+        "ticket-c.zip", exported.content, "application/zip")})
+    require(response.status_code == 200 and response.json()["failed_conversations"] == 0,
+            f"backup restore failed reminder round-trip: {response.text}")
+    for sid, expected in expectations.items():
+        detail = (await client.get(f"/sync/conversations/{sid}")).json()
+        require(detail["messages"][0].get("reminder_source_id") == expected,
+                f"backup round-trip lost reminder_source_id for {sid}")
+    main_source = (ROOT / "main.py").read_text(encoding="utf-8")
+    require("reminder_source_id" not in main_source and "reminderSourceId" not in main_source,
+            "reminder source identity leaked into an upstream-model assembly path")
+    passed("T-C-12 reminder_source_id round-trips all sync channels and stays out of upstream messages")
+
+
 async def run_suite(test_dsn: str) -> None:
     global database, config, app_module, memory_extractor
 
@@ -5751,6 +6287,7 @@ async def run_suite(test_dsn: str) -> None:
         await test_w2_04_entry_message_identity(client)
         await test_w2_04_handoff_copies(client)
         await test_w2_04_restore_stamp_states(client)
+        await test_w2_04_1_ticket_c(client)
 
 
 async def async_main() -> int:
@@ -5768,6 +6305,7 @@ async def async_main() -> int:
         w2_02_passed = [name for name in PASSED if name.startswith("T-W2-02-")]
         w2_03_passed = [name for name in PASSED if name.startswith("T-W2-03-")]
         w2_04_passed = [name for name in PASSED if name.startswith("T-W2-04-")]
+        ticket_c_passed = [name for name in PASSED if name.startswith("T-C-")]
         print(f"\nPASS: {len(legacy_passed)} permanent S1-S6 behavior guards")
         print(f"PASS: {len(w1_01_passed)} W1-01 isolation/permanent guards")
         print(f"PASS: {len(w1_06_passed)} W1-06 calendar-delete atomicity guards")
@@ -5776,6 +6314,7 @@ async def async_main() -> int:
         print(f"PASS: {len(w2_02_passed)} W2-02 message-identity/atomic-import guards")
         print(f"PASS: {len(w2_03_passed)} W2-03 ledger-schema/scope/dark-write guards")
         print(f"PASS: {len(w2_04_passed)} W2-04 session-delete/privacy guards")
+        print(f"PASS: {len(ticket_c_passed)} W2-04.1 ticket-C guards")
         if _MUTES_USED:
             print(f"MUTED: {len(_MUTES_USED)} assertion(s) let through via KIWI_KNIFE_MUTE: "
                   f"{sorted(set(_MUTES_USED))}")

--- a/scripts/w2_04_knives.py
+++ b/scripts/w2_04_knives.py
@@ -332,6 +332,24 @@ async def _handoff_source_alive_tx''', ()),
          else msg.get("reminder_source_id")
          if isinstance(msg.get("reminder_source_id"), str) else None),''',
      '''        None,''', ()),
+
+    ("C-gate-gates-stamps", "能力开关误作删除盖章总闸", "database.py", "T-C-07",
+     "gate off stopped delete stamping visible message ids",
+     '''    messages = await conn.execute("""
+        INSERT INTO message_tombstones (session_id, message_id)''',
+     '''    from config import get_config_bool
+    if not await get_config_bool(
+            "sync_delete_privacy_capability_enabled", fallback=True):
+        return {"messages": 0, "turns": 0}
+    messages = await conn.execute("""
+        INSERT INTO message_tombstones (session_id, message_id)''', ()),
+
+    ("C-handoff-select-star", "换窗取材 SELECT * 透传提醒来源", "database.py", "T-C-12",
+     "handoff upstream row exposed reminder source keys",
+     '''        SELECT role, content, summary, sort_order, time
+        FROM chat_messages''',
+     '''        SELECT *
+        FROM chat_messages''', ()),
 ]
 
 

--- a/scripts/w2_04_knives.py
+++ b/scripts/w2_04_knives.py
@@ -271,8 +271,8 @@ async def _handoff_source_alive_tx''', ()),
      '''            for session_id in session_ids:
                 await _stamp_session_tx(conn, session_id)''', ()),
 
-    ("C-restore-metadata", "metadata-only 恢复无条件撤消息与轮次章", "database.py", "T-C-01",
-     "metadata-only restore reopened a ledger-only message",
+    ("C-restore-metadata", "metadata-only 恢复无条件撤消息与轮次章", "database.py", "T-W2-04-39",
+     "a metadata-only backup speaks for no message and must lift no message stamp",
      '''    await conn.execute("DELETE FROM session_tombstones WHERE session_id = $1", session_id)
     if messages:''',
      '''    await conn.execute("DELETE FROM session_tombstones WHERE session_id = $1", session_id)
@@ -280,8 +280,8 @@ async def _handoff_source_alive_tx''', ()),
     await conn.execute("DELETE FROM turn_tombstones WHERE session_id = $1", session_id)
     if messages:''', ()),
 
-    ("C-restore-unnamed", "非空恢复撤掉未点名消息章", "database.py", "T-C-03",
-     "partial restore lifted an unnamed message stamp",
+    ("C-restore-unnamed", "非空恢复撤掉未点名消息章", "database.py", "T-W2-04-39",
+     "a backup that never mentions a message must leave its stamp in place",
      '''                "DELETE FROM message_tombstones WHERE session_id = $1 AND message_id = ANY($2::text[])",
                 session_id, named_ids,''',
      '''                "DELETE FROM message_tombstones WHERE session_id = $1",
@@ -294,8 +294,8 @@ async def _handoff_source_alive_tx''', ()),
      '''    if messages is not None:
         filtered_count = 0''', ()),
 
-    ("C-filter-outside-tx", "无来源换窗卡过滤挪到恢复事务外", "database.py", "T-C-06",
-     "sourceless handoff filtering moved outside the restore transaction",
+    ("C-filter-outside-tx", "无来源换窗卡过滤挪到恢复事务外", "database.py", "T-C-05",
+     "restore did not report all seven filtered handoffs",
      '''    """备份恢复的公开入口：一段对话一个事务，原子完成撤章与重建。"""
     pool = await get_pool()''',
      '''    """备份恢复的公开入口：一段对话一个事务，原子完成撤章与重建。"""

--- a/scripts/w2_04_knives.py
+++ b/scripts/w2_04_knives.py
@@ -256,6 +256,82 @@ async def _handoff_source_alive_tx''', ()),
      # 这一条被三层更早的同通道守卫先咬住，静默它们才能看见 T-30 自己咬。
      ("T-W2-04-10-replace-names", "T-W2-04-10-replace-state",
       "T-W2-04-24-replace", "T-W2-04-24-import")),
+
+    ("C-delete-stamps", "整删不盖可见消息与轮次章", "database.py", "T-C-01",
+     "conversation delete failed to stamp visible message id",
+     '''            await _stamp_visible_messages_tx(conn, conv_id)
+            await _stamp_session_tx(conn, conv_id)''',
+     '''            await _stamp_session_tx(conn, conv_id)''', ()),
+
+    ("C-reset-stamps", "reset 不盖可见消息与轮次章", "database.py", "T-C-04",
+     "reset + metadata restore reopened a ledger-only identity",
+     '''            for session_id in session_ids:
+                await _stamp_visible_messages_tx(conn, session_id)
+                await _stamp_session_tx(conn, session_id)''',
+     '''            for session_id in session_ids:
+                await _stamp_session_tx(conn, session_id)''', ()),
+
+    ("C-restore-metadata", "metadata-only 恢复无条件撤消息与轮次章", "database.py", "T-C-01",
+     "metadata-only restore reopened a ledger-only message",
+     '''    await conn.execute("DELETE FROM session_tombstones WHERE session_id = $1", session_id)
+    if messages:''',
+     '''    await conn.execute("DELETE FROM session_tombstones WHERE session_id = $1", session_id)
+    await conn.execute("DELETE FROM message_tombstones WHERE session_id = $1", session_id)
+    await conn.execute("DELETE FROM turn_tombstones WHERE session_id = $1", session_id)
+    if messages:''', ()),
+
+    ("C-restore-unnamed", "非空恢复撤掉未点名消息章", "database.py", "T-C-03",
+     "partial restore lifted an unnamed message stamp",
+     '''                "DELETE FROM message_tombstones WHERE session_id = $1 AND message_id = ANY($2::text[])",
+                session_id, named_ids,''',
+     '''                "DELETE FROM message_tombstones WHERE session_id = $1",
+                session_id,''', ()),
+
+    ("C-restore-handoff", "备份恢复不滤无来源换窗卡", "database.py", "T-C-05",
+     "restore did not report all seven filtered handoffs",
+     '''    if messages is not None:
+        messages, filtered_count = _drop_sourceless_handoffs(messages)''',
+     '''    if messages is not None:
+        filtered_count = 0''', ()),
+
+    ("C-filter-outside-tx", "无来源换窗卡过滤挪到恢复事务外", "database.py", "T-C-06",
+     "sourceless handoff filtering moved outside the restore transaction",
+     '''    """备份恢复的公开入口：一段对话一个事务，原子完成撤章与重建。"""
+    pool = await get_pool()''',
+     '''    """备份恢复的公开入口：一段对话一个事务，原子完成撤章与重建。"""
+    if messages is not None:
+        messages, _ = _drop_sourceless_handoffs(messages)
+    pool = await get_pool()''', ()),
+
+    ("C-capability-schema", "能力端点忽略 schema readiness", "main.py", "T-C-07",
+     "missing ticket-C schema did not fail closed with a fixed contract",
+     '''            w2_04_initialized()
+            and await probe_w2_04_schema()
+            and await get_config_bool(''',
+     '''            w2_04_initialized()
+            and True
+            and await get_config_bool(''', ()),
+
+    ("C-list-revision", "对话列表漏掉 source_rev 联表", "database.py", "T-C-08",
+     "a never-bumped conversation did not list integer source_rev=0",
+     '''                   c.pinned, c.sort_order, c.created_at, c.updated_at,
+                   COALESCE(r.rev, 0) AS source_rev
+            FROM chat_conversations c
+            LEFT JOIN session_source_rev r ON r.session_id = c.id''',
+     '''                   c.pinned, c.sort_order, c.created_at, c.updated_at
+            FROM chat_conversations c''', ()),
+
+    ("C-search-final", "搜索省略删除与版本终检", "database.py", "T-C-09",
+     "the search final-check seam was never reached",
+     '''        return await _search_final_check(conn, results, initial_state)''',
+     '''        return results''', ()),
+
+    ("C-reminder-source", "消息序列化漏写 reminder_source_id", "database.py", "T-C-12",
+     "detail lost reminder_source_id for tc12-single",
+     '''        (msg.get("reminderSourceId") if isinstance(msg.get("reminderSourceId"), str)
+         else msg.get("reminder_source_id")
+         if isinstance(msg.get("reminder_source_id"), str) else None),''',
+     '''        None,''', ()),
 ]
 
 


### PR DESCRIPTION
## 状态

- **Scope Frozen / Draft**。实际施工基线：`main@fa786b7c4ff5b49129e88011012a2851843c3254`，开工前工作树干净。
- 分支：`codex/w2-04-1-kiwi-narrow-20260818`；当前 head：`e2492fe2c403ff33615c9acae7aa83c7aaee08e8`。
- 本 PR 不转 Ready、不合并、不打 tag、不部署；CC 第二轨已交零生产反例卷，当前等待爹爹 r2 复验、双签与露露裁决。

## 范围内实现

- **C1.1 删除/reset 防复活**：整删与 reset 在原事务/原 G-S 锁内，以 `chat_messages(id, turn_key) ∪ conversations(source_message_id, turn_key)` 的非空并集盖 message/turn 章；metadata-only、`messages: []`、非空点名恢复的三态撤章合同保持不变。
- **C1.2 旧备份过滤**：恢复事务内部过滤七类 sourceless handoff，判定与启动 SQL 对齐；回执新增 `filtered_sourceless_handoffs`。既有 `messages` 仍表示成功会话中的备份文件条数，实际写入数 = `messages - filtered_sourceless_handoffs`；失败会话不累计任何计数。
- **C1.3 能力端点**：新增公开 `GET /sync/capabilities`，与 kiwi 其他 `/sync/*` 一样没有仓库内建鉴权。`ready = 本进程 init 完整成功 && schema probe 通过 && 开关开启`；未就绪仍 HTTP 200、固定声明合同、`ready:false`，不泄漏异常。
- **C1.4 rev/搜索**：对话列表 LEFT JOIN `session_source_rev`，缺行返回整数 `0`；搜索阶段一在 `repeatable_read readonly` 快照内读正文/标题/上下文/初始章与 rev，阶段二按当前章/rev 过滤整段陈旧结果，公开路由和模型工具共用同一原语。
- **X1**：`ev_handoff.sourceId/sourceRev` 生产形状已在，本票只加守卫锁住两条流式路径。
- **X2**：新增 nullable `chat_messages.reminder_source_id`；单条、legacy 全量、import、详情、export/import-backup 往返支持 camel/snake 输入，字段不进入上游模型 messages。

## 开关与兼容边界

- 键：`sync_delete_privacy_capability_enabled`，默认 `true`，位于管理面板「兼容与回退」。
- 关闭方式：管理面板、`PUT /admin/config/sync_delete_privacy_capability_enabled` 或直接改 `gateway_config`；即时生效，无需重启。关闭只改变能力宣称，不改变删除章/锁/清理。
- 该键不进入 `SYNC_SETTING_KEYS`；`PUT /sync/settings` 会拒收。
- `revision` 只读 `KIWI_REVISION` 并 trim，缺失/空值返回空串；运行时不读 `.git`、不调用 git。
- 没有比冻结合同更严或更松的额外选择。

## Tests-first 与证据

- Tests-only：`c1d3c0f`；红证 Run [32441684507](https://github.com/LucieEveille/kiwi-mem/actions/runs/32441684507)，PG16 behavior job 在 `BEGIN T-C-01` 行为红：整删未给 `tc01-chat-m1` 盖消息章。
- 实现：`70d5a7b`；守卫/刀册加固：`a0bfc67`、`04f8a1b`；r1 前 head：`2f328f2`。
- 最终普通 CI：[32443723660](https://github.com/LucieEveille/kiwi-mem/actions/runs/32443723660) 全绿；12 个既有回归脚本通过，PG16 真库永久守卫 `147 + 12 = 159`。
- 十刀真库账：[32443372070](https://github.com/LucieEveille/kiwi-mem/actions/runs/32443372070) 的「票 C 十刀变异账」步骤成功；刀本只有 10/10 都为声明红点 `RED` 才返回 0。artifact：`ticket-c-knife-results`。第一次诊断 Run 32442984816 如实暴露 7 RED + 3 RED-ELSEWHERE，随后把三把的声明红点对齐到仓库真实第一道防线后重跑全绿，未静默守卫。
- 本机没有 PostgreSQL，未冒充本地真库；真库证据全部来自 CI PostgreSQL 16。

## Stage verification

- `python -m compileall -q .`：PASS；`node --check admin-panel/js/config-schema.js`：PASS；`git diff --check origin/main...HEAD`：PASS。
- 新增行私有标识扫描：`Veillée|Veillee|veillee|source_signature|eveille.love|Éveille|Fidélis|小斐` 为 0；FastAPI 标题仍是 `Kiwi-Mem`；最终 diff 无工作流改动。
- 数据库/schema/迁移：老库缺列升级、重复 init 幂等、3 条存量消息核心字段零改写、nullable 默认、schema 缺失 fail-closed 均由 T-C-07/T-C-12 真库验证。
- 同步/导入导出：新旧写通道、缺字段、完整替换、`messages: []`、partial restore、失败事务/回执无半写均由 T-C-01…06/T-C-12 验证。
- 权限/隐私/错误：按 README 如实维持「无仓库内建鉴权」公开边界；任意 Authorization 头响应同形；异常/DSN/过滤正文不泄漏。
- 闸门/管理面板：默认开、即时关/开、`/sync/settings` 拒收、面板 schema 正确分组、admin API bool 保存均通过；CI 的 admin panel 回归通过。
- 流式：生产未改，仅 X1 形状守卫；日历、记忆、Docker、README：N/A，本票未触碰。
- 本票无发布版本，因此未创建 `docs/acceptance/vX.Y.Z.md`，也不申报发布验收。

## 顺手记账与停车场

- 总纲票 C：`Scope Frozen`，实际施工基线 `fa786b7c4ff5b49129e88011012a2851843c3254`。
- §3.1 勘误 r2（露露 2026-08-21 已裁）：原「受同步鉴权保护」句保留划线，改为「与该仓库其他 `/sync/*` 端点同一鉴权层的：`GET /sync/capabilities`」；gateway 继承其 Bearer 中间件，kiwi 与其他 `/sync/*` 一样无内建鉴权，Chat 继续携带 Authorization 头但 kiwi 忽略。理由：跨仓合同描述同层，不虚构统一鉴权实现。
- 停车场补登 P-12：Chat outbox 键元组全序 + 混排守卫；本票未实现。
- 票 A 收案挂账：merge `86feb49`，提交链/tree/刀账/跨票登记以票 A 收案证据为准；本票未重写。
- 继续停车：ticket B/gateway 反向搬运、P-10、P-11、W2-05、Chat outbox/UI、DataTab 全失败仍显示成功、两端 UI 不展示 `failed_conversations`/过滤计数、import-backup 旧 500 `str(e)` 脸。

## r1 守卫返工（2026-08-21）

- **结论来源**：CC 第二轨在 PostgreSQL 16.13 上交出零生产反例卷，并在既有七刀之外发现“能力开关误作数据库盖章总闸”可穿过全部 159 条；爹爹沿 CC 未攻完的上游取材面确认 T-C-12 原源码 grep 方向错误。本轮只修两条守卫缺口，不改生产实现。
- **R1 / T-C-07**：新增关闸行为断言。开关为 `false` 时能力端点仍以 HTTP 200 返回固定合同 `1` 与 `ready:false`；整删仍给 chat 身份 `tc07-m1`、ledger-only 身份 `tc07-lm1` 和轮次 `tc07-k1` 盖章，迟到 PUT 仍为 410；`finally` 恢复开关。
- **R2 / T-C-12**：删掉 `main.py` 全文 grep，改为真种 `reminderSourceId=tc12-rs` 后直接调用 `database._handoff_messages_tx`，逐行断言 camel/snake 两种键与值均不进入 handoff 上游取材。经路径核对，`snapshot_recent_conversation` 读取 ledger `conversations`，不读取 `chat_messages`，所以本轮不虚加与该字段无关的快照断言。
- **刀册 10 → 12**：新增 `C-gate-gates-stamps`（目标 T-C-07）与 `C-handoff-select-star`（目标 T-C-12）。取证 Run [32447901555](https://github.com/LucieEveille/kiwi-mem/actions/runs/32447901555) 在 PostgreSQL 16 上先跑基线 159/159，再跑票 C 十二刀；12/12 全部为声明目标 `RED`，无 `RED-ELSEWHERE`、`SURVIVED`、`CRASH`、`PATCH-MISS` 或 `TIMEOUT`。两把新刀分别红为：
  - `C-gate-gates-stamps -> RED [T-C-07]`：`gate off stopped delete stamping visible message ids: []`
  - `C-handoff-select-star -> RED [T-C-12]`：`handoff upstream row exposed reminder source keys`
- **刀账 artifact**：`ticket-c-r1-knife-results`，artifact ID `9434746959`，digest `sha256:3374e1dd97254374149c490aac06446349f7738fb3f82a9c970bb5402b2cbafc`。一次性 CI 取证步只存在于 `628bf91`，已由 `e2492fe` 完整撤回。
- **最终证据**：最终 head `e2492fe2c403ff33615c9acae7aa83c7aaee08e8`；普通 CI Run [32448224481](https://github.com/LucieEveille/kiwi-mem/actions/runs/32448224481) 全绿，PostgreSQL 16.15 真库路径 `147 + 12 = 159`，票 C T-C-01…12 全过；模型/API 路径未调用，边界仍为 mock。
- **最终净 diff**：相对 r1 前 head `2f328f2` 只修改 `scripts/test_kiwi_safety_sync.py` 与 `scripts/w2_04_knives.py`，77 行新增、3 行删除；`.github/workflows/ci.yml` 零净变化，生产代码零改动。
- 本机 5432 未监听，未冒充本地真库；真库与十二刀证据均来自上述 GitHub Actions。PR 继续保持 Draft，等待 r2 与双签。
