### PR TITLE
修复记忆提取失败被误记为成功

### DIFF
--- a/main.py
+++ b/main.py
@@ -1320,7 +1320,7 @@ async def _extract_and_save_batch(*, session_id, limit,
     for attempt in (1, 2):
         snapshot, messages = await _snapshot_extraction_material(session_id, limit=limit)
         if not messages:
-            return "abandoned", [], 0, 0
+            return "abandoned", [], 0, 0, None
 
         new_memories = await extract_memories(
             messages,
@@ -1330,6 +1330,8 @@ async def _extract_and_save_batch(*, session_id, limit,
             prompt_override=prompt_override,
             emotion_level=emotion_level,
         )
+        if isinstance(new_memories, dict) and new_memories.get("ok") is False:
+            return "extract_failed", [], 0, 0, new_memories.get("reason") or "unknown"
         plans, skipped = await _prepare_memory_batch(
             _filter_meta_memories(new_memories), project_id=project_id,
             emotion_level=emotion_level)
@@ -1344,9 +1346,18 @@ async def _extract_and_save_batch(*, session_id, limit,
                 )
         if outcome == "saved":
             saved_items, contradictions = result
-            return "extract", saved_items, skipped, contradictions
+            return "extract", saved_items, skipped, contradictions, None
         print(f"event=extraction_sources_changed attempt={attempt} increment=1")
-    return "abandoned", [], 0, 0
+    return "abandoned", [], 0, 0, None
+
+
+def _should_push_memory_event(result) -> bool:
+    """Publish only actionable failures or an actual memory save."""
+    if not isinstance(result, dict):
+        return False
+    saved = result.get("saved", 0)
+    has_saved = isinstance(saved, (int, float)) and not isinstance(saved, bool) and saved > 0
+    return has_saved or result.get("action") in ("extract_failed", "error")
 
 
 async def process_memories_background(session_id: str, user_msg: str, assistant_msg: str, model: str, emotion_level: str = "normal", project_id: str = None, is_regenerate: bool = False, *, extract_enabled: bool = True, usage: dict = None, turn_key: str = None, client_gave_conv_id: bool = False, project_id_present: bool = False, payload_project_id=None, user_message_id: str = None,
@@ -1473,7 +1484,7 @@ async def process_memories_background(session_id: str, user_msg: str, assistant_
 
         # ===== v3.7 改进：攒 N 轮完整对话一起提取 =====
         # 从数据库捞最近 N*2 条消息（N轮 = N条user + N条assistant）
-        action, saved_items, skipped_count, contradiction_count = await _extract_and_save_batch(
+        action, saved_items, skipped_count, contradiction_count, failure_reason = await _extract_and_save_batch(
             session_id=session_id, limit=extract_interval * 2,
             existing_contents=existing_contents, cat_names=cat_names,
             emotion_level=emotion_level, project_id=project_id,
@@ -1483,6 +1494,14 @@ async def process_memories_background(session_id: str, user_msg: str, assistant_
         if action == "abandoned":
             print("💭 提取素材在生成期间被删改，本轮放弃保存")
             return {"action": "abandoned", "reason": "sources_changed"}
+        if action == "extract_failed":
+            # The global counter is the current extraction trigger carrier. Restore it so
+            # the next eligible turn retries instead of treating this batch as processed.
+            async with _counter_lock:
+                _conversation_counter = max(_conversation_counter, extract_interval)
+            reason = failure_reason or "unknown"
+            print(f"⚠️  本批提取失败，恢复重试触发（reason={reason}）")
+            return {"action": "extract_failed", "saved": 0, "reason": reason}
         saved_count = len(saved_items)
 
         if saved_count > 0 or skipped_count > 0:
@@ -1495,8 +1514,9 @@ async def process_memories_background(session_id: str, user_msg: str, assistant_
             return {"action": "extract", "saved": 0, "skipped": 0, "contradictions": 0, "total": await get_all_memories_count(), "items": []}
             
     except Exception as e:
-        print(f"⚠️  后台记忆处理失败: {e}")
-        return {"action": "error", "error": str(e)}
+        error_code = f"exception:{type(e).__name__}"
+        print(f"⚠️  后台记忆处理失败: {type(e).__name__}")
+        return {"action": "error", "error_code": error_code, "error": error_code}
 
 
 # ============================================================
@@ -3054,7 +3074,7 @@ async def _stream_with_tools(messages, tools, tool_map, model, temperature, tool
                 except Exception as e:
                     print(f"⚠️ 收尾记忆 task 出错（不影响流收尾）: {e}")
                     mem_result = None
-                if mem_result and mem_result.get("action") != "skip":
+                if _should_push_memory_event(mem_result):
                     yield f"data: {json.dumps({'ev_memory': mem_result}, ensure_ascii=False)}\n\n"
             # Dream 事件必须在 [DONE] 之前
             if dream_triggered:
@@ -3611,7 +3631,7 @@ async def stream_and_capture(headers: dict, body: dict, session_id: str, user_me
         except Exception as e:
             print(f"⚠️ 收尾记忆 task 出错（不影响流收尾）: {e}")
             mem_result = None
-        if mem_result and mem_result.get("action") != "skip":
+        if _should_push_memory_event(mem_result):
             yield f"data: {json.dumps({'ev_memory': mem_result}, ensure_ascii=False)}\n\n".encode("utf-8")
 
     # Dream 触发：在 [DONE] 之前推送，前端据此启动 Dream 并展示进度（既有"陪看"体验不动）

--- a/memory_extractor.py
+++ b/memory_extractor.py
@@ -88,9 +88,11 @@ EMOTION_HIGH_INSTRUCTION = """# 🩷 情绪锚点提取【本轮对话情绪浓�
 EMOTION_NORMAL_INSTRUCTION = ""
 
 
-async def extract_memories(messages: List[Dict[str, str]], existing_memories: List[str] = None, categories: List[str] = None, model_override: str = None, prompt_override: str = None, emotion_level: str = "normal") -> List[Dict]:
+async def extract_memories(messages: List[Dict[str, str]], existing_memories: List[str] = None, categories: List[str] = None, model_override: str = None, prompt_override: str = None, emotion_level: str = "normal"):
     """
-    从对话消息中提取记忆
+    从对话消息中提取记忆。
+
+    list（含合法空数组）表示成功；{"ok": False, "reason": code} 表示失败。
 
     参数：
         messages: 对话消息列表，格式 [{"role": "user", "content": "..."}, ...]
@@ -157,7 +159,7 @@ async def extract_memories(messages: List[Dict[str, str]], existing_memories: Li
 
     if not use_api_key:
         print("⚠️  无可用 API Key（供应商和环境变量均未配置），跳过记忆提取")
-        return []
+        return {"ok": False, "reason": "no_api_key"}
 
     # 调用 LLM 提取记忆
     try:
@@ -180,7 +182,7 @@ async def extract_memories(messages: List[Dict[str, str]], existing_memories: Li
 
             if response.status_code != 200:
                 print(f"⚠️  记忆提取请求失败: {response.status_code}")
-                return []
+                return {"ok": False, "reason": f"http_{response.status_code}"}
 
             data = parse_background_response(response.json(), use_api_format)
             text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
@@ -223,9 +225,9 @@ async def extract_memories(messages: List[Dict[str, str]], existing_memories: Li
                     if "content" in memories:
                         memories = [memories]
             
-            if not memories or not isinstance(memories, list):
+            if memories is None or not isinstance(memories, list):
                 print(f"⚠️  记忆提取返回非数组格式，跳过")
-                return []
+                return {"ok": False, "reason": "parse_failed"}
 
             # 验证格式
             valid_memories = []
@@ -254,9 +256,17 @@ async def extract_memories(messages: List[Dict[str, str]], existing_memories: Li
             print(f"📝 从对话中提取了 {len(valid_memories)} 条新记忆（已对比 {len(existing_memories or [])} 条已有记忆）")
             return valid_memories
 
+    except httpx.TimeoutException as e:
+        print(f"⚠️  记忆提取超时: {type(e).__name__}")
+        return {"ok": False, "reason": "timeout"}
+    except httpx.TransportError as e:
+        name = type(e).__name__
+        print(f"⚠️  记忆提取网络失败: {name}")
+        return {"ok": False, "reason": f"network:{name}"}
     except json.JSONDecodeError as e:
-        print(f"⚠️  记忆提取结果解析失败: {e}")
-        return []
+        print(f"⚠️  记忆提取结果解析失败: {type(e).__name__}")
+        return {"ok": False, "reason": "parse_failed"}
     except Exception as e:
-        print(f"⚠️  记忆提取出错: {e}")
-        return []
+        name = type(e).__name__
+        print(f"⚠️  记忆提取出错: {name}")
+        return {"ok": False, "reason": f"exception:{name}"}

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -6316,6 +6316,156 @@ async def test_w2_04_1_ticket_c(client: httpx.AsyncClient) -> None:
     passed("T-C-12 reminder_source_id round-trips all sync channels and stays out of upstream messages")
 
 
+class _MNResponse:
+    def __init__(self, status_code: int = 200, payload: Any = None) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class _MNClient:
+    response: Any = None
+    error: BaseException | None = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> "_MNClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> bool:
+        return False
+
+    async def post(self, *args: Any, **kwargs: Any) -> Any:
+        if self.error:
+            raise self.error
+        return self.response
+
+
+async def _mn_extractor_case(*, key: str = "key", response: Any = None,
+                             error: BaseException | None = None) -> Any:
+    async def _resolver(_model: str) -> tuple[str, str, str]:
+        return "http://memory.test/chat/completions", key, "openai"
+
+    _MNClient.response = response
+    _MNClient.error = error
+    try:
+        with patch.object(database, "resolve_model_endpoint", _resolver), patch.object(
+            memory_extractor.httpx, "AsyncClient", _MNClient
+        ):
+            return await memory_extractor.extract_memories([
+                {"role": "user", "content": "remember this public contract"},
+            ])
+    finally:
+        _MNClient.response = None
+        _MNClient.error = None
+
+
+async def test_memory_notice_contracts() -> None:
+    begin("T-MN-K-01")
+    failure_results = {
+        "no_api_key": await _mn_extractor_case(key=""),
+        "http_401": await _mn_extractor_case(response=_MNResponse(401, {})),
+        "http_429": await _mn_extractor_case(response=_MNResponse(429, {})),
+        "timeout": await _mn_extractor_case(
+            error=httpx.TimeoutException("secret timeout body")
+        ),
+        "network:ConnectError": await _mn_extractor_case(
+            error=httpx.ConnectError("postgresql://user:pw@host/db")
+        ),
+        "parse_failed": await _mn_extractor_case(response=_MNResponse(200, {
+            "choices": [{"message": {"content": "not-json"}}],
+        })),
+    }
+    for expected_reason, result in failure_results.items():
+        require(result == {"ok": False, "reason": expected_reason},
+                f"extractor failure reason drifted for {expected_reason}: {result!r}")
+    passed("T-MN-K-01 extractor exposes six stable failure reasons")
+
+    begin("T-MN-K-02")
+    prepare_called = False
+    save_called = False
+
+    async def _snapshot(*args: Any, **kwargs: Any) -> tuple[dict[str, Any], list[dict[str, str]]]:
+        return {"conversation": 1}, [{"role": "user", "content": "failed batch"}]
+
+    async def _failed_extract(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"ok": False, "reason": "timeout"}
+
+    async def _must_not_prepare(*args: Any, **kwargs: Any) -> Any:
+        nonlocal prepare_called
+        prepare_called = True
+        raise AssertionError("failed extraction reached memory preparation")
+
+    async def _must_not_save(*args: Any, **kwargs: Any) -> Any:
+        nonlocal save_called
+        save_called = True
+        raise AssertionError("failed extraction reached source marking/save")
+
+    with patch.object(app_module, "_snapshot_extraction_material", _snapshot), patch.object(
+        app_module, "extract_memories", _failed_extract
+    ), patch.object(app_module, "_prepare_memory_batch", _must_not_prepare), patch.object(
+        app_module, "save_if_sources_unchanged", _must_not_save
+    ):
+        failed_batch = await app_module._extract_and_save_batch(
+            session_id="mn-k-retry", limit=4, existing_contents=[], cat_names=[],
+            emotion_level="normal", project_id=None, model_override=None,
+            prompt_override=None,
+        )
+    require(failed_batch == ("extract_failed", [], 0, 0, "timeout"),
+            f"failed batch was not propagated distinctly: {failed_batch!r}")
+    require(not prepare_called and not save_called,
+            "failed batch was incorrectly marked processed or prepared for save")
+    process_source = inspect.getsource(app_module.process_memories_background)
+    require('if action == "extract_failed":' in process_source
+            and '_conversation_counter = max(_conversation_counter, extract_interval)' in process_source,
+            "failed batch does not restore an immediate retry trigger")
+    passed("T-MN-K-02 failed batches stay unsaved and restore the retry trigger")
+
+    begin("T-MN-K-03")
+    push = getattr(app_module, "_should_push_memory_event", None)
+    cases = [
+        ({"action": "skip", "saved": 0}, False),
+        ({"action": "skip_tombstoned", "saved": 0}, False),
+        ({"action": "skip_extract_disabled", "saved": 0}, False),
+        ({"action": "skip_project", "saved": 0}, False),
+        ({"action": "abandoned", "saved": 0}, False),
+        ({"action": "extract", "saved": 0}, False),
+        ({"action": "extract", "saved": 2}, True),
+        ({"action": "extract_failed", "saved": 0}, True),
+        ({"action": "extract_failed", "saved": 2}, True),
+        ({"action": "error", "saved": 0}, True),
+    ]
+    require(callable(push) and all(push(event) is expected for event, expected in cases),
+            "memory event push truth table drifted")
+    source = inspect.getsource(app_module)
+    require(source.count("_should_push_memory_event(mem_result)") == 2,
+            "both streaming paths must call the shared push predicate exactly once")
+    passed("T-MN-K-03 both streamers share the frozen memory push predicate")
+
+    begin("T-MN-K-04")
+    secret = "postgresql://user:pw@host/db secret-payload"
+
+    async def _explode(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(secret)
+
+    output = io.StringIO()
+    with patch.object(app_module, "append_turn_events_atomic", _explode), redirect_stdout(output):
+        result = await app_module.process_memories_background(
+            "mn-k-error", "u", "a", "model", extract_enabled=False,
+            reset_generation=0,
+        )
+    require(result == {
+        "action": "error", "error_code": "exception:RuntimeError",
+        "error": "exception:RuntimeError",
+    }, f"unsafe error event shape: {result!r}")
+    require(secret not in json.dumps(result, ensure_ascii=False) and secret not in output.getvalue(),
+            "exception body leaked to the event or server log")
+    passed("T-MN-K-04 error events and logs expose class codes only")
+
+
 async def run_suite(test_dsn: str) -> None:
     global database, config, app_module, memory_extractor
 
@@ -6377,6 +6527,7 @@ async def run_suite(test_dsn: str) -> None:
         await test_w2_04_handoff_copies(client)
         await test_w2_04_restore_stamp_states(client)
         await test_w2_04_1_ticket_c(client)
+        await test_memory_notice_contracts()
 
 
 async def async_main() -> int:
@@ -6395,6 +6546,7 @@ async def async_main() -> int:
         w2_03_passed = [name for name in PASSED if name.startswith("T-W2-03-")]
         w2_04_passed = [name for name in PASSED if name.startswith("T-W2-04-")]
         ticket_c_passed = [name for name in PASSED if name.startswith("T-C-")]
+        memory_notice_passed = [name for name in PASSED if name.startswith("T-MN-K-")]
         print(f"\nPASS: {len(legacy_passed)} permanent S1-S6 behavior guards")
         print(f"PASS: {len(w1_01_passed)} W1-01 isolation/permanent guards")
         print(f"PASS: {len(w1_06_passed)} W1-06 calendar-delete atomicity guards")
@@ -6404,6 +6556,7 @@ async def async_main() -> int:
         print(f"PASS: {len(w2_03_passed)} W2-03 ledger-schema/scope/dark-write guards")
         print(f"PASS: {len(w2_04_passed)} W2-04 session-delete/privacy guards")
         print(f"PASS: {len(ticket_c_passed)} W2-04.1 ticket-C guards")
+        print(f"PASS: {len(memory_notice_passed)} memory-notice/failure-propagation guards")
         if _MUTES_USED:
             print(f"MUTED: {len(_MUTES_USED)} assertion(s) let through via KIWI_KNIFE_MUTE: "
                   f"{sorted(set(_MUTES_USED))}")


### PR DESCRIPTION
## 票面

修复公版失败传播：提取器失败返回稳定原因；失败批次不准备、不保存、不推进为成功，并恢复下一轮重试触发；两条流式路径共用可行动结果推送判据；异常出口只暴露安全类名机器码。

## 提交

- 0acab89 tests-only 红证
- b9d754d implementation

## 本地证据

- 临时 PG16 真库：163/163
- T-MN-K-01..04 目标合同：4/4
- Kiwi-Mem 标题抽查通过
- 变异刀：旧推送判据与异常原文泄漏均精确刺红
- 未调用真实模型/API

保持 Draft；不要合并或发布，等待独立验收与露露授权。