### PR TITLE
feat(admin): hide projects entry when no projects exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           python scripts/test_mcp_calendar_sections.py
           python scripts/test_calendar_period_guards.py
           python scripts/test_admin_panel_cache.py
+          node scripts/test_admin_panel_nav.mjs
           node scripts/test_calendar_period_defaults.mjs
 
       - name: 运行 S1-S6 永久真库行为守卫

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ set -euo pipefail
 python -m compileall -q .
 git diff --check
 
-# 12 套既有回归：与 .github/workflows/ci.yml 保持一致，任一失败立即停止。
+# 13 套既有回归：与 .github/workflows/ci.yml 保持一致，任一失败立即停止。
 python scripts/test_drawer_stability.py
 python scripts/test_gateway_tool_streaming.py
 python scripts/test_stream_capture.py
@@ -51,6 +51,7 @@ python scripts/test_calendar_delete_atomicity.py
 python scripts/test_mcp_calendar_sections.py
 python scripts/test_calendar_period_guards.py
 python scripts/test_admin_panel_cache.py
+node scripts/test_admin_panel_nav.mjs
 node scripts/test_calendar_period_defaults.mjs
 
 # 真库守卫（需要本机 PostgreSQL 16；没有则依赖 CI 结果并在交付里注明）

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ kiwi-mem 内置了 20 多个工具（记忆搜索、日历查询、提醒、联�
 
 你不需要做任何设置，隔离是自动的。
 
+项目由支持它的客户端传入和使用；管理面板仅在已有项目时显示「项目分隔」页，直达 `#/projects` 仍可增删改。
+
 ---
 
 ## 适合谁用
@@ -505,6 +507,7 @@ GitHub 上那个 fork 留着不管就行，删不删都不影响服务器。
 - 历史账本行不回填；未知归属行保留为历史档，不进入后续新读路径
 - 命令只返回计数与有限的数字行 ID 样本，详见 [`docs/event-ledger-scope-and-reconciliation.md`](docs/event-ledger-scope-and-reconciliation.md)
 - 无需手动配置，创建项目后自动生效
+- 项目由支持它的客户端传入和使用；管理面板仅在已有项目时显示该页，直达 `#/projects` 仍可增删改
 
 ### 🔧 工具与扩展
 - MCP Server（20+ 工具）+ MCP Client

--- a/README_EN.md
+++ b/README_EN.md
@@ -76,6 +76,8 @@ If you use projects to separate contexts (work, daily life, fiction), global mem
 
 No setup needed — isolation is automatic.
 
+Projects are supplied and used by clients that support them. The admin panel only shows the Projects page when at least one project exists; direct access through `#/projects` remains available for creating, editing, and deleting projects.
+
 ---
 
 ## Who is it for
@@ -321,6 +323,7 @@ Memory import is being rebuilt and will return in a future version in a smarter 
 - Historical rows are not backfilled; unknown-scope rows remain an archive and stay out of future readers
 - Output contains counts and bounded numeric row-ID samples only; see [`docs/event-ledger-scope-and-reconciliation.md`](docs/event-ledger-scope-and-reconciliation.md)
 - No manual config needed — automatic on project creation
+- Projects are supplied and used by clients that support them; the admin panel only shows this page when projects exist, while `#/projects` remains directly available for creating, editing, and deleting projects
 
 ### 🔧 Tools & extensions
 - MCP Server (20+ tools) + MCP Client

--- a/admin-panel/css/style.css
+++ b/admin-panel/css/style.css
@@ -155,6 +155,7 @@ h1,h2,h3,h4 { margin:0; font-weight:700; }
   transition:background .12s,color .12s,box-shadow .12s;
   white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
 }
+.nav-item[hidden] { display:none !important; }
 .nav-item:hover { background:var(--surface-hover); color:var(--text); }
 /* 选中态：浅绿底 + 左侧绿条 */
 .nav-item.active {

--- a/admin-panel/js/app.js
+++ b/admin-panel/js/app.js
@@ -15,6 +15,11 @@ import { errorBlock, loadingBlock } from './ui.js';
 import { get } from './api.js';
 import { initSearch, tryHighlight } from './search.js';
 import { maybeShowWizard } from './wizard.js';
+import {
+  bindProjectChanges,
+  createNavVisibilityController,
+  shouldHide,
+} from './nav-visibility.mjs';
 
 const DEFAULT_ROUTE = 'dashboard';
 
@@ -57,6 +62,20 @@ function renderSidebar() {
           <span class="ico">${it.icon}</span><span class="nav-label">${it.label}</span>
         </a>`).join('')}
     </div>`).join('');
+}
+
+const conditionalNavItems = NAV.flatMap(group => group.items)
+  .filter(item => item.hideWhenEmpty);
+const navVisibilityController = createNavVisibilityController({
+  items: conditionalNavItems,
+  fetchVisibility: async item => {
+    try { return shouldHide(await get(item.hideWhenEmpty)); } catch { return false; }
+  },
+  navRoot: () => document.getElementById('sidebar-nav'),
+});
+
+export function refreshNavVisibility() {
+  return navVisibilityController.refresh();
 }
 
 function highlight(key) {
@@ -154,6 +173,8 @@ function boot() {
   initTheme();
   renderSidebar();
   initSearch(document.getElementById('global-search'));
+  bindProjectChanges(window, refreshNavVisibility);
+  refreshNavVisibility();
   document.getElementById('theme-btn')?.addEventListener('click', () => {
     applyTheme(document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
   });

--- a/admin-panel/js/nav-visibility.mjs
+++ b/admin-panel/js/nav-visibility.mjs
@@ -1,0 +1,74 @@
+// 数据驱动的侧栏显隐状态。模块不依赖 DOM 实现，Node 守卫可直接加载。
+const HIDDEN_KEYS = new Set();
+const VISIBILITY_LISTENERS = new Set();
+
+export function shouldHide(response) {
+  return Boolean(
+    response
+    && typeof response === 'object'
+    && !Array.isArray(response)
+    && Array.isArray(response.projects)
+    && response.projects.length === 0
+  );
+}
+
+export function hiddenKeys() {
+  return new Set(HIDDEN_KEYS);
+}
+
+export function applyNavVisibility(navEl, keys = HIDDEN_KEYS) {
+  if (!navEl?.querySelectorAll) return;
+  const keySet = keys instanceof Set ? keys : new Set(keys || []);
+  navEl.querySelectorAll('.nav-item').forEach(el => {
+    el.hidden = keySet.has(el.dataset.key);
+  });
+}
+
+export function visibleRouteEntries(routeIndex) {
+  return Object.entries(routeIndex).filter(([key]) => !HIDDEN_KEYS.has(key));
+}
+
+export function onNavVisibilityChange(listener) {
+  VISIBILITY_LISTENERS.add(listener);
+  return () => VISIBILITY_LISTENERS.delete(listener);
+}
+
+function commitVisibility(items, decisions) {
+  let changed = false;
+  for (const item of items) {
+    const hidden = decisions.get(item.key) === true;
+    if (hidden === HIDDEN_KEYS.has(item.key)) continue;
+    changed = true;
+    if (hidden) HIDDEN_KEYS.add(item.key);
+    else HIDDEN_KEYS.delete(item.key);
+  }
+  if (changed) VISIBILITY_LISTENERS.forEach(listener => listener());
+}
+
+export function createNavVisibilityController({ items, fetchVisibility, navRoot }) {
+  let latestSeq = 0;
+
+  return {
+    async refresh() {
+      const seq = ++latestSeq;
+      const pairs = await Promise.all(items.map(async item => {
+        try {
+          return [item.key, Boolean(await fetchVisibility(item))];
+        } catch {
+          return [item.key, false];
+        }
+      }));
+
+      if (seq !== latestSeq) return false;
+      commitVisibility(items, new Map(pairs));
+      applyNavVisibility(navRoot?.(), HIDDEN_KEYS);
+      return true;
+    },
+  };
+}
+
+export function bindProjectChanges(target, refresh) {
+  const listener = () => refresh();
+  target.addEventListener('kiwi:projects-changed', listener);
+  return () => target.removeEventListener('kiwi:projects-changed', listener);
+}

--- a/admin-panel/js/pages/projects.js
+++ b/admin-panel/js/pages/projects.js
@@ -197,6 +197,7 @@ export default {
         await put(`/sync/projects/${id}`, body);
         toast('项目已创建', 'ok');
         mod.close();
+        window.dispatchEvent(new CustomEvent('kiwi:projects-changed'));
         this.load();
       } catch (e) {
         toast('创建失败：' + e.message, 'err');
@@ -237,6 +238,7 @@ export default {
         await put(`/sync/projects/${p.id}`, body);
         toast('项目已更新', 'ok');
         mod.close();
+        window.dispatchEvent(new CustomEvent('kiwi:projects-changed'));
         this.load();
       } catch (e) {
         toast('保存失败：' + e.message, 'err');
@@ -247,7 +249,12 @@ export default {
 
   async remove(id) {
     if (!(await confirmDialog({ title: '删除项目', message: '确定删除这个项目？其文件向量块会一并删除，此操作不可恢复。', danger: true, okText: '删除' }))) return;
-    try { await del(`/sync/projects/${id}`); toast('项目已删除', 'ok'); this.load(); }
+    try {
+      await del(`/sync/projects/${id}`);
+      toast('项目已删除', 'ok');
+      window.dispatchEvent(new CustomEvent('kiwi:projects-changed'));
+      this.load();
+    }
     catch (e) { toast('删除失败：' + e.message, 'err'); }
   },
 };

--- a/admin-panel/js/routes.js
+++ b/admin-panel/js/routes.js
@@ -28,7 +28,7 @@ export const NAV = [
     { key: 'calendar',    icon: '📅', label: '日历与整理' },
     { key: 'compression', icon: '🗜️', label: '上下文压缩' },
     { key: 'handoff',     icon: '🪟', label: '无缝换窗' },
-    { key: 'projects',    icon: '📁', label: '项目分隔' },
+    { key: 'projects',    icon: '📁', label: '项目分隔', hideWhenEmpty: '/sync/projects' },
   ]},
   { title: '运维与安全', items: [
     { key: 'gateway',     icon: '🚦', label: '网关与延迟' },

--- a/admin-panel/js/search.js
+++ b/admin-panel/js/search.js
@@ -7,6 +7,7 @@
 // ============================================================
 import { CONFIG_META, CONFIG_PAGES } from './config-schema.js';
 import { ROUTE_INDEX } from './routes.js';
+import { onNavVisibilityChange, visibleRouteEntries } from './nav-visibility.mjs';
 
 // CONFIG_PAGES 的 key 大多就是路由页；例外在此映射
 const PAGE_ALIAS = { reminderTools: 'tools' };
@@ -14,6 +15,7 @@ const PAGE_ALIAS = { reminderTools: 'tools' };
 const TAB_PAGES = { memories: 'settings', dream: 'settings', calendar: 'settings' };
 
 let INDEX = null;
+onNavVisibilityChange(_event => { INDEX = null; });
 
 function keyPos(key) {
   for (const [pk, def] of Object.entries(CONFIG_PAGES)) {
@@ -29,7 +31,7 @@ function keyPos(key) {
 function buildIndex() {
   if (INDEX) return INDEX;
   INDEX = [];
-  for (const [key, meta] of Object.entries(ROUTE_INDEX)) {
+  for (const [key, meta] of visibleRouteEntries(ROUTE_INDEX)) {
     INDEX.push({ type:'page', icon: meta.icon, label: meta.label, sub: meta.group, page: key, hay: (meta.label + ' ' + key).toLowerCase() });
   }
   for (const [key, m] of Object.entries(CONFIG_META)) {

--- a/admin-panel/js/search.js
+++ b/admin-panel/js/search.js
@@ -137,14 +137,21 @@ export function initSearch(container) {
       </div>`).join('');
   };
 
-  const refreshForVisibility = () => {
+  const refreshResults = () => {
     results = search(input.value);
     cursor = -1;
-    render();
+  };
+  const refreshForVisibility = () => {
+    const wasOpen = !drop.hidden;
+    refreshResults();
+    if (wasOpen) render();
   };
   ACTIVE_SEARCH_REFRESH = refreshForVisibility;
 
-  input.addEventListener('input', refreshForVisibility);
+  input.addEventListener('input', () => {
+    refreshResults();
+    render();
+  });
   input.addEventListener('keydown', (e) => {
     if (e.key === 'ArrowDown') { e.preventDefault(); cursor = Math.min(cursor + 1, results.length - 1); render(); }
     else if (e.key === 'ArrowUp') { e.preventDefault(); cursor = Math.max(cursor - 1, 0); render(); }

--- a/admin-panel/js/search.js
+++ b/admin-panel/js/search.js
@@ -15,7 +15,11 @@ const PAGE_ALIAS = { reminderTools: 'tools' };
 const TAB_PAGES = { memories: 'settings', dream: 'settings', calendar: 'settings' };
 
 let INDEX = null;
-onNavVisibilityChange(_event => { INDEX = null; });
+let ACTIVE_SEARCH_REFRESH = null;
+onNavVisibilityChange(_event => {
+  INDEX = null;
+  ACTIVE_SEARCH_REFRESH?.();
+});
 
 function keyPos(key) {
   for (const [pk, def] of Object.entries(CONFIG_PAGES)) {
@@ -133,7 +137,14 @@ export function initSearch(container) {
       </div>`).join('');
   };
 
-  input.addEventListener('input', () => { results = search(input.value); cursor = -1; render(); });
+  const refreshForVisibility = () => {
+    results = search(input.value);
+    cursor = -1;
+    render();
+  };
+  ACTIVE_SEARCH_REFRESH = refreshForVisibility;
+
+  input.addEventListener('input', refreshForVisibility);
   input.addEventListener('keydown', (e) => {
     if (e.key === 'ArrowDown') { e.preventDefault(); cursor = Math.min(cursor + 1, results.length - 1); render(); }
     else if (e.key === 'ArrowUp') { e.preventDefault(); cursor = Math.max(cursor - 1, 0); render(); }

--- a/docs/Release Acceptance.md
+++ b/docs/Release Acceptance.md
@@ -32,7 +32,7 @@
 | # | 测试 | 执行方式 | 通过标准 | 证据 | 结论 |
 |---|---|---|---|---|---|
 | A1 | Python 语法检查 | CI：`syntax-check` job（"Python 语法自检"）/ 本地 `python -m compileall -q .` | job success；本地零输出 | Run 号 | |
-| A2 | 全部既有回归脚本 | CI：**`behavior-tests` job 的"运行既有开源回归脚本"步骤** / 本地逐个跑 `scripts/test_*.py` 与 `.mjs`（现 12 套） | 该步骤 success；本地全部 exit 0 | Run 号或输出尾行 | |
+| A2 | 全部既有回归脚本 | CI：**`behavior-tests` job 的"运行既有开源回归脚本"步骤** / 本地逐个跑 `scripts/test_*.py` 与 `.mjs`（现 13 套） | 该步骤 success；本地全部 exit 0 | Run 号或输出尾行 | |
 | A3 | PostgreSQL 16 真库守卫 | CI：`behavior-tests` job 的"运行 S1-S6 永久真库行为守卫"步骤 / 本地 `KIWI_TEST_DATABASE_URL=… python scripts/test_kiwi_safety_sync.py` | 尾行 `PASS: N total permanent behavior guards`（N=当前守卫总数，写就时 107）；本地再跑一遍取第二证据 | Run 号 + 本地尾行 | |
 | A4 | Docker 镜像构建 | 人工/CI：`docker build -t kiwi-mem:acc .` | 构建成功无报错 | 命令输出末行 | |
 | A5 | 空数据库首次安装 | 人工：一次性目录 `docker compose -p kiwi-acc up -d`（空卷）→ 等健康 | 容器全 healthy；启动日志无 Traceback；`GET /` 返回 running；`/admin` 能打开 | 日志摘要 + 截图 | |

--- a/scripts/test_admin_panel_cache.py
+++ b/scripts/test_admin_panel_cache.py
@@ -95,6 +95,61 @@ def main_test():
     orphans = sorted(page_files - set(keys))
     check("场景6 没有孤儿页面文件", not orphans, f"无人引用：{orphans}")
 
+    # ---- 票 P：项目页按数据显隐的静态接线守卫 ----
+    expected_nav_keys = {
+        "dashboard", "providers", "websearch", "tools", "persona", "profile",
+        "memories", "categories", "metabolism", "dream", "calendar",
+        "compression", "handoff", "projects", "gateway", "sync", "security",
+        "rawconfig",
+    }
+    expected_lede_keys = {
+        "providers", "websearch", "tools", "persona", "profile", "memories",
+        "categories", "metabolism", "dream", "calendar", "compression",
+        "handoff", "projects", "gateway", "sync", "security", "rawconfig",
+    }
+    ledes_block = routes_js.split("export const LEDES = {", 1)[1].split("};", 1)[0]
+    lede_keys = set(re.findall(r"^\s*([a-z0-9_]+):", ledes_block, re.MULTILINE))
+    project_nav = re.search(
+        r"\{\s*key:\s*'projects'[^}]*hideWhenEmpty:\s*'/sync/projects'[^}]*\}",
+        routes_js,
+        re.DOTALL,
+    )
+    check(
+        "T-P-01 项目导航显隐声明且 key/LEDES 集合不漂移",
+        bool(project_nav) and set(keys) == expected_nav_keys and lede_keys == expected_lede_keys,
+        f"hideWhenEmpty={bool(project_nav)} nav={sorted(keys)} ledes={sorted(lede_keys)}",
+    )
+
+    style_css = open(os.path.join(panel, "css", "style.css"), encoding="utf-8").read()
+    hidden_rule = re.search(
+        r"\.nav-item\[hidden\]\s*\{(?P<body>[^}]*)\}", style_css, re.DOTALL
+    )
+    hidden_rule_body = hidden_rule.group("body") if hidden_rule else ""
+    check(
+        "T-P-02 hidden 属性覆盖 nav-item 的 flex 显示",
+        bool(hidden_rule)
+        and re.search(r"display\s*:\s*none\s*!important\s*;", hidden_rule_body) is not None,
+        "缺少 .nav-item[hidden] { display:none !important; }",
+    )
+
+    app_js = open(os.path.join(panel, "js", "app.js"), encoding="utf-8").read()
+    fetch_visibility = re.search(
+        r"fetchVisibility\s*:\s*async\s+\w+\s*=>\s*\{(?P<body>.*?)\n\s*\}",
+        app_js,
+        re.DOTALL,
+    )
+    fetch_visibility_body = fetch_visibility.group("body") if fetch_visibility else ""
+    catch_block = re.search(r"catch\s*\{(?P<body>[^}]*)\}", fetch_visibility_body, re.DOTALL)
+    catch_body = catch_block.group("body") if catch_block else ""
+    check(
+        "T-P-03 项目查询失败保持导航显示",
+        "./nav-visibility.mjs" in app_js
+        and bool(catch_block)
+        and "return false" in catch_body
+        and "hidden = true" not in catch_body,
+        "缺少显隐模块接线，或 catch 分支没有 fail-open 显示",
+    )
+
     print()
     if FAILED:
         print(f"❌ {len(FAILED)} 项未通过：")

--- a/scripts/test_admin_panel_nav.mjs
+++ b/scripts/test_admin_panel_nav.mjs
@@ -157,9 +157,14 @@ const searchContainer = {
     if (selector === '#gs-drop') return searchDrop;
     return null;
   },
-  contains() { return true; },
+  contains(target) {
+    return target === searchContainer || target === searchInput || target === searchDrop;
+  },
 };
-globalThis.document = { addEventListener() {} };
+const documentListeners = new Map();
+globalThis.document = {
+  addEventListener(type, listener) { documentListeners.set(type, listener); },
+};
 globalThis.__KIWI_NAV_TEST__ = nav;
 const runnableSearchSource = searchSource
   .replace(
@@ -189,6 +194,27 @@ check(
   'T-P-DOM-05b open search refreshes with visibility',
   wasVisible && vanishedWhileOpen && returnedWhileOpen,
   `before=${wasVisible} hidden=${vanishedWhileOpen} shown=${returnedWhileOpen}`,
+);
+
+documentListeners.get('mousedown')({ target: {} });
+const dismissedBeforeRefresh = searchDrop.hidden;
+await emptyController.refresh();
+const stayedDismissedAfterEmpty = searchDrop.hidden;
+inputListeners.get('focus')();
+const emptyResultsStayedClosed = searchDrop.hidden;
+await nonEmptyController.refresh();
+const stayedDismissedAfterReturn = searchDrop.hidden;
+inputListeners.get('focus')();
+const refreshedResultsOpenOnFocus = !searchDrop.hidden
+  && searchDrop.innerHTML.includes('项目分隔');
+check(
+  'T-P-DOM-05c dismissed search stays closed across visibility refresh',
+  dismissedBeforeRefresh
+    && stayedDismissedAfterEmpty
+    && emptyResultsStayedClosed
+    && stayedDismissedAfterReturn
+    && refreshedResultsOpenOnFocus,
+  `dismissed=${dismissedBeforeRefresh} after_empty=${stayedDismissedAfterEmpty} empty_focus=${emptyResultsStayedClosed} after_return=${stayedDismissedAfterReturn} reopened=${refreshedResultsOpenOnFocus}`,
 );
 
 const routesSource = await fs.readFile(path.join(PANEL_JS, 'routes.js'), 'utf8');
@@ -244,4 +270,4 @@ if (failed.length) {
   console.error(`FAIL: ${failed.length} admin panel nav guards failed`);
   process.exit(1);
 }
-console.log('PASS: 9 admin panel nav behavior guards');
+console.log('PASS: 10 admin panel nav behavior guards');

--- a/scripts/test_admin_panel_nav.mjs
+++ b/scripts/test_admin_panel_nav.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.dirname(HERE);
+const PANEL_JS = path.join(ROOT, 'admin-panel', 'js');
+const NAV_MODULE = path.join(PANEL_JS, 'nav-visibility.mjs');
+
+let nav;
+try {
+  nav = await import(`${pathToFileURL(NAV_MODULE).href}?guard=${Date.now()}`);
+} catch (error) {
+  if (error?.code === 'ERR_MODULE_NOT_FOUND' || String(error?.message || '').includes('nav-visibility.mjs')) {
+    console.error('FAIL T-P-DOM-00 nav-visibility.mjs missing');
+    process.exit(1);
+  }
+  console.error(`CRASH T-P-DOM-00 ${error?.stack || error}`);
+  process.exit(2);
+}
+
+const failed = [];
+function check(id, condition, detail = '') {
+  if (condition) console.log(`PASS ${id}`);
+  else {
+    console.error(`FAIL ${id}${detail ? ` ${detail}` : ''}`);
+    failed.push(id);
+  }
+}
+
+function makeItem(key) {
+  return {
+    hidden: false,
+    dataset: { key },
+    classList: { toggle() {} },
+  };
+}
+
+function makeNavRoot(items) {
+  return {
+    querySelectorAll(selector) {
+      return selector === '.nav-item' ? items : [];
+    },
+    querySelector(selector) {
+      const match = selector.match(/data-key=["']([^"']+)["']/);
+      return match ? items.find(item => item.dataset.key === match[1]) || null : null;
+    },
+  };
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+class FakeEventTarget {
+  constructor() { this.listeners = new Map(); }
+  addEventListener(type, listener) {
+    const list = this.listeners.get(type) || [];
+    list.push(listener);
+    this.listeners.set(type, list);
+  }
+  removeEventListener(type, listener) {
+    this.listeners.set(type, (this.listeners.get(type) || []).filter(item => item !== listener));
+  }
+  async dispatchEvent(event) {
+    await Promise.all((this.listeners.get(event.type) || []).map(listener => listener(event)));
+  }
+}
+
+const requiredExports = [
+  'shouldHide', 'applyNavVisibility', 'hiddenKeys', 'visibleRouteEntries',
+  'createNavVisibilityController', 'bindProjectChanges',
+];
+check(
+  'T-P-DOM-00 exports present',
+  requiredExports.every(name => typeof nav[name] === 'function'),
+  `exports=${Object.keys(nav).sort().join(',')}`,
+);
+
+const conditionalItems = [{ key: 'projects', hideWhenEmpty: '/sync/projects' }];
+const projectItem = makeItem('projects');
+const dashboardItem = makeItem('dashboard');
+const navRoot = makeNavRoot([dashboardItem, projectItem]);
+
+const emptyController = nav.createNavVisibilityController({
+  items: conditionalItems,
+  fetchVisibility: async () => nav.shouldHide({ projects: [] }),
+  navRoot: () => navRoot,
+});
+await emptyController.refresh();
+check(
+  'T-P-DOM-01 empty projects hide nav',
+  projectItem.hidden === true && dashboardItem.hidden === false,
+  `projects.hidden=${projectItem.hidden}`,
+);
+
+const nonEmptyController = nav.createNavVisibilityController({
+  items: conditionalItems,
+  fetchVisibility: async () => nav.shouldHide({ projects: [{ id: 'p1' }] }),
+  navRoot: () => navRoot,
+});
+await nonEmptyController.refresh();
+check('T-P-DOM-02 non-empty projects show nav', projectItem.hidden === false);
+
+const errorController = nav.createNavVisibilityController({
+  items: conditionalItems,
+  fetchVisibility: async () => { throw new Error('network'); },
+  navRoot: () => navRoot,
+});
+await errorController.refresh();
+check('T-P-DOM-03 query failure shows nav', projectItem.hidden === false);
+
+const malformed = [{}, { projects: null }, [], 'x', undefined, null];
+check(
+  'T-P-DOM-04 malformed responses show nav',
+  malformed.every(value => nav.shouldHide(value) === false),
+);
+
+await emptyController.refresh();
+const hidden = nav.hiddenKeys();
+const routeIndex = {
+  dashboard: { label: '仪表盘' },
+  projects: { label: '项目分隔' },
+};
+const filtered = nav.visibleRouteEntries(routeIndex).map(([key]) => key);
+const searchSource = await fs.readFile(path.join(PANEL_JS, 'search.js'), 'utf8');
+check(
+  'T-P-DOM-05 hidden page excluded from search index',
+  hidden.has('projects')
+    && !filtered.includes('projects')
+    && searchSource.includes('visibleRouteEntries(ROUTE_INDEX)')
+    && /onNavVisibilityChange\s*\([^)]*INDEX\s*=\s*null/s.test(searchSource),
+  `hidden=${[...hidden]} filtered=${filtered}`,
+);
+
+const routesSource = await fs.readFile(path.join(PANEL_JS, 'routes.js'), 'utf8');
+const routesModule = await import(`data:text/javascript;base64,${Buffer.from(routesSource).toString('base64')}`);
+check(
+  'T-P-DOM-06 direct projects route remains mountable',
+  Boolean(routesModule.ROUTE_INDEX?.projects)
+    && routesModule.ROUTE_INDEX.projects.hideWhenEmpty === '/sync/projects',
+);
+
+const eventTarget = new FakeEventTarget();
+let eventResponse = { projects: [{ id: 'p1' }] };
+const eventController = nav.createNavVisibilityController({
+  items: conditionalItems,
+  fetchVisibility: async () => nav.shouldHide(eventResponse),
+  navRoot: () => navRoot,
+});
+await eventController.refresh();
+const unbind = nav.bindProjectChanges(eventTarget, () => eventController.refresh());
+eventResponse = { projects: [] };
+await eventTarget.dispatchEvent({ type: 'kiwi:projects-changed' });
+const projectsSource = await fs.readFile(path.join(PANEL_JS, 'pages', 'projects.js'), 'utf8');
+const appSource = await fs.readFile(path.join(PANEL_JS, 'app.js'), 'utf8');
+check(
+  'T-P-DOM-07 project changes trigger immediate refresh',
+  projectItem.hidden === true
+    && (projectsSource.match(/kiwi:projects-changed/g) || []).length >= 3
+    && appSource.includes('bindProjectChanges(window, refreshNavVisibility)'),
+);
+unbind();
+
+const first = deferred();
+const second = deferred();
+let requestNo = 0;
+const raceController = nav.createNavVisibilityController({
+  items: conditionalItems,
+  fetchVisibility: () => (++requestNo === 1 ? first.promise : second.promise),
+  navRoot: () => navRoot,
+});
+const older = raceController.refresh();
+const newer = raceController.refresh();
+second.resolve(false);
+await newer;
+first.resolve(true);
+await older;
+check(
+  'T-P-DOM-08 latest response wins',
+  projectItem.hidden === false && nav.hiddenKeys().has('projects') === false,
+  `projects.hidden=${projectItem.hidden}`,
+);
+
+if (failed.length) {
+  console.error(`FAIL: ${failed.length} admin panel nav guards failed`);
+  process.exit(1);
+}
+console.log('PASS: 8 admin panel nav behavior guards');

--- a/scripts/test_admin_panel_nav.mjs
+++ b/scripts/test_admin_panel_nav.mjs
@@ -138,6 +138,59 @@ check(
   `hidden=${[...hidden]} filtered=${filtered}`,
 );
 
+await nonEmptyController.refresh();
+const inputListeners = new Map();
+const searchInput = {
+  value: '',
+  addEventListener(type, listener) { inputListeners.set(type, listener); },
+  blur() {},
+};
+const searchDrop = {
+  hidden: true,
+  innerHTML: '',
+  addEventListener() {},
+};
+const searchContainer = {
+  set innerHTML(_value) {},
+  querySelector(selector) {
+    if (selector === '#gs-input') return searchInput;
+    if (selector === '#gs-drop') return searchDrop;
+    return null;
+  },
+  contains() { return true; },
+};
+globalThis.document = { addEventListener() {} };
+globalThis.__KIWI_NAV_TEST__ = nav;
+const runnableSearchSource = searchSource
+  .replace(
+    "import { CONFIG_META, CONFIG_PAGES } from './config-schema.js';",
+    'const CONFIG_META = {}; const CONFIG_PAGES = {};',
+  )
+  .replace(
+    "import { ROUTE_INDEX } from './routes.js';",
+    "const ROUTE_INDEX = { dashboard: { icon: 'D', label: '仪表盘', group: '概览' }, projects: { icon: 'P', label: '项目分隔', group: '记忆机制' } };",
+  )
+  .replace(
+    "import { onNavVisibilityChange, visibleRouteEntries } from './nav-visibility.mjs';",
+    'const { onNavVisibilityChange, visibleRouteEntries } = globalThis.__KIWI_NAV_TEST__;',
+  );
+const searchModule = await import(
+  `data:text/javascript;base64,${Buffer.from(runnableSearchSource).toString('base64')}`
+);
+searchModule.initSearch(searchContainer);
+searchInput.value = '项目';
+inputListeners.get('input')();
+const wasVisible = searchDrop.innerHTML.includes('项目分隔');
+await emptyController.refresh();
+const vanishedWhileOpen = !searchDrop.innerHTML.includes('项目分隔');
+await nonEmptyController.refresh();
+const returnedWhileOpen = searchDrop.innerHTML.includes('项目分隔');
+check(
+  'T-P-DOM-05b open search refreshes with visibility',
+  wasVisible && vanishedWhileOpen && returnedWhileOpen,
+  `before=${wasVisible} hidden=${vanishedWhileOpen} shown=${returnedWhileOpen}`,
+);
+
 const routesSource = await fs.readFile(path.join(PANEL_JS, 'routes.js'), 'utf8');
 const routesModule = await import(`data:text/javascript;base64,${Buffer.from(routesSource).toString('base64')}`);
 check(
@@ -191,4 +244,4 @@ if (failed.length) {
   console.error(`FAIL: ${failed.length} admin panel nav guards failed`);
   process.exit(1);
 }
-console.log('PASS: 8 admin panel nav behavior guards');
+console.log('PASS: 9 admin panel nav behavior guards');


### PR DESCRIPTION
## 目的
项目为空时隐藏管理面板中的「项目分隔」入口；已有项目、请求失败或响应畸形时照常显示。后端项目接口与 `#/projects` 直达路由保持不变。

## 行为
- 空项目：侧栏与全局搜索隐藏项目页
- 非空项目：侧栏与搜索显示项目页
- 请求失败/畸形响应：fail-open，避免误藏
- 新建、改名、删除项目后即时重判；并发响应 latest-wins
- 原生 `hidden` 配合 CSS 覆盖 `.nav-item` 的 flex 显示

## 证据
已 rebase 到 W2-05 main `b7e63c7`。Node 面板守卫 10/10（含 P-7 的 T-P-DOM-05c）；刀账 K-P-1…8 全部精确红；13 套回归全绿；PostgreSQL 16 永久守卫 177/177；CI Run #180 `33081347049` success。爹爹二轨通过（真浏览器复验 + K-P-8 复刀）。

## 组合闸门
保持 Draft，等待露露转 Ready。