### PR TITLE
fix: diagnose and retry empty memory extraction responses

### DIFF
--- a/anthropic_adapter.py
+++ b/anthropic_adapter.py
@@ -13,6 +13,7 @@ Anthropic format: POST /v1/messages
 """
 
 import json
+import re
 import uuid
 from typing import AsyncGenerator
 
@@ -285,6 +286,58 @@ def prepare_background_request(api_key: str, api_format: str, openai_body: dict,
 def parse_background_response(data: dict, api_format: str) -> dict:
     """把后台任务的响应统一成 OpenAI chat.completion 结构。"""
     return from_anthropic_response(data) if api_format == "anthropic" else data
+
+
+_DIAGNOSTIC_WORD_RE = re.compile(r"^[A-Za-z_]+$")
+
+
+def describe_background_response(data: object) -> dict:
+    """Return body-free metadata for one normalized background response."""
+    root = data if isinstance(data, dict) else {}
+    choices = root.get("choices")
+    choices_count = len(choices) if isinstance(choices, list) else 0
+    choice = choices[0] if choices_count and isinstance(choices[0], dict) else {}
+    message_value = choice.get("message")
+    message = message_value if isinstance(message_value, dict) else {}
+    content = message.get("content")
+    content_type = type(content).__name__
+    if not _DIAGNOSTIC_WORD_RE.fullmatch(content_type):
+        content_type = "?"
+
+    if "finish_reason" not in choice:
+        finish_reason = "-"
+    else:
+        raw_finish = choice.get("finish_reason")
+        finish_reason = (
+            raw_finish
+            if isinstance(raw_finish, str) and _DIAGNOSTIC_WORD_RE.fullmatch(raw_finish)
+            else "?"
+        )
+
+    reasoning = message.get("reasoning_content")
+    reasoning_alt = message.get("reasoning")
+    tool_calls = message.get("tool_calls")
+    usage_value = root.get("usage")
+    usage = usage_value if isinstance(usage_value, dict) else {}
+    completion_value = usage.get("completion_tokens")
+    completion_tokens = (
+        completion_value
+        if isinstance(completion_value, int) and not isinstance(completion_value, bool)
+        else -1
+    )
+    return {
+        "choices": choices_count,
+        "content_present": "content" in message,
+        "content_type": content_type,
+        "content_len": len(content) if isinstance(content, str) else 0,
+        "stripped_len": len(content.strip()) if isinstance(content, str) else 0,
+        "finish_reason": finish_reason,
+        "reasoning_len": len(reasoning) if isinstance(reasoning, str) else 0,
+        "reasoning_alt_len": len(reasoning_alt) if isinstance(reasoning_alt, str) else 0,
+        "tool_calls": len(tool_calls) if isinstance(tool_calls, list) else 0,
+        "refusal_present": bool(message.get("refusal")),
+        "completion_tokens": completion_tokens,
+    }
 
 
 # ============================================================

--- a/memory_extractor.py
+++ b/memory_extractor.py
@@ -10,7 +10,7 @@ v2.3 改进：提取时注入已有记忆，让模型对比后只提取全新信
 import os
 import json
 import httpx
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 API_KEY = os.getenv("MEMORY_API_KEY", "") or os.getenv("API_KEY", "")
 _RAW_BASE_URL = os.getenv("MEMORY_API_BASE_URL", "") or os.getenv("API_BASE_URL", "https://openrouter.ai/api/v1/chat/completions")
@@ -20,6 +20,7 @@ API_BASE_URL = _RAW_BASE_URL if _RAW_BASE_URL.rstrip("/").endswith("/chat/comple
 
 # 用来提取记忆的模型（便宜的就行）
 MEMORY_MODEL = os.getenv("MEMORY_MODEL", "anthropic/claude-haiku-4")
+EXTRACT_EMPTY_RETRY = 1
 
 
 EXTRACTION_PROMPT = """你是信息提取专家，负责从对话中识别并提取值得长期记住的关键信息。
@@ -86,6 +87,26 @@ EMOTION_HIGH_INSTRUCTION = """# 🩷 情绪锚点提取【本轮对话情绪浓�
 - 这类记忆的 emotional_weight 应为 6-10"""
 
 EMOTION_NORMAL_INSTRUCTION = ""
+
+
+def _read_extract_text(data: object) -> tuple[Optional[str], str]:
+    """Read normalized completion text without trusting any response shape."""
+    if not isinstance(data, dict):
+        return None, "missing"
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        return None, "missing"
+    message = choices[0].get("message")
+    if not isinstance(message, dict) or "content" not in message:
+        return None, "missing"
+    content = message.get("content")
+    if content is None:
+        return None, "none"
+    if not isinstance(content, str):
+        return None, "unsupported"
+    if not content.strip():
+        return "", "empty"
+    return content, "str"
 
 
 async def extract_memories(messages: List[Dict[str, str]], existing_memories: List[str] = None, categories: List[str] = None, model_override: str = None, prompt_override: str = None, emotion_level: str = "normal"):
@@ -163,7 +184,11 @@ async def extract_memories(messages: List[Dict[str, str]], existing_memories: Li
 
     # 调用 LLM 提取记忆
     try:
-        from anthropic_adapter import prepare_background_request, parse_background_response
+        from anthropic_adapter import (
+            describe_background_response,
+            parse_background_response,
+            prepare_background_request,
+        )
         _body = {
             "model": use_model,
             "max_tokens": 1000,
@@ -178,16 +203,40 @@ async def extract_memories(messages: List[Dict[str, str]], existing_memories: Li
             title="AI Memory Gateway - Memory Extraction",
         )
         async with httpx.AsyncClient(timeout=60) as client:
-            response = await client.post(use_api_url, headers=_headers, json=_send_body)
+            retry_count = 0
+            while True:
+                response = await client.post(use_api_url, headers=_headers, json=_send_body)
 
-            if response.status_code != 200:
-                print(f"⚠️  记忆提取请求失败: {response.status_code}")
-                return {"ok": False, "reason": f"http_{response.status_code}"}
+                if response.status_code != 200:
+                    print(f"⚠️  记忆提取请求失败: {response.status_code}")
+                    return {"ok": False, "reason": f"http_{response.status_code}"}
 
-            data = parse_background_response(response.json(), use_api_format)
-            text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
-            
-            print(f"🔍 记忆提取模型返回：{len(text)} 字符，待解析")
+                data = parse_background_response(response.json(), use_api_format)
+                text, shape = _read_extract_text(data)
+                if shape in ("missing", "none", "empty"):
+                    diagnostic = describe_background_response(data)
+                    print("🩺 记忆提取响应诊断: " + json.dumps(
+                        diagnostic, sort_keys=True, ensure_ascii=True,
+                    ))
+                    if retry_count < EXTRACT_EMPTY_RETRY:
+                        retry_count += 1
+                        print("🔁 记忆提取空正文，当场重试 1 次")
+                        continue
+                    print("⚠️ 记忆提取空正文（重试后仍空），跳过")
+                    return {"ok": False, "reason": "parse_failed"}
+                if shape == "unsupported":
+                    diagnostic = describe_background_response(data)
+                    print("🩺 记忆提取响应诊断: " + json.dumps(
+                        diagnostic, sort_keys=True, ensure_ascii=True,
+                    ))
+                    print("⚠️  记忆提取返回不支持的正文形状（解析失败），跳过")
+                    return {"ok": False, "reason": "parse_failed"}
+
+                if retry_count:
+                    print(f"🔁 重试后取得 {len(text)} 字符")
+                else:
+                    print(f"🔍 记忆提取模型返回：{len(text)} 字符，待解析")
+                break
 
             # 清理可能的 markdown 格式
             text = text.strip()
@@ -226,6 +275,10 @@ async def extract_memories(messages: List[Dict[str, str]], existing_memories: Li
                         memories = [memories]
             
             if memories is None or not isinstance(memories, list):
+                diagnostic = describe_background_response(data)
+                print("🩺 记忆提取响应诊断: " + json.dumps(
+                    diagnostic, sort_keys=True, ensure_ascii=True,
+                ))
                 print(f"⚠️  记忆提取返回非数组格式，跳过")
                 return {"ok": False, "reason": "parse_failed"}
 

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -6327,7 +6327,9 @@ class _MNResponse:
 
 class _MNClient:
     response: Any = None
+    responses: list[Any] | None = None
     error: BaseException | None = None
+    calls: int = 0
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         pass
@@ -6339,28 +6341,46 @@ class _MNClient:
         return False
 
     async def post(self, *args: Any, **kwargs: Any) -> Any:
+        index = self.calls
+        type(self).calls += 1
         if self.error:
             raise self.error
-        return self.response
+        if self.responses is None:
+            return self.response
+        if index >= len(self.responses):
+            raise AssertionError("extractor posted more than fixture allows")
+        item = self.responses[index]
+        if isinstance(item, BaseException):
+            raise item
+        return item
 
 
 async def _mn_extractor_case(*, key: str = "key", response: Any = None,
-                             error: BaseException | None = None) -> Any:
+                             responses: list[Any] | None = None,
+                             error: BaseException | None = None,
+                             trace: bool = False) -> Any:
     async def _resolver(_model: str) -> tuple[str, str, str]:
         return "http://memory.test/chat/completions", key, "openai"
 
     _MNClient.response = response
+    _MNClient.responses = responses
     _MNClient.error = error
+    _MNClient.calls = 0
     try:
         with patch.object(database, "resolve_model_endpoint", _resolver), patch.object(
             memory_extractor.httpx, "AsyncClient", _MNClient
         ):
-            return await memory_extractor.extract_memories([
+            result = await memory_extractor.extract_memories([
                 {"role": "user", "content": "remember this public contract"},
             ])
+            calls = _MNClient.calls
+            remaining = None if responses is None else max(0, len(responses) - calls)
+            return (result, calls, remaining) if trace else result
     finally:
         _MNClient.response = None
+        _MNClient.responses = None
         _MNClient.error = None
+        _MNClient.calls = 0
 
 
 async def test_memory_notice_contracts() -> None:
@@ -6466,6 +6486,156 @@ async def test_memory_notice_contracts() -> None:
     passed("T-MN-K-04 error events and logs expose class codes only")
 
 
+def _er_payload(content: Any, *, reasoning: str = "", reasoning_alt: str = "",
+                refusal: Any = None, finish_reason: str = "stop",
+                completion_tokens: int = 57, tool_calls: Any = None) -> dict[str, Any]:
+    message: dict[str, Any] = {"content": content}
+    if reasoning:
+        message["reasoning_content"] = reasoning
+    if reasoning_alt:
+        message["reasoning"] = reasoning_alt
+    if refusal is not None:
+        message["refusal"] = refusal
+    if tool_calls is not None:
+        message["tool_calls"] = tool_calls
+    return {
+        "choices": [{"message": message, "finish_reason": finish_reason}],
+        "usage": {"completion_tokens": completion_tokens},
+    }
+
+
+async def _er_trace(payloads: list[Any]) -> tuple[Any, int, int | None]:
+    responses = [
+        item if isinstance(item, (_MNResponse, BaseException)) else _MNResponse(200, item)
+        for item in payloads
+    ]
+    return await _mn_extractor_case(responses=responses, trace=True)
+
+
+async def test_empty_response_resilience_contracts() -> None:
+    import importlib
+
+    adapter = importlib.import_module("anthropic_adapter")
+    describe = getattr(adapter, "describe_background_response", None)
+    read_extract = getattr(memory_extractor, "_read_extract_text", None)
+
+    begin("T-ER-K-01")
+    require(callable(describe) and callable(read_extract),
+            "empty-response diagnostic/read helpers are missing")
+    secret = "postgresql://user:pw@host/db 中文正文"
+    expected = {
+        "choices": 1,
+        "content_present": True,
+        "content_type": "str",
+        "content_len": 0,
+        "stripped_len": 0,
+        "finish_reason": "stop",
+        "reasoning_len": len(secret),
+        "reasoning_alt_len": 0,
+        "tool_calls": 2,
+        "refusal_present": False,
+        "completion_tokens": 57,
+    }
+    diagnostic = describe(_er_payload(
+        "", reasoning=secret, tool_calls=[{"id": "a"}, {"id": "b"}],
+    ))
+    dump = json.dumps(diagnostic, ensure_ascii=True, sort_keys=True)
+    require(diagnostic == expected and secret not in dump,
+            f"diagnostic contract drifted: {diagnostic!r}")
+    require(describe(_er_payload("", finish_reason="stop; DROP"))["finish_reason"] == "?",
+            "unsafe finish_reason was not reduced to the sentinel")
+    require(describe(_er_payload(None))["content_type"] == "NoneType",
+            "None content type/count contract drifted")
+    require(all(isinstance(describe(value), dict) for value in ({}, None, [], "unexpected")),
+            "diagnostic helper raised or returned a non-dict for malformed top-level data")
+    expected_shapes = [
+        (None, (None, "missing")),
+        ([], (None, "missing")),
+        ("unexpected", (None, "missing")),
+        ({}, (None, "missing")),
+        ({"choices": []}, (None, "missing")),
+        ({"choices": [{"message": None}]}, (None, "missing")),
+        ({"choices": [{"message": {}}]}, (None, "missing")),
+        (_er_payload(None), (None, "none")),
+        (_er_payload("  \n"), ("", "empty")),
+        (_er_payload("[]"), ("[]", "str")),
+        (_er_payload({"a": 1}), (None, "unsupported")),
+    ]
+    require(all(read_extract(value) == expected_shape
+                for value, expected_shape in expected_shapes),
+            "safe extraction shape table drifted")
+    passed("T-ER-K-01 diagnostics expose fixed metadata and all payload shapes are safe")
+
+    begin("T-ER-K-02")
+    valid = _er_payload(json.dumps([{"content": "remembered"}]))
+    empty = _er_payload("")
+    retry_cases = [
+        [empty, valid],
+        [None, valid],
+        [[], valid],
+        [{"choices": []}, valid],
+        [{"choices": [{"message": None}]}, valid],
+        [_er_payload(None), valid],
+    ]
+    retry_results = [await _er_trace(case) for case in retry_cases]
+    twice = await _er_trace([empty, empty, valid])
+    http_error = await _er_trace([empty, _MNResponse(429, {})])
+    unsupported = [
+        await _er_trace([_er_payload({"a": 1})]),
+        await _er_trace([_er_payload(["x"])]),
+    ]
+    require(all(isinstance(result, list) and len(result) == 1 and calls == 2
+                for result, calls, _remaining in retry_results),
+            f"empty-like payloads did not recover in exactly two posts: {retry_results!r}")
+    require(twice == ({"ok": False, "reason": "parse_failed"}, 2, 1),
+            f"retry limit or permanent third-response fixture drifted: {twice!r}")
+    require(http_error == ({"ok": False, "reason": "http_429"}, 2, 0),
+            f"retry HTTP reason drifted: {http_error!r}")
+    require(all(result == {"ok": False, "reason": "parse_failed"} and calls == 1
+                for result, calls, _remaining in unsupported),
+            f"unsupported content shape was retried: {unsupported!r}")
+    passed("T-ER-K-02 empty responses retry once and leave the third fixture unused")
+
+    begin("T-ER-K-03")
+    nonjson = await _er_trace([_er_payload("not-json")])
+    empty_fence = await _er_trace([_er_payload("```json\n```")])
+    require(nonjson == ({"ok": False, "reason": "parse_failed"}, 1, 0)
+            and empty_fence == ({"ok": False, "reason": "parse_failed"}, 1, 0),
+            f"non-JSON response was retried: {nonjson!r} / {empty_fence!r}")
+    passed("T-ER-K-03 non-JSON and empty fenced output never retry")
+
+    begin("T-ER-K-04")
+    dsn = "postgresql://user:pw@host/db"
+    api_key = "sk-secret-should-never-log"
+    chinese = "绝密中文正文"
+    secret_text = f"{dsn} {api_key} {chinese}"
+    empty_log = io.StringIO()
+    with redirect_stdout(empty_log):
+        empty_result = await _er_trace([
+            _er_payload("", reasoning=secret_text, refusal=secret_text),
+            _er_payload("", reasoning_alt=secret_text, refusal=secret_text),
+        ])
+    nonjson_log = io.StringIO()
+    with redirect_stdout(nonjson_log):
+        nonjson_result = await _er_trace([_er_payload(secret_text)])
+    timeout_log = io.StringIO()
+    with redirect_stdout(timeout_log):
+        await _mn_extractor_case(error=httpx.TimeoutException(secret_text))
+    combined = empty_log.getvalue() + nonjson_log.getvalue() + timeout_log.getvalue()
+    require(empty_result == ({"ok": False, "reason": "parse_failed"}, 2, 0)
+            and empty_log.getvalue().count("记忆提取响应诊断") == 2
+            and empty_log.getvalue().count("当场重试 1 次") == 1,
+            "empty response diagnostics/retry log contract drifted")
+    require(nonjson_result == ({"ok": False, "reason": "parse_failed"}, 1, 0)
+            and nonjson_log.getvalue().count("记忆提取响应诊断") == 1,
+            "non-JSON diagnostic count drifted")
+    require("记忆提取响应诊断" not in timeout_log.getvalue(),
+            "timeout unexpectedly emitted a response diagnostic")
+    require(all(value not in combined for value in (dsn, api_key, chinese)),
+            "diagnostic logs leaked a DSN, API key, or response body")
+    passed("T-ER-K-04 both diagnostic arms are body-free and timeout stays separate")
+
+
 async def run_suite(test_dsn: str) -> None:
     global database, config, app_module, memory_extractor
 
@@ -6528,6 +6698,7 @@ async def run_suite(test_dsn: str) -> None:
         await test_w2_04_restore_stamp_states(client)
         await test_w2_04_1_ticket_c(client)
         await test_memory_notice_contracts()
+        await test_empty_response_resilience_contracts()
 
 
 async def async_main() -> int:
@@ -6547,6 +6718,7 @@ async def async_main() -> int:
         w2_04_passed = [name for name in PASSED if name.startswith("T-W2-04-")]
         ticket_c_passed = [name for name in PASSED if name.startswith("T-C-")]
         memory_notice_passed = [name for name in PASSED if name.startswith("T-MN-K-")]
+        empty_response_passed = [name for name in PASSED if name.startswith("T-ER-K-")]
         print(f"\nPASS: {len(legacy_passed)} permanent S1-S6 behavior guards")
         print(f"PASS: {len(w1_01_passed)} W1-01 isolation/permanent guards")
         print(f"PASS: {len(w1_06_passed)} W1-06 calendar-delete atomicity guards")
@@ -6557,6 +6729,7 @@ async def async_main() -> int:
         print(f"PASS: {len(w2_04_passed)} W2-04 session-delete/privacy guards")
         print(f"PASS: {len(ticket_c_passed)} W2-04.1 ticket-C guards")
         print(f"PASS: {len(memory_notice_passed)} memory-notice/failure-propagation guards")
+        print(f"PASS: {len(empty_response_passed)} empty-response diagnostic/resilience guards")
         if _MUTES_USED:
             print(f"MUTED: {len(_MUTES_USED)} assertion(s) let through via KIWI_KNIFE_MUTE: "
                   f"{sorted(set(_MUTES_USED))}")

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -6608,7 +6608,7 @@ async def test_empty_response_resilience_contracts() -> None:
     dsn = "postgresql://user:pw@host/db"
     api_key = "sk-secret-should-never-log"
     chinese = "绝密中文正文"
-    secret_text = f"{dsn} {api_key} {chinese}"
+    secret_text = f"{chinese} {dsn} {api_key}"
     empty_log = io.StringIO()
     with redirect_stdout(empty_log):
         empty_result = await _er_trace([

--- a/scripts/test_kiwi_safety_sync.py
+++ b/scripts/test_kiwi_safety_sync.py
@@ -6605,6 +6605,39 @@ async def test_empty_response_resilience_contracts() -> None:
     passed("T-ER-K-03 non-JSON and empty fenced output never retry")
 
     begin("T-ER-K-04")
+    diagnostic_prefix = "🩺 记忆提取响应诊断: "
+    diagnostic_keys = {
+        "choices", "content_present", "content_type", "content_len", "stripped_len",
+        "finish_reason", "reasoning_len", "reasoning_alt_len", "tool_calls",
+        "refusal_present", "completion_tokens",
+    }
+    diagnostic_word = re.compile(r"^[A-Za-z_?\-]+$")
+
+    def diagnostics_are_canonical(output: str) -> bool:
+        payloads = [
+            line[len(diagnostic_prefix):]
+            for line in output.splitlines()
+            if line.startswith(diagnostic_prefix)
+        ]
+        if not payloads:
+            return False
+        for raw in payloads:
+            try:
+                diagnostic = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                return False
+            if json.dumps(diagnostic, sort_keys=True, ensure_ascii=True) != raw:
+                return False
+            if not isinstance(diagnostic, dict) or set(diagnostic) != diagnostic_keys:
+                return False
+            if not all(
+                isinstance(value, (int, bool))
+                or (isinstance(value, str) and diagnostic_word.fullmatch(value))
+                for value in diagnostic.values()
+            ):
+                return False
+        return True
+
     dsn = "postgresql://user:pw@host/db"
     api_key = "sk-secret-should-never-log"
     chinese = "绝密中文正文"
@@ -6629,6 +6662,9 @@ async def test_empty_response_resilience_contracts() -> None:
     require(nonjson_result == ({"ok": False, "reason": "parse_failed"}, 1, 0)
             and nonjson_log.getvalue().count("记忆提取响应诊断") == 1,
             "non-JSON diagnostic count drifted")
+    require(diagnostics_are_canonical(empty_log.getvalue())
+            and diagnostics_are_canonical(nonjson_log.getvalue()),
+            "diagnostic lines are not canonical fixed-shape JSON")
     require("记忆提取响应诊断" not in timeout_log.getvalue(),
             "timeout unexpectedly emitted a response diagnostic")
     require(all(value not in combined for value in (dsn, api_key, chinese)),


### PR DESCRIPTION
## Summary
- classify malformed/empty provider response shapes without throwing
- emit fixed body-free diagnostics for parse failures
- retry empty extraction content exactly once with the same request
- keep non-JSON and unsupported content non-retryable
- lock every diagnostic line to canonical JSON, the frozen 11-key set, and safe scalar values

## Evidence
- tests-only red: `9264d4d`
- implementation: `96fc4dd`
- structural guard follow-up / final head: `c6e9d914d215cae34c96431ee5c9e0af3859e367`
- final tree: `c093e22732bf3fb6765a5c19771d1bb600fd9c09`
- final CI Run `32979558174`: syntax green, disposable PostgreSQL verified, T-ER-K-01…04 PASS, 167/167 permanent guards PASS
- K-ER-1b independently re-exercised: body-prefix leakage makes only T-ER-K-04 red with `diagnostic lines are not canonical fixed-shape JSON`; restored implementation is green
- final follow-up commit changes only `scripts/test_kiwi_safety_sync.py` (+36); production files are byte-identical to implementation commit `96fc4dd`
- `main.py` still identifies the service as Kiwi-Mem

## Boundaries
- no private Éveille behavior, schema, migration, config, gate, or Chat change
- real model/API path was not called; model, embedding, and HTTP boundaries were mocked in CI
- merge and VPS test-instance verification remain separate evidence